### PR TITLE
Remote Repository Manager bugs fixed and UI updated

### DIFF
--- a/rabbitvcs/ui/remotes.py
+++ b/rabbitvcs/ui/remotes.py
@@ -150,7 +150,7 @@ class GitRemotes(InterfaceView):
         dialog.title(label + " Git Remote")
         dialog.resizable(0,0)
         dialog["padx"] = 40
-        dialog["pady"] = 20
+        dialog["pady"] = 15
 
         # Create Name label.
         entryLabel = Label(dialog)
@@ -162,7 +162,7 @@ class GitRemotes(InterfaceView):
         txtName["width"] = 50
         txtName.bind("<Return>", (lambda event: self.onSave(dialog, txtName.get(), txtHost.get(), name)))
         txtName.bind("<KP_Enter>", (lambda event: self.onSave(dialog, txtName.get(), txtHost.get(), name)))
-        txtName.grid(row=0, column=1, columnspan=2)
+        txtName.grid(row=0, column=1, columnspan=60)
         txtName.focus();
 
         # Create Host label.
@@ -175,7 +175,7 @@ class GitRemotes(InterfaceView):
         txtHost["width"] = 50
         txtHost.bind("<Return>", (lambda event: self.onSave(dialog, txtName.get(), txtHost.get(), name)))
         txtHost.bind("<KP_Enter>", (lambda event: self.onSave(dialog, txtName.get(), txtHost.get(), name)))
-        txtHost.grid(row=1, column=1, columnspan=2)
+        txtHost.grid(row=1, column=1, columnspan=60)
 
         # Create OK button.
         button = Button(dialog, width=5, text="OK", command = (lambda: self.onSave(dialog, txtName.get(), txtHost.get(), name)))
@@ -183,7 +183,7 @@ class GitRemotes(InterfaceView):
 
         # Create Cancel button.
         button = Button(dialog, width=5, text="Cancel", command = (lambda: dialog.destroy()))
-        button.grid(row=2, column=2)
+        button.grid(row=2, column=60)
 
         # Set default value, if editing.
         if name:

--- a/rabbitvcs/ui/remotes.py
+++ b/rabbitvcs/ui/remotes.py
@@ -179,11 +179,11 @@ class GitRemotes(InterfaceView):
 
         # Create OK button.
         button = Button(dialog, width=5, text="OK", command = (lambda: self.onSave(dialog, txtName.get(), txtHost.get(), name)))
-        button.grid(row=2, column=1)
+        button.grid(row=2, column=60)
 
         # Create Cancel button.
         button = Button(dialog, width=5, text="Cancel", command = (lambda: dialog.destroy()))
-        button.grid(row=2, column=60)
+        button.grid(row=2, column=59)
 
         # Set default value, if editing.
         if name:

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -965,7 +965,7 @@ class GittyupClient:
     def onUsername(self, window, username, remoteKey, originalRemoteUrl, isOk):
         if isOk == True:
             if username == "":
-                tkMessageBox.showinfo("debug", "Please enter a username.", parent=window)
+                tkMessageBox.showinfo("Error", "Please enter a username.", parent=window)
                 return
             else:
                 # Insert password into url.
@@ -985,7 +985,7 @@ class GittyupClient:
     def onPassword(self, window, password, remoteKey, originalRemoteUrl, isOk):
         if isOk == True:
             if password == "":
-                tkMessageBox.showinfo("debug", "Please enter a password.", parent=window)
+                tkMessageBox.showinfo("Error", "Please enter a password.", parent=window)
                 return
             else:
                 # Insert password into url.


### PR DESCRIPTION
The existing Remote Repository Manager dialog was fairly buggy. Adding and editing multiple Git remotes would either edit the wrong selected item, insert duplicate rows, or not save the changes at all. In addition, the UI seemed difficult to use, with regard to double-clicking rows multiple times to start inline-editing.

This fork replaces the existing Remote Repository Manager UI with a new version made via TkInter. Bugs related to adding and editing remotes are now fixed.

![Remote Manager Screenshot](http://i.imgur.com/21FGL3i.png)
