### PR TITLE
Ubuntu 14.10 install fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,9 +160,9 @@ dist = setup(
 if sys.argv[1] == "install":
 
     if os.uname()[0] != 'Darwin':
-        print "Running gtk-update-icon-cache"
+        print "Running gtk-update-icon-cache-3.0"
         
         subprocess.Popen(
-            ["gtk-update-icon-cache", icon_theme_directory], 
+            ["gtk-update-icon-cache-3.0", icon_theme_directory], 
             stdout=subprocess.PIPE
         ).communicate()[0]


### PR DESCRIPTION
command gtk-update-icon-cache does not exist. Changed it to gtk-update-icon-cache-3.0.