### PR TITLE
minor fix: commits without date specified are shown correctly

### DIFF
--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -122,21 +122,24 @@ def format_datetime(dt, format=None):
     delta = now - dt
     
     returner = ""
-    if delta.days == 0:
-        if delta.seconds < 60:
-            returner = _("just now")
-        elif delta.seconds >= 60 and delta.seconds < 600:
-            returner = _("%d minute(s) ago") % (delta.seconds/60)
-        elif delta.seconds >= 600 and delta.seconds < 43200:
-            returner = dt.strftime("%I:%M%P")
-        else:
-            returner = dt.strftime(DT_FORMAT_THISWEEK)
-    elif delta.days > 0 and delta.days < 7:
-        returner = dt.strftime(DT_FORMAT_THISWEEK)
-    elif delta.days >= 7 and delta.days < 365:
-        returner = dt.strftime(DT_FORMAT_THISYEAR)
+    if dt.year == 1900:
+        returner = _("(no date)")
     else:
-        returner = dt.strftime(DT_FORMAT_ALL)
+        if delta.days == 0:
+            if delta.seconds < 60:
+                returner = _("just now")
+            elif delta.seconds >= 60 and delta.seconds < 600:
+                returner = _("%d minute(s) ago") % (delta.seconds/60)
+            elif delta.seconds >= 600 and delta.seconds < 43200:
+                returner = dt.strftime("%I:%M%P")
+            else:
+                returner = dt.strftime(DT_FORMAT_THISWEEK)
+        elif delta.days > 0 and delta.days < 7:
+            returner = dt.strftime(DT_FORMAT_THISWEEK)
+        elif delta.days >= 7 and delta.days < 365:
+            returner = dt.strftime(DT_FORMAT_THISYEAR)
+        else:
+            returner = dt.strftime(DT_FORMAT_ALL)
 
     enc = locale.getpreferredencoding(False)
     if enc is None or len(enc) == 0:

--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -1176,7 +1176,7 @@ class SVN:
         returner = []
         for item in log:
             revision = Revision(pysvn.opt_revision_kind.number, item.revision.number)
-            date = datetime.fromtimestamp(item.date)
+            date = datetime.fromtimestamp(item.date) if hasattr(item, "date") else datetime(1900, 1, 1)
             
             author = _("(no author)")
             if hasattr(item, "author"):


### PR DESCRIPTION
Greetings!

I'm not quite sure, how our team managed to get the following result while using svn, maybe one of the build scripts caused it, nevertheless there occured to be an _empty_ commit in our log. Not with the author empty, but with the date also.

Not a great problem at all really, but it caused my favourite RabbitVCS to fail on "Show log", displaying the following error (pic. 1). I got the nerve to offer you a small commit, which fixes it instead of bothering you with such a minor issue.

The solution is based on my belief that no other commit could be dated with 1900 year. The output matches the similar of the console svn (pic. 2). 

**Before:**

![before_error](https://cloud.githubusercontent.com/assets/8866886/11147492/4fa5b6a2-8a27-11e5-9fba-d32888e3e469.png)

**After:**

![after](https://cloud.githubusercontent.com/assets/8866886/11147505/62db5268-8a27-11e5-91a4-a9a7a8c0afee.png)

Accept it, if you find it worthy. 
With best regards