### PR TITLE
Clear diff errors

### DIFF
--- a/rabbitvcs/ui/diff.py
+++ b/rabbitvcs/ui/diff.py
@@ -21,7 +21,7 @@
 #
 
 import thread
-
+import time
 import pygtk
 import gobject
 import gtk
@@ -60,6 +60,7 @@ class Diff(InterfaceNonView):
             self.path2 = path1
         
         self.dialog = None
+        self.dialogIsAlive = False
         
     def launch(self):
         
@@ -85,11 +86,11 @@ class Diff(InterfaceNonView):
         self.dialog.run()
     
     def stop_loading(self):
-        
         # Sometimes the launching will be too fast, and the dialog we're trusted with
         # cleaning up, may not even have been created!
-        while self.dialog == None:
+        while self.dialog == None or self.dialog.dialog == None:
             # Wait for dialog's creation.
+            time.sleep(0.1)
             pass
         
         self.dialog.close()
@@ -178,9 +179,13 @@ class SVNDiff(Diff):
                 self.svn.export, 
                 self.path1, 
                 dest1, 
-                self.revision1
+                self.revision1,
+                silent_fail=True
             )
             action.stop_loader()
+            if not os.path.isfile(dest1):
+                with open(dest1, 'a'):
+                    os.utime(dest1, None)
     
         if self.revision2.kind == "working":
             dest2 = self.path2
@@ -190,9 +195,13 @@ class SVNDiff(Diff):
                 self.svn.export, 
                 self.path2, 
                 dest2, 
-                self.revision2
+                self.revision2,
+                silent_fail=True
             )
             action.stop_loader()
+            if not os.path.isfile(dest2):
+                with open(dest2, 'a'):
+                    os.utime(dest2, None)
     
         rabbitvcs.util.helper.launch_diff_tool(dest1, dest2)
 

--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -1215,7 +1215,7 @@ class SVN:
         return returner
 
     def export(self, src_url_or_path, dest_path, revision=Revision("head"),
-            recurse=True, ignore_externals=False, force=False, native_eol=None):
+            recurse=True, ignore_externals=False, force=False, native_eol=None, silent_fail=False):
 
         """
         Export files from either a working copy or repository into a local
@@ -1236,13 +1236,20 @@ class SVN:
         @type   recurse: boolean
         @param  recurse: Whether or not to run a recursive checkout.
 
+        @type   silent_fail: boolean
+        @param  silent_fail: If export fails, simply return None
+
         """
         revision=Revision("head")
 
-
-
-        return self.client.export(src_url_or_path, dest_path, force,
-            revision.primitive(), native_eol, ignore_externals, recurse)
+        try:
+            return self.client.export(src_url_or_path, dest_path, force,
+                revision.primitive(), native_eol, ignore_externals, recurse)
+        except pysvn.ClientError, e:
+            if silent_fail:
+                return None
+            else:
+                raise e
 
     def import_(self, path, url, log_message, ignore=False):
 


### PR DESCRIPTION
I got annoyed with the errors thrown into the console and the useless error dialog popped up when opening an unversioned or deleted file from the commit dialog.  Now those don't happen.