### PR TITLE
Fix svn export: respect the provided Revision parameter rather than o…

### DIFF
--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -1237,9 +1237,6 @@ class SVN:
         @param  recurse: Whether or not to run a recursive checkout.
 
         """
-        revision=Revision("head")
-
-
 
         return self.client.export(src_url_or_path, dest_path, force,
             revision.primitive(), native_eol, ignore_externals, recurse)


### PR DESCRIPTION
Hi ... just worked with rabbitcvs first time on an svn repository and found that comparing two revisions always resulted in meld reporting identical files.

Digging into the code, I found the svn vcs export method overwrites the parameter revision and always exports the head ... leading to identical files being passed to meld :-)

