### PR TITLE
GIT - fix working with polish characters in filenames

### DIFF
--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -25,10 +25,13 @@ import util
 from objects import *
 from command import GittyupCommand
 
+
 import Tkinter
 import tkMessageBox
 
 ENCODING = "UTF-8"
+
+
 
 def callback_notify_null(val):
     pass
@@ -1351,7 +1354,7 @@ class GittyupClient:
             if components:
                 status = components.group(1)
                 strip_status = status.strip()
-                path = components.group(2).decode("string_escape")
+                path = components.group(2).decode("string_escape").decode("UTF-8")
                 if path[0] == '"' and path[-1] == '"':
                     path = path[1:-1]
                
@@ -1440,7 +1443,7 @@ class GittyupClient:
 
             # Check if directory includes modified files
             for file in modified_files:
-                if file.startswith(d):
+                if file.startswith("%s/" % d): # fix, when file startwith same prefix as directory
                     d_status = ModifiedStatus(d)
                     break
 
@@ -1629,7 +1632,7 @@ class GittyupClient:
                     changed_file = {
                         "additions": file_line[0],
                         "removals": file_line[1],
-                        "path": file_line[2].decode('string_escape')
+                        "path": file_line[2].decode('string_escape').decode("UTF-8")
                     }
                     if changed_file['path'][0] == '"' and changed_file['path'][-1] == '"':
                         changed_file['path'] = changed_file['path'][1:-1]

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -1351,7 +1351,9 @@ class GittyupClient:
             if components:
                 status = components.group(1)
                 strip_status = status.strip()
-                path = components.group(2)
+                path = components.group(2).decode("string_escape")
+                if path[0] == '"' and path[-1] == '"':
+                    path = path[1:-1]
                
                 if status == " D":
                     statuses.append(MissingStatus(path))
@@ -1627,8 +1629,10 @@ class GittyupClient:
                     changed_file = {
                         "additions": file_line[0],
                         "removals": file_line[1],
-                        "path": file_line[2]
+                        "path": file_line[2].decode('string_escape')
                     }
+                    if changed_file['path'][0] == '"' and changed_file['path'][-1] == '"':
+                        changed_file['path'] = changed_file['path'][1:-1]
                     revision["changed_paths"].append(changed_file)
 
         if revision:

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -1440,10 +1440,14 @@ class GittyupClient:
                 if untracked_path in d:
                     d_status = UntrackedStatus(d)
                     break
+            
+            dirPattern = "/%s/" % d
+            if len(d) == 0:
+                dirPattern = "/"
 
             # Check if directory includes modified files
             for file in modified_files:
-                if file.startswith("%s/" % d): # fix, when file startwith same prefix as directory
+                if ("/%s" % file).startswith(dirPattern): # fix, when file startwith same prefix as directory, fix status for root repo path ""
                     d_status = ModifiedStatus(d)
                     break
 
@@ -1453,7 +1457,6 @@ class GittyupClient:
                     d_status = IgnoredStatus(d)
                     break
             statuses.append(d_status)
-
 
         return statuses
 


### PR DESCRIPTION
When filename contains special latin characters, git commands return filenames encoded, so any further operation fails :
$ git status --porcelain
?? "TEST_\304\205\305\202\303\263\305\2721.txt"

to properly operate we need to decode this strings and remove quotation marks