### PR TITLE
Set clone dialog Url to value in clipboard.

### DIFF
--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -27,6 +27,7 @@ import urllib
 import pygtk
 import gobject
 import gtk
+import Tkinter
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.checkout import Checkout
@@ -48,6 +49,7 @@ class GitClone(Checkout):
         self.get_widget("Checkout").set_title(_("Clone"))
         self.get_widget("repo_chooser").hide()
 
+        self.default_text()
         self.check_form()
 
     def on_ok_clicked(self, widget):
@@ -97,6 +99,15 @@ class GitClone(Checkout):
         )
         
         self.check_form()
+
+    def default_text(self):
+        # Use a repo url from the clipboard by default.
+        root = Tkinter.Tk()
+        root.withdraw()
+        
+        text = root.clipboard_get()
+        if ".git" in text:
+            self.repositories.set_child_text(text)
 
     def check_form(self):
         self.complete = True

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -103,7 +103,7 @@ class GitClone(Checkout):
         # Use a repo url from the clipboard by default.
         clipboard = gtk.clipboard_get()
         text = clipboard.wait_for_text()
-        if text.endswith(('.git', '.git/')):
+        if text and text.endswith(('.git', '.git/')):
             self.repositories.set_child_text(text)
 
     def check_form(self):

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -102,10 +102,10 @@ class GitClone(Checkout):
 
     def default_text(self):
         # Use a repo url from the clipboard by default.
-        root = Tkinter.Tk()
-        root.withdraw()
-        
-        text = root.clipboard_get()
+        clipboard = gtk.Clipboard()
+        clipboard.request_text(self.receive_clipboard_text)
+
+    def receive_clipboard_text(self, clipboard, text):
         if ".git" in text:
             self.repositories.set_child_text(text)
 

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -27,7 +27,6 @@ import urllib
 import pygtk
 import gobject
 import gtk
-import Tkinter
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.checkout import Checkout

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -102,11 +102,9 @@ class GitClone(Checkout):
 
     def default_text(self):
         # Use a repo url from the clipboard by default.
-        clipboard = gtk.Clipboard()
-        clipboard.request_text(self.receive_clipboard_text)
-
-    def receive_clipboard_text(self, clipboard, text):
-        if ".git" in text:
+        clipboard = gtk.clipboard_get()
+        text = clipboard.wait_for_text()
+        if text.endswith(('.git', '.git/')):
             self.repositories.set_child_text(text)
 
     def check_form(self):


### PR DESCRIPTION
Added a feature to the Clone dialog to set the default url to the value in the clipboard (for `.git` urls).

This feature allows the user to copy a repo url from Github, etc and have the Clone dialog default to this url.