### PR TITLE
Fixed typo in promptUsername for push/pull/clone dialog.

### DIFF
--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -1031,7 +1031,7 @@ class GittyupClient:
                 if remoteKey.find("://") == -1:
                     # Write url temporarily back to config.
                     self._config_set(remoteKey, "url", newRemoteUrl)
-                    self._config_seteable.write_to_path()
+                    self.config.write_to_path()
                 else:
                     # Change the url in memory, since we don't have a config yet.
                     self.modifiedHost = newRemoteUrl


### PR DESCRIPTION
This fix resolves the issue of the promptUsername dialog not working correctly.

![promptusername](https://user-images.githubusercontent.com/529049/33409721-dd72cd9c-d54a-11e7-8798-cf5f0259457d.png)

*When clicking `OK` in the above dialog, nothing would happen, forcing the user to click `Cancel`. This fix resolves the issue.*
