### PR TITLE
Solve configspec.ini not existing during install on Debian

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ icons += include_by_pattern("data/icons/hicolor", icon_theme_directory, ".png")
 # Config parsing specification
 config_spec = [(
     "share/rabbitvcs",
-    ["rabbitvcs/util/configspec/configspec.ini"]
+    ["util/configspec/configspec.ini"]
 )]
 
 # Documentation


### PR DESCRIPTION
Solve an error with not existing configspec.ini during install on Debian system. See issue #241 about details.