### PR TITLE
Gtk3/Python3 contributions

### DIFF
--- a/clients/caja/RabbitVCS.py
+++ b/clients/caja/RabbitVCS.py
@@ -29,7 +29,6 @@ Our module for everything related to the Caja extension.
 """
 from __future__ import with_statement
 from __future__ import absolute_import
-import six
 from six.moves import range
 
 def log_all_exceptions(type, value, tb):
@@ -77,6 +76,7 @@ import rabbitvcs.vcs.status
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import to_text
 
 from rabbitvcs.util.decorators import timeit, disable
 
@@ -431,7 +431,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
         import cProfile
         import rabbitvcs.util.helper
         
-        path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()),
+        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()),
                        "utf-8").replace("/", ":")
         
         profile_data_file = os.path.join(

--- a/clients/nautilus-3.0/RabbitVCS.py
+++ b/clients/nautilus-3.0/RabbitVCS.py
@@ -27,7 +27,6 @@ Our module for everything related to the Nautilus extension.
 """
 from __future__ import with_statement
 from __future__ import absolute_import
-import six
 from six.moves import range
 
 def log_all_exceptions(type, value, tb):
@@ -73,6 +72,7 @@ import rabbitvcs.vcs.status
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import to_text
 
 from rabbitvcs.util.decorators import timeit, disable
 
@@ -427,7 +427,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         import cProfile
         import rabbitvcs.util.helper
         
-        path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()),
+        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()),
                        "utf-8").replace("/", ":")
         
         profile_data_file = os.path.join(

--- a/clients/nautilus-3.0/RabbitVCS.py
+++ b/clients/nautilus-3.0/RabbitVCS.py
@@ -133,9 +133,14 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         factory = Gtk.IconFactory()
 
         rabbitvcs_icons = [
+            "scalable/actions/rabbitvcs-cancel.svg",
+            "scalable/actions/rabbitvcs-ok.svg",
+            "scalable/actions/rabbitvcs-no.svg",
+            "scalable/actions/rabbitvcs-yes.svg",
             "scalable/actions/rabbitvcs-settings.svg",
             "scalable/actions/rabbitvcs-export.svg",
             "scalable/actions/rabbitvcs-properties.svg",
+            "scalable/actions/rabbitvcs-editprops.svg",
             "scalable/actions/rabbitvcs-show_log.svg",
             "scalable/actions/rabbitvcs-delete.svg",
             "scalable/actions/rabbitvcs-run.svg",

--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -27,7 +27,6 @@ Our module for everything related to the Nautilus extension.
 """
 from __future__ import with_statement
 from __future__ import absolute_import
-import six
 from six.moves import range
 
 def log_all_exceptions(type, value, tb):
@@ -71,6 +70,7 @@ import rabbitvcs.vcs.status
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import to_text
 from rabbitvcs.util.decorators import timeit, disable
 from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
 
@@ -191,7 +191,7 @@ class RabbitVCS(nautilus.InfoProvider, nautilus.MenuProvider,
                 
         if not self.valid_uri(item.get_uri()): return nautilus.OPERATION_FAILED
         
-        path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
+        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
 
         # log.debug("update_file_info() called for %s" % path)
 
@@ -309,7 +309,7 @@ class RabbitVCS(nautilus.InfoProvider, nautilus.MenuProvider,
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
+                path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 
@@ -337,7 +337,7 @@ class RabbitVCS(nautilus.InfoProvider, nautilus.MenuProvider,
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
+                path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 
@@ -359,7 +359,7 @@ class RabbitVCS(nautilus.InfoProvider, nautilus.MenuProvider,
         import cProfile
         import rabbitvcs.util.helper
         
-        path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()),
+        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()),
                        "utf-8").replace("/", ":")
         
         profile_data_file = os.path.join(
@@ -389,7 +389,7 @@ class RabbitVCS(nautilus.InfoProvider, nautilus.MenuProvider,
         """
 
         if not self.valid_uri(item.get_uri()): return
-        path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
+        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
         self.nautilusVFSFile_table[path] = item
 
         # log.debug("get_background_items_full() called")
@@ -412,7 +412,7 @@ class RabbitVCS(nautilus.InfoProvider, nautilus.MenuProvider,
 
     def get_background_items(self, window, item):
         if not self.valid_uri(item.get_uri()): return
-        path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
+        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
         self.nautilusVFSFile_table[path] = item
 
         # log.debug("get_background_items() called")
@@ -549,7 +549,7 @@ class RabbitVCS(nautilus.InfoProvider, nautilus.MenuProvider,
 
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
+                path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()), "utf-8")
                 
                 if self.vcs_client.is_in_a_or_a_working_copy(path):
                     paths.append(path)

--- a/clients/nemo/RabbitVCS.py
+++ b/clients/nemo/RabbitVCS.py
@@ -133,9 +133,14 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
         factory = Gtk.IconFactory()
 
         rabbitvcs_icons = [
+            "scalable/actions/rabbitvcs-cancel.svg",
+            "scalable/actions/rabbitvcs-ok.svg",
+            "scalable/actions/rabbitvcs-no.svg",
+            "scalable/actions/rabbitvcs-yes.svg",
             "scalable/actions/rabbitvcs-settings.svg",
             "scalable/actions/rabbitvcs-export.svg",
             "scalable/actions/rabbitvcs-properties.svg",
+            "scalable/actions/rabbitvcs-editprops.svg",
             "scalable/actions/rabbitvcs-show_log.svg",
             "scalable/actions/rabbitvcs-delete.svg",
             "scalable/actions/rabbitvcs-run.svg",

--- a/clients/nemo/RabbitVCS.py
+++ b/clients/nemo/RabbitVCS.py
@@ -27,7 +27,6 @@ Our module for everything related to the Nautilus extension.
 """
 from __future__ import with_statement
 from __future__ import absolute_import
-import six
 from six.moves import range
 
 def log_all_exceptions(type, value, tb):
@@ -73,6 +72,7 @@ import rabbitvcs.vcs.status
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import to_text
 
 from rabbitvcs.util.decorators import timeit, disable
 
@@ -427,7 +427,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
         import cProfile
         import rabbitvcs.util.helper
         
-        path = six.text_type(gnomevfs.get_local_path_from_uri(item.get_uri()),
+        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()),
                        "utf-8").replace("/", ":")
         
         profile_data_file = os.path.join(

--- a/clients/thunar-gtk3/RabbitVCS.py
+++ b/clients/thunar-gtk3/RabbitVCS.py
@@ -50,11 +50,11 @@ import rabbitvcs.ui.property_page
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import to_text
 from rabbitvcs.util.decorators import timeit, disable
 from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR
 
 from rabbitvcs.util.log import Log, reload_log_settings
-import six
 log = Log("rabbitvcs.util.extensions.thunarx.RabbitVCS")
 
 from rabbitvcs import gettext
@@ -183,7 +183,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = realpath(six.text_type(self.get_local_path(item), "utf-8"))
+                path = realpath(to_text(self.get_local_path(item), "utf-8"))
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 
@@ -210,7 +210,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         """
         
         if not self.valid_uri(item.get_uri()): return
-        path = realpath(six.text_type(self.get_local_path(item), "utf-8"))
+        path = realpath(to_text(self.get_local_path(item), "utf-8"))
         self.nautilusVFSFile_table[path] = item
         
         # log.debug("get_background_items() called")
@@ -316,7 +316,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = realpath(six.text_type(self.get_local_path(item), "utf-8"))
+                path = realpath(to_text(self.get_local_path(item), "utf-8"))
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 

--- a/clients/thunar-gtk3/RabbitVCS.py
+++ b/clients/thunar-gtk3/RabbitVCS.py
@@ -35,7 +35,7 @@ import threading
 import urllib
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import GObject, Gtk, Thunarx
 
 import pysvn
@@ -50,7 +50,7 @@ import rabbitvcs.ui.property_page
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
-from rabbitvcs.util.helper import to_text
+from rabbitvcs.util.helper import to_text unquote
 from rabbitvcs.util.decorators import timeit, disable
 from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR
 
@@ -156,7 +156,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         self.status_checker = StatusChecker()
     
     def get_local_path(self, item):
-        return urllib.unquote(item.get_uri().replace("file://", ""))
+        return unquote(item.get_uri().replace("file://", ""))
 
     #~ @disable
     # @timeit

--- a/clients/thunar/RabbitVCS.py
+++ b/clients/thunar/RabbitVCS.py
@@ -43,11 +43,11 @@ import rabbitvcs.ui.property_page
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import to_text
 from rabbitvcs.util.decorators import timeit, disable
 from rabbitvcs.util.contextmenu import MainContextMenu, SEPARATOR
 
 from rabbitvcs.util.log import Log, reload_log_settings
-import six
 log = Log("rabbitvcs.util.extensions.thunarx.RabbitVCS")
 
 from rabbitvcs import gettext
@@ -176,7 +176,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = realpath(six.text_type(self.get_local_path(item), "utf-8"))
+                path = realpath(to_text(self.get_local_path(item), "utf-8"))
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 
@@ -203,7 +203,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         """
         
         if not self.valid_uri(item.get_uri()): return
-        path = realpath(six.text_type(self.get_local_path(item), "utf-8"))
+        path = realpath(to_text(self.get_local_path(item), "utf-8"))
         self.nautilusVFSFile_table[path] = item
         
         # log.debug("get_background_items() called")
@@ -307,7 +307,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = realpath(six.text_type(self.get_local_path(item), "utf-8"))
+                path = realpath(to_text(self.get_local_path(item), "utf-8"))
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 

--- a/data/icons/hicolor/scalable/actions/rabbitvcs-cancel.svg
+++ b/data/icons/hicolor/scalable/actions/rabbitvcs-cancel.svg
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48.000000px"
+   height="48.000000px"
+   id="svg6361"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="rabbitvcs-cancel.svg"
+   version="1.1">
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient2256">
+      <stop
+         style="stop-color:#ff0202;stop-opacity:1;"
+         offset="0"
+         id="stop2258" />
+      <stop
+         style="stop-color:#ff9b9b;stop-opacity:1;"
+         offset="1"
+         id="stop2260" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2248">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2250" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop2252" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9647">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop9649" />
+      <stop
+         style="stop-color:#dbdbdb;stop-opacity:1;"
+         offset="1"
+         id="stop9651" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient21644">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop21646" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop21648" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient21644"
+       id="radialGradient21650"
+       cx="25.125"
+       cy="36.75"
+       fx="25.125"
+       fy="36.75"
+       r="15.75"
+       gradientTransform="matrix(1.000000,0.000000,0.000000,0.595238,-2.300678e-15,14.87500)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7895">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7897" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7899" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4981">
+      <stop
+         style="stop-color:#cc0000;stop-opacity:1;"
+         offset="0"
+         id="stop4983" />
+      <stop
+         style="stop-color:#b30000;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop4985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15762"
+       inkscape:collect="always">
+      <stop
+         id="stop15764"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop15766"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient14236">
+      <stop
+         id="stop14238"
+         offset="0.0000000"
+         style="stop-color:#ed4040;stop-opacity:1.0000000;" />
+      <stop
+         id="stop14240"
+         offset="1.0000000"
+         style="stop-color:#a40000;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11780">
+      <stop
+         style="stop-color:#ff8b8b;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop11782" />
+      <stop
+         style="stop-color:#ec1b1b;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop11784" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11014">
+      <stop
+         style="stop-color:#a80000;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop11016" />
+      <stop
+         style="stop-color:#c60000;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop13245" />
+      <stop
+         style="stop-color:#e50000;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop11018" />
+    </linearGradient>
+    <linearGradient
+       y2="9.6507530"
+       x2="9.8940229"
+       y1="5.3855424"
+       x1="5.7365270"
+       gradientTransform="matrix(-1.000000,0.000000,0.000000,-1.000000,31.72170,31.29079)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient15772"
+       xlink:href="#linearGradient15762"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4981"
+       id="linearGradient4987"
+       x1="23.995985"
+       y1="20.105337"
+       x2="41.047836"
+       y2="37.959785"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.000000,-2.000000)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7895"
+       id="linearGradient7901"
+       x1="15.578875"
+       y1="16.285088"
+       x2="32.166405"
+       y2="28.394291"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4981"
+       id="linearGradient2243"
+       gradientUnits="userSpaceOnUse"
+       x1="23.995985"
+       y1="20.105337"
+       x2="41.047836"
+       y2="37.959785"
+       gradientTransform="matrix(0.988373,0.000000,0.000000,0.988373,0.279002,0.278984)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2248"
+       id="radialGradient2254"
+       cx="16.75"
+       cy="10.666344"
+       fx="16.75"
+       fy="10.666344"
+       r="21.25"
+       gradientTransform="matrix(4.154957,-2.979206e-24,3.255657e-24,3.198723,-52.84553,-23.50921)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:guide-bbox="true"
+     showguides="true"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="0.15294118"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="19.223361"
+     inkscape:cy="15.539422"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1067"
+     inkscape:window-height="803"
+     inkscape:window-x="95"
+     inkscape:window-y="98"
+     inkscape:showpageshadow="false"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Cancel</dc:title>
+        <dc:date>2005-10-16</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Andreas Nilsson</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Cancel</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       sodipodi:type="arc"
+       style="opacity:0.63068183;color:#000000;fill:url(#radialGradient21650);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
+       id="path21642"
+       sodipodi:cx="25.125"
+       sodipodi:cy="36.75"
+       sodipodi:rx="15.75"
+       sodipodi:ry="9.375"
+       d="M 40.875 36.75 A 15.75 9.375 0 1 1  9.375,36.75 A 15.75 9.375 0 1 1  40.875 36.75 z"
+       transform="matrix(1.173803,0.000000,0.000000,0.600000,-5.265866,19.57500)" />
+    <path
+       style="fill:url(#linearGradient4987);fill-opacity:1;fill-rule:evenodd;stroke:#860000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15.591006,0.4919213 L 32.676311,0.4919213 L 45.497585,13.586385 L 45.497585,31.48003 L 32.848986,43.496929 L 15.418649,43.496929 L 2.4943857,30.658264 L 2.4943857,13.464078 L 15.591006,0.4919213 z "
+       id="path9480"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="opacity:0.81318683;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffdfdf;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="M 16.020655,1.5003424 L 32.248563,1.5003424 L 44.496456,13.922717 L 44.496456,31.037001 L 32.638472,42.48783 L 15.870253,42.48783 L 3.5090792,30.208718 L 3.5090792,13.84561 L 16.020655,1.5003424 z "
+       id="path9482"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="opacity:0.28977272;fill:url(#radialGradient2254);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15.6875,0.75 L 2.75,13.5625 L 2.75,30.5625 L 5.6875,33.46875 C 22.450041,33.526299 22.164665,20.450067 45.25,21.59375 L 45.25,13.6875 L 32.5625,0.75 L 15.6875,0.75 z "
+       id="path2241"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/data/icons/hicolor/scalable/actions/rabbitvcs-editprops.svg
+++ b/data/icons/hicolor/scalable/actions/rabbitvcs-editprops.svg
@@ -1,0 +1,535 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg7854"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.4 (unknown)"
+   version="1.0"
+   sodipodi:docname="rabbitvcs-editprops.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs7856">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5788">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5790" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5792" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5772">
+      <stop
+         id="stop5774"
+         offset="0"
+         style="stop-color:#e2b369;stop-opacity:1" />
+      <stop
+         id="stop5776"
+         offset="1"
+         style="stop-color:#c79b55;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5586">
+      <stop
+         style="stop-color:#bfbcb3;stop-opacity:1;"
+         offset="0"
+         id="stop5588" />
+      <stop
+         style="stop-color:#9c988a;stop-opacity:1;"
+         offset="1"
+         id="stop5590" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5586"
+       id="linearGradient5592"
+       x1="24.635435"
+       y1="7.202693"
+       x2="24.635435"
+       y2="12.380689"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,51.823723,0)" />
+    <filter
+       inkscape:collect="always"
+       x="-0.085321058"
+       width="1.1706421"
+       y="-0.73719835"
+       height="2.4743967"
+       id="filter5670">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.38394476"
+         id="feGaussianBlur5672" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       x="-0.090666526"
+       width="1.1813331"
+       y="-0.31875174"
+       height="1.6375035"
+       id="filter5766">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.79295562"
+         id="feGaussianBlur5768" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5772"
+       id="linearGradient5784"
+       gradientUnits="userSpaceOnUse"
+       x1="25.5"
+       y1="-13.625"
+       x2="26"
+       y2="-39.125"
+       gradientTransform="translate(-51.823723)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5788"
+       id="linearGradient5794"
+       x1="24.499998"
+       y1="-38.500011"
+       x2="24.499998"
+       y2="-1.6250113"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-51.823723)" />
+    <filter
+       inkscape:collect="always"
+       x="-0.083650827"
+       width="1.1673017"
+       y="-0.4520362"
+       height="1.9040724"
+       id="filter5830">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.4691176"
+         id="feGaussianBlur5832" />
+    </filter>
+    <linearGradient
+       id="linearGradient6732">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop6734" />
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1;"
+         offset="1"
+         id="stop6736" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6732"
+       id="linearGradient5968"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9716096,0,0,1.283333,-40.47809,-6.1310478)"
+       x1="37.926636"
+       y1="37.668934"
+       x2="5.4959755"
+       y2="10.982666" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2966"
+       id="linearGradient2468"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1096722,0,0,1.1096722,-15.40275,-2.3927604)"
+       x1="48.90625"
+       y1="17.376184"
+       x2="50.988335"
+       y2="22.250591" />
+    <linearGradient
+       id="linearGradient2966">
+      <stop
+         style="stop-color:#ffd1d1;stop-opacity:1;"
+         offset="0"
+         id="stop2968" />
+      <stop
+         id="stop3006"
+         offset="0.5"
+         style="stop-color:#ff1d1d;stop-opacity:1;" />
+      <stop
+         style="stop-color:#6f0000;stop-opacity:1;"
+         offset="1"
+         id="stop2970" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2974"
+       id="linearGradient2470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1096722,0,0,1.1096722,-15.40275,-2.3927604)"
+       x1="46"
+       y1="19.8125"
+       x2="47.6875"
+       y2="22.625" />
+    <linearGradient
+       id="linearGradient2974">
+      <stop
+         style="stop-color:#c1c1c1;stop-opacity:1;"
+         offset="0"
+         id="stop2976" />
+      <stop
+         style="stop-color:#acacac;stop-opacity:1;"
+         offset="1"
+         id="stop2978" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2984"
+       id="radialGradient2472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.2441988,0,0,2.2523205,-77.417921,-33.335049)"
+       cx="29.053354"
+       cy="27.640751"
+       fx="29.053354"
+       fy="27.640751"
+       r="3.2408545" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2984">
+      <stop
+         style="stop-color:#e7e2b8;stop-opacity:1;"
+         offset="0"
+         id="stop2986" />
+      <stop
+         style="stop-color:#e7e2b8;stop-opacity:0;"
+         offset="1"
+         id="stop2988" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2994"
+       id="linearGradient2474"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1096722,0,0,1.1096722,-15.576136,-2.2540513)"
+       x1="25.71875"
+       y1="31.046875"
+       x2="25.514589"
+       y2="30.703125" />
+    <linearGradient
+       id="linearGradient2994">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2996" />
+      <stop
+         style="stop-color:#c9c9c9;stop-opacity:1;"
+         offset="1"
+         id="stop2998" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#e0e0e0"
+     borderopacity="1"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="5.2534225"
+     inkscape:cy="28.868481"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     width="48px"
+     height="48px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1129"
+     inkscape:window-height="632"
+     inkscape:window-x="139"
+     inkscape:window-y="27"
+     showgrid="false"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7859">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source>http://jimmac.musichall.cz</dc:source>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/GPL/2.0/" />
+        <dc:title>Edit Properties</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>edit properties</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/GPL/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/SourceCode" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       ry="7.272984"
+       rx="4.4858322"
+       y="38.438263"
+       x="19.514534"
+       height="6.5"
+       width="35.125"
+       id="rect5984"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.35294118;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;filter:url(#filter5830);enable-background:accumulate"
+       transform="matrix(-0.7245031,0,0,0.4468592,45.652037,23.280448)" />
+    <rect
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.41764706;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;filter:url(#filter5830);enable-background:accumulate"
+       id="rect5796"
+       width="35.125"
+       height="6.5"
+       x="6.8749995"
+       y="35.875"
+       rx="3.2499998"
+       ry="5.28125"
+       transform="matrix(-1,0,0,0.6153846,51.823723,15.798077)" />
+    <rect
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient5784);fill-opacity:1;fill-rule:nonzero;stroke:#8f5902;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+       id="rect4613"
+       width="29.999996"
+       height="31.999998"
+       x="-42.323723"
+       y="-40.5"
+       rx="2.7499998"
+       ry="2.75"
+       transform="scale(-1)" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       id="path5674"
+       d="m 16.722015,14.506832 h 15.632463 c 0.972272,0.04419 1.026805,-1.889084 1.026805,-1.889084 l -2.88421,-2.310477 0.0091,-0.7545235 c 0,0 -12.01513,-0.02055 -12.01513,-0.02055 v 0.8902013 l -2.600867,2.242637 c 0,0 -0.05203,1.797602 0.83185,1.841796 z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.44117647;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;filter:url(#filter5766);enable-background:accumulate"
+       transform="matrix(-1.0502474,0,0,1.0502474,53.06159,-1.6664683)"
+       inkscape:connector-curvature="0" />
+    <rect
+       transform="scale(-1)"
+       ry="1.2499995"
+       rx="1.2499995"
+       y="-39.289101"
+       x="-41.188496"
+       height="29.578182"
+       width="27.729544"
+       id="rect5786"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.41764706;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5794);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate" />
+    <path
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient5592);fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+       d="M 35.101708,12.506832 H 19.469245 c -0.972272,0.04419 -1.026805,-1.889084 -1.026805,-1.889084 l 2.88421,-2.3104767 -0.0091,-3.7545238 c 0,-0.8226142 0.691802,-1.9332784 1.698805,-1.9332784 l 8.520043,-0.088388 c 1.212428,0 1.796282,1.1881512 1.796282,2.0011169 v 3.8902012 l 2.600867,2.2426371 c 0,0 0.05203,1.797602 -0.83185,1.841796 z"
+       id="path5584"
+       sodipodi:nodetypes="ccccccccccc"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.46470588;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+       id="rect5594"
+       width="15"
+       height="1.0416322"
+       x="-34.823723"
+       y="10"
+       rx="0.52081609"
+       ry="0.52081609"
+       transform="scale(-1,1)" />
+    <rect
+       ry="0.52081609"
+       rx="0.52081609"
+       y="4"
+       x="20"
+       height="1.0416322"
+       width="9"
+       id="rect5596"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.53529412;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;filter:url(#filter5670);enable-background:accumulate"
+       transform="matrix(-1,0,0,1,51.823723,0)" />
+    <g
+       id="g5945"
+       transform="translate(-78.176286,1.3465954)">
+      <g
+         transform="matrix(0.5454547,0,0,0.5454547,106.45908,17.135117)"
+         id="g5646">
+        <g
+           transform="matrix(1.1,0,0,1,-43.74165,5.918957)"
+           id="layer6"
+           inkscape:label="Shadow">
+          <g
+             id="g2043"
+             inkscape:label="Shadow"
+             transform="matrix(1,0,0,0.555556,-4.549998e-7,13.88887)">
+            <g
+               style="display:inline"
+               id="g2036"
+               inkscape:label="Shadow">
+              <g
+                 id="g3712"
+                 style="opacity:0.4"
+                 transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)" />
+            </g>
+          </g>
+          <g
+             id="g2285"
+             inkscape:label="pixmap"
+             style="display:inline"
+             transform="translate(50.6887,6.21499)" />
+          <g
+             transform="matrix(0.186703,0,0,0.186703,29.5814,63.83798)"
+             id="g891" />
+        </g>
+        <g
+           style="display:inline"
+           inkscape:label="Base"
+           id="g5657" />
+        <g
+           id="layer5"
+           inkscape:label="Text"
+           style="display:inline">
+          <rect
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5968);fill-opacity:1;fill-rule:evenodd;stroke:#939393;stroke-width:1.8333329;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+             id="rect2373"
+             width="38.499989"
+             height="38.499989"
+             x="-36.591621"
+             y="5.4189425"
+             rx="2.6242812"
+             ry="2.6242814"
+             inkscape:r_cx="true"
+             inkscape:r_cy="true" />
+          <rect
+             inkscape:r_cy="true"
+             inkscape:r_cx="true"
+             ry="1.0501654"
+             rx="1.0501657"
+             y="7.252274"
+             x="-34.758289"
+             height="34.833324"
+             width="34.833324"
+             id="rect2423"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.8333317;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+        </g>
+      </g>
+      <rect
+         inkscape:r_cy="true"
+         inkscape:r_cx="true"
+         ry="0"
+         rx="0"
+         y="23.590904"
+         x="89.000008"
+         height="2.0625005"
+         width="16"
+         id="rect6916"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#adaeab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate" />
+      <rect
+         inkscape:r_cy="true"
+         inkscape:r_cx="true"
+         ry="0"
+         rx="0"
+         y="27.590904"
+         x="89.000008"
+         height="2.0625005"
+         width="16"
+         id="rect5972"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#adaeab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate" />
+      <rect
+         inkscape:r_cy="true"
+         inkscape:r_cx="true"
+         ry="0"
+         rx="0"
+         y="31.64636"
+         x="89.000008"
+         height="2.0070443"
+         width="16"
+         id="rect5976"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#adaeab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate" />
+      <rect
+         inkscape:r_cy="true"
+         inkscape:r_cx="true"
+         ry="0"
+         rx="0"
+         y="35.590904"
+         x="89.000008"
+         height="2.0625005"
+         width="9.000001"
+         id="rect5980"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#adaeab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate" />
+    </g>
+    <g
+       id="layer1-3"
+       inkscape:label="Layer 1"
+       inkscape:groupmode="layer"
+       transform="matrix(0.70106024,-0.41232863,0.47028638,0.61466209,-2.6476336,21.495066)">
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#cb9022;fill-opacity:1;fill-rule:evenodd;stroke:#5c410c;stroke-width:1.10967219;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         d="m 10.131309,33.671585 6.241906,-6.241906 22.297474,-10.819303 c 3.606435,-1.387091 5.756425,3.745143 2.566117,5.548361 l -22.22812,10.403176 z"
+         id="path2960"
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="czcczcc"
+         id="path2964"
+         d="m 33.422826,19.800683 c 0,0 1.595154,0.104032 2.219345,1.491122 0.643047,1.428993 0,2.947567 0,2.947567 l 5.583038,-2.739503 c 0,0 1.61128,-0.978029 0.728222,-3.155631 -0.870995,-2.147856 -2.982244,-1.283058 -2.982244,-1.283058 z"
+         style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient2468);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient2470);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         d="m 33.422826,19.800683 c 0,0 1.595154,0.104032 2.219345,1.491122 0.643047,1.428993 0,2.947567 0,2.947567 L 37.861515,23.1297 c 0,0 0.917735,-1.46351 0.242741,-2.982244 -0.693545,-1.560477 -2.462085,-1.456445 -2.462085,-1.456445 z"
+         id="path2962"
+         sodipodi:nodetypes="czcczcc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient2472);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         d="m 11.714864,32.874009 4.993525,-4.993525 c 1.664508,0.901608 2.53144,2.39273 2.080635,4.126593 z"
+         id="path2982"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient2474);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         d="m 13.205986,31.313532 -1.803217,1.76854 2.600794,-0.346772 C 14.246304,31.937723 13.7955,31.556273 13.205986,31.313532 Z"
+         id="path2992"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.36363639;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         d="m 16.708389,27.845806 1.733863,1.387091 17.074903,-8.121325 c -0.493174,-0.949928 -1.377954,-1.203547 -2.112127,-1.28973 z"
+         id="path3002"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:0.36363639;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         d="m 18.789024,32.076432 0.208064,-0.832254 16.901517,-7.911519 c 0,0 -0.122241,0.680925 -0.239555,0.831533 z"
+         id="path3004"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/data/icons/hicolor/scalable/actions/rabbitvcs-no.svg
+++ b/data/icons/hicolor/scalable/actions/rabbitvcs-no.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48.000000px"
+   height="48.000000px"
+   id="svg6361"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="rabbitvcs-no.svg"
+   version="1.1">
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient2256">
+      <stop
+         style="stop-color:#ff0202;stop-opacity:1;"
+         offset="0"
+         id="stop2258" />
+      <stop
+         style="stop-color:#ff9b9b;stop-opacity:1;"
+         offset="1"
+         id="stop2260" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9647">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop9649" />
+      <stop
+         style="stop-color:#dbdbdb;stop-opacity:1;"
+         offset="1"
+         id="stop9651" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7895">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7897" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7899" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4981">
+      <stop
+         style="stop-color:#cc0000;stop-opacity:1;"
+         offset="0"
+         id="stop4983" />
+      <stop
+         style="stop-color:#b30000;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop4985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15762"
+       inkscape:collect="always">
+      <stop
+         id="stop15764"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop15766"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient14236">
+      <stop
+         id="stop14238"
+         offset="0.0000000"
+         style="stop-color:#ed4040;stop-opacity:1.0000000;" />
+      <stop
+         id="stop14240"
+         offset="1.0000000"
+         style="stop-color:#a40000;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11780">
+      <stop
+         style="stop-color:#ff8b8b;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop11782" />
+      <stop
+         style="stop-color:#ec1b1b;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop11784" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11014">
+      <stop
+         style="stop-color:#a80000;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop11016" />
+      <stop
+         style="stop-color:#c60000;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop13245" />
+      <stop
+         style="stop-color:#e50000;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop11018" />
+    </linearGradient>
+    <linearGradient
+       y2="9.6507530"
+       x2="9.8940229"
+       y1="5.3855424"
+       x1="5.7365270"
+       gradientTransform="matrix(-1.000000,0.000000,0.000000,-1.000000,31.72170,31.29079)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient15772"
+       xlink:href="#linearGradient15762"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7895"
+       id="linearGradient7901"
+       x1="15.578875"
+       y1="16.285088"
+       x2="32.166405"
+       y2="28.394291"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4981"
+       id="linearGradient2243"
+       gradientUnits="userSpaceOnUse"
+       x1="23.995985"
+       y1="20.105337"
+       x2="41.047836"
+       y2="37.959785"
+       gradientTransform="matrix(0.988373,0.000000,0.000000,0.988373,0.279002,0.278984)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14236"
+       id="radialGradient864"
+       cx="24.085232"
+       cy="24.008034"
+       fx="24.085232"
+       fy="24.008034"
+       r="21.918055"
+       gradientTransform="matrix(1,0,0,1.0030899,0,-0.07418202)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:guide-bbox="true"
+     showguides="true"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="0.15294118"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.7175144"
+     inkscape:cx="42.957058"
+     inkscape:cy="38.085766"
+     inkscape:current-layer="svg6361"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1067"
+     inkscape:window-height="803"
+     inkscape:window-x="95"
+     inkscape:window-y="98"
+     inkscape:showpageshadow="false"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>No</dc:title>
+        <dc:date>2005-10-16</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Andreas Nilsson</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>No</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer" />
+  <ellipse
+     style="stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1.0;fill:url(#radialGradient864)"
+     id="path48"
+     cx="24.085232"
+     cy="24.008034"
+     rx="21.174494"
+     ry="21.242218" />
+</svg>

--- a/data/icons/hicolor/scalable/actions/rabbitvcs-ok.svg
+++ b/data/icons/hicolor/scalable/actions/rabbitvcs-ok.svg
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="rabbitvcs-ok.svg"
+   version="1.0"
+   inkscape:r_cx="true"
+   inkscape:r_cy="true"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient5313">
+      <stop
+         id="stop5315"
+         offset="0"
+         style="stop-color:#99b8df;stop-opacity:1" />
+      <stop
+         style="stop-color:#3969a8;stop-opacity:1;"
+         offset="0.23705086"
+         id="stop5333" />
+      <stop
+         style="stop-color:#4f7eba;stop-opacity:1;"
+         offset="0.54706067"
+         id="stop5317" />
+      <stop
+         id="stop5321"
+         offset="0.74557692"
+         style="stop-color:#96b6d7;stop-opacity:1" />
+      <stop
+         style="stop-color:#a0bddc;stop-opacity:1"
+         offset="0.87321436"
+         id="stop5331" />
+      <stop
+         id="stop5319"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8152">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop8154" />
+      <stop
+         id="stop3174"
+         offset="0.5"
+         style="stop-color:#4f7eba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="1"
+         id="stop8156" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3207">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:0.47058824;"
+         offset="0"
+         id="stop3209" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:0;"
+         offset="1"
+         id="stop3211" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2847">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop2849" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0;"
+         offset="1"
+         id="stop2851" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2831">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop2833" />
+      <stop
+         id="stop2855"
+         offset="0.33333334"
+         style="stop-color:#5b86be;stop-opacity:1;" />
+      <stop
+         style="stop-color:#83a8d8;stop-opacity:0;"
+         offset="1"
+         id="stop2835" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8662">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop8664" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop8666" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8662"
+       id="radialGradient1503"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5146484,0,0,0.47064594,-60.868499,-57.345308)"
+       cx="24.837126"
+       cy="36.421127"
+       fx="24.837126"
+       fy="36.421127"
+       r="15.644737" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2831"
+       id="linearGradient8170"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.3096777,0,0,-1.6407386,49.454961,36.043112)"
+       x1="13.272219"
+       y1="10.762897"
+       x2="16.890039"
+       y2="22.128948" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2847"
+       id="linearGradient8172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3096777,0,0,1.6407386,-12.181757,-39.635946)"
+       x1="37.128052"
+       y1="29.729605"
+       x2="37.40255"
+       y2="26.800913" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8152"
+       id="linearGradient8174"
+       gradientUnits="userSpaceOnUse"
+       x1="49.412277"
+       y1="37.904068"
+       x2="11.881318"
+       y2="19.776045" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5313"
+       id="linearGradient8180"
+       gradientUnits="userSpaceOnUse"
+       x1="61.572533"
+       y1="28.049652"
+       x2="10.969182"
+       y2="20.333939" />
+  </defs>
+  <sodipodi:namedview
+     stroke="#3465a4"
+     fill="#729fcf"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#e8e8e8"
+     borderopacity="0.86666667"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.7381848"
+     inkscape:cx="23.839402"
+     inkscape:cy="27.402221"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="977"
+     inkscape:window-height="937"
+     inkscape:window-x="289"
+     inkscape:window-y="27"
+     width="48px"
+     height="48px"
+     borderlayer="true"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source>http://jimmac.musichall.cz</dc:source>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/GPL/2.0/" />
+        <dc:title>OK</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>ok</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Ricardo 'Rick' González</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/GPL/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/SourceCode" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     inkscape:r_cx="true"
+     inkscape:r_cy="true">
+    <ellipse
+       transform="scale(-1)"
+       id="path8660"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.36111109;fill:url(#radialGradient1503);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.15246558;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       inkscape:r_cx="true"
+       inkscape:r_cy="true"
+       cx="-23.248985"
+       cy="-40.20385"
+       rx="23.696276"
+       ry="7.3631353" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:r_cy="true"
+       inkscape:r_cx="true"
+       id="path8160"
+       d="m 26.932311,19.0524 c 0,0 2.943885,0.406366 2.223026,-16.389093 L 42.283993,2.4160632 c 0.0023,0 -0.804189,20.1967768 -15.351682,16.6363368 z"
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.51807233;fill:url(#linearGradient8170);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient8172);stroke-width:1.39102995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       inkscape:connector-curvature="0" />
+    <g
+       style="fill:url(#linearGradient8174);fill-opacity:1;stroke:#204a87;stroke-width:1.24932528;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:r_cy="true"
+       inkscape:r_cx="true"
+       transform="matrix(0.93061628,-0.02461973,-0.02592886,-0.88435103,-6.2072654,44.158387)"
+       id="g8162">
+      <path
+         inkscape:r_cy="true"
+         inkscape:r_cx="true"
+         style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient8180);fill-opacity:1;fill-rule:nonzero;stroke:#204a87;stroke-width:1.25256371;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+         d="m 53.930127,45.420124 c -0.257578,-8.530815 -0.720551,-22.286985 -0.720551,-22.286985 -0.170489,-4.582762 -2.516017,-8.888447 -6.342797,-9.457036 -3.185823,-0.473355 -8.097257,0.03676 -20.021985,0.04209 L 26.56069,3.4206089 10.686406,22.231507 27.693381,39.144592 27.42357,27.91546 c 5.138675,-0.02762 12.197504,-1.758775 17.799092,2.516047 5.187105,3.958511 7.14845,7.000191 8.707465,14.988617 z"
+         id="path8164"
+         sodipodi:nodetypes="ccscccccsc"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/data/icons/hicolor/scalable/actions/rabbitvcs-yes.svg
+++ b/data/icons/hicolor/scalable/actions/rabbitvcs-yes.svg
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48.000000px"
+   height="48.000000px"
+   id="svg6361"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="rabbitvcs-yes.svg"
+   version="1.1">
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient14236">
+      <stop
+         style="stop-color:#ed4040;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop850" />
+      <stop
+         style="stop-color:#a40000;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop852" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2256">
+      <stop
+         style="stop-color:#ff0202;stop-opacity:1;"
+         offset="0"
+         id="stop2258" />
+      <stop
+         style="stop-color:#ff9b9b;stop-opacity:1;"
+         offset="1"
+         id="stop2260" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9647">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop9649" />
+      <stop
+         style="stop-color:#dbdbdb;stop-opacity:1;"
+         offset="1"
+         id="stop9651" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7895">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7897" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7899" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4981">
+      <stop
+         style="stop-color:#cc0000;stop-opacity:1;"
+         offset="0"
+         id="stop4983" />
+      <stop
+         style="stop-color:#b30000;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop4985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15762"
+       inkscape:collect="always">
+      <stop
+         id="stop15764"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop15766"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient14236-3">
+      <stop
+         id="stop14238"
+         offset="0.0000000"
+         style="stop-color:#ed4040;stop-opacity:1.0000000;" />
+      <stop
+         id="stop14240"
+         offset="1.0000000"
+         style="stop-color:#a40000;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11780">
+      <stop
+         style="stop-color:#ff8b8b;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop11782" />
+      <stop
+         style="stop-color:#ec1b1b;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop11784" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11014">
+      <stop
+         style="stop-color:#a80000;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop11016" />
+      <stop
+         style="stop-color:#c60000;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop13245" />
+      <stop
+         style="stop-color:#e50000;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop11018" />
+    </linearGradient>
+    <linearGradient
+       y2="9.6507530"
+       x2="9.8940229"
+       y1="5.3855424"
+       x1="5.7365270"
+       gradientTransform="matrix(-1.000000,0.000000,0.000000,-1.000000,31.72170,31.29079)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient15772"
+       xlink:href="#linearGradient15762"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7895"
+       id="linearGradient7901"
+       x1="15.578875"
+       y1="16.285088"
+       x2="32.166405"
+       y2="28.394291"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4981"
+       id="linearGradient2243"
+       gradientUnits="userSpaceOnUse"
+       x1="23.995985"
+       y1="20.105337"
+       x2="41.047836"
+       y2="37.959785"
+       gradientTransform="matrix(0.988373,0.000000,0.000000,0.988373,0.279002,0.278984)" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0030899,0,-0.07418202)"
+       r="21.918055"
+       fy="24.008034"
+       fx="24.085232"
+       cy="24.008034"
+       cx="24.085232"
+       id="radialGradient864-480"
+       xlink:href="#linearGradient14236-3-70"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient14236-3-70">
+      <stop
+         style="stop-color:#40ed40;stop-opacity:1.0000000;;opacity:1"
+         offset="0.0000000"
+         id="stop888" />
+      <stop
+         style="stop-color:#00a400;stop-opacity:1.0000000;;opacity:1"
+         offset="1.0000000"
+         id="stop890" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     inkscape:guide-bbox="true"
+     showguides="true"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="0.15294118"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9770484"
+     inkscape:cx="24.556809"
+     inkscape:cy="26.514821"
+     inkscape:current-layer="svg6361"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1067"
+     inkscape:window-height="803"
+     inkscape:window-x="95"
+     inkscape:window-y="98"
+     inkscape:showpageshadow="false"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Yes</dc:title>
+        <dc:date>2005-10-16</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Andreas Nilsson</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Yes</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer" />
+  <ellipse
+     ry="21.242218"
+     rx="21.174494"
+     cy="24.008034"
+     cx="24.085232"
+     id="path48"
+     style="stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1.0;fill:url(#radialGradient864-480);opacity:1" />
+</svg>

--- a/rabbitvcs/services/checkerservice.py
+++ b/rabbitvcs/services/checkerservice.py
@@ -49,21 +49,16 @@ import sys
 import simplejson
 import six
 
-if "REQUIRE_GTK3" in os.environ and os.environ["REQUIRE_GTK3"]:
-    from gi.repository import GObject as gobject
-    from gi.repository import GLib as glib
-else:
-    import gobject
-    import glib
-    
+from gi.repository import GObject
+from gi.repository import GLib
+
 import dbus
-import dbus.glib # FIXME: this might actually already set the default loop
 import dbus.mainloop.glib
 import dbus.service
 
 import rabbitvcs.util.decorators
 import rabbitvcs.util._locale
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 import rabbitvcs.services.service
 from rabbitvcs.services.statuschecker import StatusChecker
 
@@ -111,6 +106,11 @@ def decode_status(json_dict):
         raise TypeError("RabbitVCS status object has no path")
     return st
 
+def output_and_flush(*args):
+    # Idle output function.
+    sys.stdout.write(*args)
+    sys.stdout.flush()
+
 class StatusCheckerService(dbus.service.Object):
     """ StatusCheckerService objects wrap a StatusCheckerPlus instance,
     exporting methods that can be called via DBUS.
@@ -150,7 +150,7 @@ class StatusCheckerService(dbus.service.Object):
 
     @dbus.service.method(INTERFACE)
     def MemoryUsage(self):
-        own_mem = rabbitvcs.util.helper.process_memory(os.getpid())
+        own_mem = helper.process_memory(os.getpid())
         checker_mem = self.status_checker.get_memory_usage()
 
         return own_mem + checker_mem
@@ -335,7 +335,7 @@ class StatusCheckerStub:
         def reply_handler(*args, **kwargs):
             # The callback should be performed as a low priority task, so we
             # keep Nautilus as responsive as possible.
-            gobject.idle_add(real_reply_handler, *args, **kwargs)
+            GLib.idle_add(real_reply_handler, *args, **kwargs)
         
         def error_handler(dbus_ex):
             log.exception(dbus_ex)
@@ -366,7 +366,7 @@ class StatusCheckerStub:
         service (which is, in turn, a wrapper around the real status checker).
         """
         if callback:
-            gobject.idle_add(self.check_status_later,
+            GLib.idle_add(self.check_status_later,
                      path, callback, recurse, invalidate, summary)
             return rabbitvcs.vcs.status.Status.status_calc(path)
         else:
@@ -383,7 +383,7 @@ class StatusCheckerStub:
         def reply_handler(*args, **kwargs):
             # The callback should be performed as a low priority task, so we
             # keep Nautilus as responsive as possible.
-            gobject.idle_add(real_reply_handler, *args, **kwargs)
+            GLib.idle_add(real_reply_handler, *args, **kwargs)
         
         def error_handler(dbus_ex):
             log.exception(dbus_ex)
@@ -403,7 +403,7 @@ class StatusCheckerStub:
             self._connect_to_checker()
 
     def generate_menu_conditions_async(self, provider, base_dir, paths, callback):
-        gobject.idle_add(self.generate_menu_conditions, provider, base_dir, paths, callback)
+        GLib.idle_add(self.generate_menu_conditions, provider, base_dir, paths, callback)
         return {}
 
 def start():
@@ -426,19 +426,18 @@ def Main():
 
     # The following calls are required to make DBus thread-aware and therefore
     # support the ability run threads.
-    gobject.threads_init()
-    dbus.glib.threads_init()
+    helper.gobject_threads_init()
+    dbus.mainloop.glib.threads_init()
 
     # This registers our service name with the bus
     session_bus = dbus.SessionBus()
     service_name = dbus.service.BusName(SERVICE, session_bus)
 
-    mainloop = gobject.MainLoop()
+    mainloop = GLib.MainLoop()
 
     checker_service = StatusCheckerService(session_bus, mainloop)
 
-    gobject.idle_add(sys.stdout.write, "Started status checker service\n")
-    gobject.idle_add(sys.stdout.flush)
+    GLib.idle_add(output_and_flush, "Started status checker service\n")
 
     mainloop.run()
 

--- a/rabbitvcs/services/checkerservice.py
+++ b/rabbitvcs/services/checkerservice.py
@@ -47,7 +47,6 @@ from __future__ import absolute_import
 import os, os.path
 import sys
 import simplejson
-import six
 
 from gi.repository import GObject
 from gi.repository import GLib
@@ -168,7 +167,7 @@ class StatusCheckerService(dbus.service.Object):
                       summary=False):
         """ Requests a status check from the underlying status checker.
         """
-        status = self.status_checker.check_status(six.text_type(path),
+        status = self.status_checker.check_status(helper.to_text(path),
                                                   recurse=recurse,
                                                   summary=summary,
                                                   invalidate=invalidate)
@@ -179,7 +178,7 @@ class StatusCheckerService(dbus.service.Object):
     def GenerateMenuConditions(self, paths):
         upaths = []
         for path in paths:
-            upaths.append(six.text_type(path))
+            upaths.append(helper.to_text(path))
     
         path_dict = self.status_checker.generate_menu_conditions(upaths)
         return simplejson.dumps(path_dict)

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -31,7 +31,7 @@ import os
 from six.moves import range
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GLib
 
 from rabbitvcs import APP_NAME, LOCALE_DIR, gettext
@@ -198,6 +198,18 @@ class InterfaceView(GtkBuilderWidgetWrapper):
                 Gdk.keyval_name(data.keyval).lower() == "r"):
             self.on_refresh_clicked(widget)
             return True             
+
+    def change_button(self, id, label = None, icon = None):
+        """
+         Replace label and/or icon of the named button.
+        """
+
+        button = self.get_widget(id)
+        if label:
+            button.set_label(label)
+        if icon:
+            image = Gtk.Image.new_from_icon_name(icon, Gtk.IconSize.BUTTON)
+            button.set_image(image)
 
 class InterfaceNonView:
     """

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -38,6 +38,7 @@ from rabbitvcs import APP_NAME, LOCALE_DIR, gettext
 _ = gettext.gettext
 
 import rabbitvcs.vcs.status
+from rabbitvcs.util import helper
 
 REVISION_OPT = (["-r", "--revision"], {"help":"specify the revision number"})
 BASEDIR_OPT = (["-b", "--base-dir"], {})
@@ -148,16 +149,13 @@ class InterfaceView(GtkBuilderWidgetWrapper):
         window = self.get_widget(self.gtkbuilder_id)
         if window is not None:
             if threaded:
-                Gdk.threads_enter()
+                helper.run_in_main_thread(window.destroy)
+            else:
+                window.destroy()
 
-            window.destroy()
-
-            if threaded:
-                Gdk.threads_leave()
-            
         if self.do_gtk_quit:
             Gtk.main_quit()
-            
+
     def register_gtk_quit(self):
         window = self.get_widget(self.gtkbuilder_id)
         self.do_gtk_quit = True

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -182,10 +182,10 @@ class InterfaceView(GtkBuilderWidgetWrapper):
         return True
 
     def on_key_pressed(self, widget, data):
-        if (data.keyval == Gdk.KEY_Escape):
+        if data.keyval == Gdk.keyval_from_name('Escape'):
             self.on_cancel_clicked(widget)
             return True
-            
+
         if (data.state & Gdk.ModifierType.CONTROL_MASK and 
                 Gdk.keyval_name(data.keyval).lower() == "w"):
             self.on_cancel_clicked(widget)

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -32,7 +32,7 @@ from six.moves import range
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject, Gdk
+from gi.repository import Gtk, Gdk, GLib
 
 from rabbitvcs import APP_NAME, LOCALE_DIR, gettext
 _ = gettext.gettext
@@ -164,7 +164,7 @@ class InterfaceView(GtkBuilderWidgetWrapper):
         
         # This means we've already been closed
         if window is None:
-            GObject.idle_add(Gtk.main_quit)
+            GLib.idle_add(Gtk.main_quit)
     
     def gtk_quit_is_set(self):
         return self.do_gtk_quit

--- a/rabbitvcs/ui/about.py
+++ b/rabbitvcs/ui/about.py
@@ -27,7 +27,7 @@ import string
 import re
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, GdkPixbuf
 
 import rabbitvcs
@@ -78,7 +78,7 @@ class About:
         self.about.set_authors(authors.split("\n"))
 
         pixbuf = GdkPixbuf.Pixbuf.new_from_file(rabbitvcs.get_icon_path() +
-                                                '/scalable/apps/rabbitvcs.svg')
+                                                "/scalable/apps/rabbitvcs.svg")
         self.about.set_logo(pixbuf)
 
         versions = []

--- a/rabbitvcs/ui/about.py
+++ b/rabbitvcs/ui/about.py
@@ -7,19 +7,20 @@ from __future__ import absolute_import
 # Copyright (C) 2007-2008 by Bruce van der Kooij <brucevdkooij@gmail.com>
 # Copyright (C) 2008-2010 by Adam Plumb <adamplumb@gmail.com>
 # 
-# RabbitVCS is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-# 
-# RabbitVCS is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
-#
+license = """\
+RabbitVCS is free software; you can redistribute it and/or modify  
+it under the terms of the GNU General Public License as published by  
+the Free Software Foundation; either version 2 of the License, or  
+(at your option) any later version.  
+
+RabbitVCS is distributed in the hope that it will be useful,  
+but WITHOUT ANY WARRANTY; without even the implied warranty of  
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the  
+GNU General Public License for more details.  
+
+You should have received a copy of the GNU General Public License  
+along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.  """
+
 
 import os.path
 import string
@@ -27,7 +28,7 @@ import re
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject
+from gi.repository import Gtk, GObject, GdkPixbuf
 
 import rabbitvcs
 from rabbitvcs.ui import InterfaceView
@@ -46,13 +47,7 @@ class About:
     """
 
     def __init__(self):
-    
-        #def url_hook(dialog, url):
-        #    rabbitvcs.util.helper.launch_url_in_webbrowser(url)
-    
-        #Gtk.about_dialog_set_url_hook(url_hook)
         self.about = Gtk.AboutDialog()
-        self.about.set_transient_for(window);
         self.about.set_name(rabbitvcs.APP_NAME)
 
         self.about.set_program_name(rabbitvcs.APP_NAME)
@@ -81,13 +76,19 @@ class About:
         authors = open(authors_path, "r").read()
 
         self.about.set_authors(authors.split("\n"))
-        
+
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file(rabbitvcs.get_icon_path() +
+                                                '/scalable/apps/rabbitvcs.svg')
+        self.about.set_logo(pixbuf)
+
         versions = []
         versions.append("Subversion - %s" % ".".join(list(map(str,pysvn.svn_version))))
         versions.append("Pysvn - %s" % ".".join(list(map(str,pysvn.version))))
         versions.append("ConfigObj - %s" % str(configobj.__version__))
         
         self.about.set_comments("\n".join(versions))
+
+        self.about.set_license(license)
     
     def run(self):
         self.about.show_all()

--- a/rabbitvcs/ui/action.py
+++ b/rabbitvcs/ui/action.py
@@ -36,13 +36,13 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util
 import rabbitvcs.vcs
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 from rabbitvcs.ui.dialog import MessageBox
 
 from rabbitvcs import gettext
 _ = gettext.gettext
 
-GObject.threads_init()
+helper.gobject_threads_init()
 
 from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.ui.action")
@@ -695,7 +695,7 @@ class SVNAction(VCSAction):
             self.queue.insert(position+1, self.edit_conflict, data)
 
     def edit_conflict(self, data):
-        rabbitvcs.util.helper.launch_ui_window("editconflicts", [data["path"]], block=True)
+        helper.launch_ui_window("editconflicts", [data["path"]], block=True)
 
 class GitAction(VCSAction):
     def __init__(self, client, register_gtk_quit=False, notification=True,
@@ -737,7 +737,7 @@ class GitAction(VCSAction):
     def conflict_filter(self, data):
         if str(data).startswith("ERROR:"):
             path = data[27:]
-            rabbitvcs.util.helper.launch_ui_window("editconflicts", [path], block=True)
+            helper.launch_ui_window("editconflicts", [path], block=True)
 
 class MercurialAction(VCSAction):
     def __init__(self, client, register_gtk_quit=False, notification=True,
@@ -777,7 +777,7 @@ class MercurialAction(VCSAction):
     def conflict_filter(self, data):
         if str(data).startswith("ERROR:"):
             path = data[27:]
-            rabbitvcs.util.helper.launch_ui_window("editconflicts", [path], block=True)
+            helper.launch_ui_window("editconflicts", [path], block=True)
 
 def vcs_action_factory(client, register_gtk_quit=False, notification=True,
         run_in_thread=True):

--- a/rabbitvcs/ui/add.py
+++ b/rabbitvcs/ui/add.py
@@ -160,7 +160,7 @@ class Add(InterfaceView, GtkContextMenuCaller):
         rabbitvcs.util.helper.launch_diff_tool(*paths)
 
     def on_files_table_key_event(self, treeview, data=None):
-        if Gtk.gdk.keyval_name(data.keyval) == "Delete":
+        if Gdk.keyval_name(data.keyval) == "Delete":
             self.delete_items(treeview, data)
 
     def on_files_table_mouse_event(self, treeview, data=None):

--- a/rabbitvcs/ui/annotate.py
+++ b/rabbitvcs/ui/annotate.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os
 
 from gi import require_version
-require_version('Gtk', '3.0')
+require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk, GLib
 
 from datetime import datetime
@@ -170,10 +170,11 @@ class SVNAnnotate(Annotate):
         )
         self.action.append(self.populate_table)
         self.action.append(self.enable_saveas)
-        self.action.run()
+        self.action.schedule()
 
         self.kill_loading()
-        
+
+    @gtk_unsafe
     def populate_table(self):
         blamedict = self.action.get_result(0)
 
@@ -268,10 +269,10 @@ class GitAnnotate(Annotate):
         )
         self.action.append(self.populate_table)
         self.action.append(self.enable_saveas)
-        self.action.run()
+        self.action.schedule()
         self.kill_loading()
-        
-        
+
+    @gtk_unsafe
     def populate_table(self):
         blamedict = self.action.get_result(0)
 

--- a/rabbitvcs/ui/annotate.py
+++ b/rabbitvcs/ui/annotate.py
@@ -25,7 +25,7 @@ import os
 
 from gi import require_version
 require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject, Gdk
+from gi.repository import Gtk, GObject, Gdk, GLib
 
 from datetime import datetime
 import time
@@ -106,10 +106,10 @@ class Annotate(InterfaceView):
 
     def launch_loading(self):
         self.loading_dialog = Loading()
-        GObject.idle_add(self.loading_dialog.run)
+        GLib.idle_add(self.loading_dialog.run)
 
     def kill_loading(self):
-        GObject.idle_add(self.loading_dialog.destroy)
+        GLib.idle_add(self.loading_dialog.destroy)
         
 class SVNAnnotate(Annotate):
     def __init__(self, path, revision=None):
@@ -246,10 +246,10 @@ class GitAnnotate(Annotate):
 
     def launch_loading(self):
         self.loading_dialog = Loading()
-        GObject.idle_add(self.loading_dialog.run)
+        GLib.idle_add(self.loading_dialog.run)
 
     def kill_loading(self):
-        GObject.idle_add(self.loading_dialog.destroy)
+        GLib.idle_add(self.loading_dialog.destroy)
     
     def load(self):
         to_rev = self.git.revision(self.get_widget("to").get_text())

--- a/rabbitvcs/ui/applypatch.py
+++ b/rabbitvcs/ui/applypatch.py
@@ -24,9 +24,8 @@ from __future__ import absolute_import
 import os.path
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
-import commands
 
 from rabbitvcs.ui import InterfaceNonView
 from rabbitvcs.ui.action import SVNAction
@@ -54,10 +53,11 @@ class ApplyPatch(InterfaceNonView):
         path = None
         
         dialog = Gtk.FileChooserDialog(
-            _("Apply Patch"),
-            None,
-            Gtk.FILE_CHOOSER_ACTION_OPEN,(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                          Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
+            title = _("Apply Patch"),
+            parent = None,
+            action = Gtk.FileChooserAction.OPEN)
+        dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        dialog.add_button(_("_Open"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
@@ -74,11 +74,11 @@ class ApplyPatch(InterfaceNonView):
         dir = None
         
         dialog = Gtk.FileChooserDialog(
-                    _("Apply Patch To Directory..."),
-                    None,
-                    Gtk.FILE_CHOOSER_ACTION_SELECT_FOLDER,
-                    (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                     Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
+                title = _("Apply Patch To Directory..."),
+                parent = None,
+                action = Gtk.FileChooserAction.SELECT_FOLDER)
+        dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        dialog.add_button(_("_Select"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
         
         response = dialog.run()
@@ -118,7 +118,7 @@ class SVNApplyPatch(ApplyPatch):
         self.action.append(self.svn.apply_patch, path, base_dir)
         self.action.append(self.action.set_status, _("Patch File Applied"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 class GitApplyPatch(ApplyPatch):
     def __init__(self, paths):
@@ -148,7 +148,7 @@ class GitApplyPatch(ApplyPatch):
         self.action.append(self.git.apply_patch, path, base_dir)
         self.action.append(self.action.set_status, _("Patch File Applied"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNApplyPatch,

--- a/rabbitvcs/ui/branch.py
+++ b/rabbitvcs/ui/branch.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -111,7 +111,7 @@ class SVNBranch(InterfaceView):
         self.action.append(self.svn.copy, src, dest, revision)
         self.action.append(self.action.set_status, _("Completed Branch/tag"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_previous_messages_clicked(self, widget, data=None):
         dialog = rabbitvcs.ui.dialog.PreviousMessages()

--- a/rabbitvcs/ui/branches.py
+++ b/rabbitvcs/ui/branches.py
@@ -241,7 +241,7 @@ class GitBranchManager(InterfaceView):
         self.show_edit(branch_name)
 
     def on_treeview_key_event(self, treeview, data=None):
-        if Gtk.gdk.keyval_name(data.keyval) in ("Up", "Down", "Return"):
+        if Gdk.keyval_name(data.keyval) in ("Up", "Down", "Return"):
             self.on_treeview_event(treeview, data)
 
     def on_treeview_mouse_event(self, treeview, data=None):

--- a/rabbitvcs/ui/branches.py
+++ b/rabbitvcs/ui/branches.py
@@ -35,13 +35,12 @@ from rabbitvcs.ui.action import GitAction
 from rabbitvcs.ui.log import log_dialog_factory
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.dialog import DeleteConfirmation
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 import rabbitvcs.vcs
 
 from xml.sax import saxutils
 
 from rabbitvcs import gettext
-import six
 _ = gettext.gettext
 
 STATE_ADD = 0
@@ -273,7 +272,7 @@ class GitBranchManager(InterfaceView):
         if self.revision:
             active_branch = self.git.get_active_branch()
             if active_branch:
-                revision = six.text_type(active_branch.name)
+                revision = helper.to_text(active_branch.name)
 
         self.items_treeview.unselect_all()
         self.branch_entry.set_text("")
@@ -298,7 +297,7 @@ class GitBranchManager(InterfaceView):
 
         if self.selected_branch:
             self.branch_entry.set_text(self.selected_branch.name)
-            self.revision_label.set_text(six.text_type(self.selected_branch.revision))
+            self.revision_label.set_text(helper.to_text(self.selected_branch.revision))
             self.message_label.set_text(self.selected_branch.message.rstrip("\n"))
             if self.selected_branch.tracking:
                 self.checkout_checkbox.set_active(True)

--- a/rabbitvcs/ui/branches.py
+++ b/rabbitvcs/ui/branches.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk, Pango
 
 from datetime import datetime
@@ -93,25 +93,25 @@ class GitBranchManager(InterfaceView):
     def initialize_detail(self):
         self.detail_container = self.get_widget("detail_container")
 
-        vbox = Gtk.VBox(False, 6)
+        vbox = Gtk.VBox(homogeneous = False, spacing = 6)
 
         # Set up the Branch line
-        label = Gtk.Label(_("Name:"))
+        label = Gtk.Label(label = _("Name:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=.5)
         self.branch_entry = Gtk.Entry()
-        self.branch_name_container = Gtk.HBox(False, 0)
+        self.branch_name_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.branch_name_container.pack_start(label, False, False, 0)
         self.branch_name_container.pack_start(self.branch_entry, False, False, 0)
         vbox.pack_start(self.branch_name_container, False, False, 0)
 
         # Set up the Commit-sha line
-        label = Gtk.Label(_("Start Point:"))
+        label = Gtk.Label(label = _("Start Point:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=.5)
         self.start_point_entry = Gtk.Entry()
         self.start_point_entry.set_size_request(300, -1)
-        self.start_point_container = Gtk.HBox(False, 0)
+        self.start_point_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.log_dialog_button = Gtk.Button()
         self.log_dialog_button.connect("clicked", self.on_log_dialog_button_clicked)
         image = Gtk.Image()
@@ -123,54 +123,54 @@ class GitBranchManager(InterfaceView):
         vbox.pack_start(self.start_point_container, False, False, 0)
 
         # Set up the Track line
-        label = Gtk.Label("")
+        label = Gtk.Label(label = "")
         label.set_size_request(90, -1)
-        self.track_checkbox = Gtk.CheckButton(_("Keep old branch's history"))
-        self.track_container = Gtk.HBox(False, 0)
+        self.track_checkbox = Gtk.CheckButton(label = _("Keep old branch's history"))
+        self.track_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.track_container.pack_start(label, False, False, 0)
         self.track_container.pack_start(self.track_checkbox, False, False, 0)
         vbox.pack_start(self.track_container, False, False, 0)
 
         # Set up the checkout line
-        label = Gtk.Label("")
+        label = Gtk.Label(label = "")
         label.set_size_request(90, -1)
-        self.checkout_checkbox = Gtk.CheckButton(_("Set as active branch"))
-        self.checkout_container = Gtk.HBox(False, 0)
+        self.checkout_checkbox = Gtk.CheckButton(label = _("Set as active branch"))
+        self.checkout_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.checkout_container.pack_start(label, False, False, 0)
         self.checkout_container.pack_start(self.checkout_checkbox, False, False, 0)
         vbox.pack_start(self.checkout_container, False, False, 0)
         
         # Set up Save button
-        label = Gtk.Label("")
+        label = Gtk.Label(label = "")
         label.set_size_request(90, -1)
         self.save_button = Gtk.Button(label=_("Save"))
         self.save_button.connect("clicked", self.on_save_clicked)
-        self.save_container = Gtk.HBox(False, 0)
+        self.save_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.save_container.pack_start(label, False, False, 0)
         self.save_container.pack_start(self.save_button, False, False, 0)
         vbox.pack_start(self.save_container, False, False, 0)
 
         # Set up the Revision line
-        label = Gtk.Label(_("Revision:"))
+        label = Gtk.Label(label = _("Revision:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=0)
-        self.revision_label = Gtk.Label("")
+        self.revision_label = Gtk.Label(label = "")
         self.revision_label.set_properties(xalign=0,selectable=True)
         self.revision_label.set_line_wrap(True)
-        self.revision_container = Gtk.HBox(False, 0)
+        self.revision_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.revision_container.pack_start(label, False, False, 0)
         self.revision_container.pack_start(self.revision_label, False, False, 0)
         vbox.pack_start(self.revision_container, False, False, 0)
 
         # Set up the Log Message line
-        label = Gtk.Label(_("Message:"))
+        label = Gtk.Label(label = _("Message:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=0)
-        self.message_label = Gtk.Label("")
+        self.message_label = Gtk.Label(label = "")
         self.message_label.set_properties(xalign=0,yalign=0,selectable=True)
         self.message_label.set_line_wrap(True)
         self.message_label.set_size_request(250, -1)
-        self.message_container = Gtk.HBox(False, 0)
+        self.message_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.message_container.pack_start(label, False, False, 0)
         self.message_container.pack_start(self.message_label, False, False, 0)
         vbox.pack_start(self.message_container, False, False, 0)

--- a/rabbitvcs/ui/browser.py
+++ b/rabbitvcs/ui/browser.py
@@ -36,8 +36,8 @@ from rabbitvcs.util.contextmenuitems import *
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
 import rabbitvcs.vcs
+from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.decorators import gtk_unsafe
 
@@ -46,7 +46,7 @@ log = Log("rabbitvcs.ui.browser")
 from rabbitvcs import gettext
 _ = gettext.gettext
 
-GObject.threads_init()
+helper.gobject_threads_init()
 
 class SVNBrowser(InterfaceView, GtkContextMenuCaller):
     def __init__(self, url):
@@ -64,10 +64,10 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
 
         self.urls = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("urls"), 
-            rabbitvcs.util.helper.get_repository_paths()
+            helper.get_repository_paths()
         )
         if self.url:
-            self.urls.set_child_text(rabbitvcs.util.helper.unquote_url(self.url))
+            self.urls.set_child_text(helper.unquote_url(self.url))
 
         # We must set a signal handler for the Gtk.Entry inside the combobox
         # Because glade will not retain that information
@@ -126,7 +126,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         self.repo_root_url = None
 
         if self.url:
-            rabbitvcs.util.helper.save_repository_path(url)
+            helper.save_repository_path(url)
             self.load()
 
     def load(self):
@@ -138,7 +138,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         revision = self.revision_selector.get_revision_object()
         self.action.append(
                         self.svn.list,
-                        rabbitvcs.util.helper.quote_url(self.url), 
+                        helper.quote_url(self.url), 
                         revision=revision, recurse=False)
         self.action.append(self.init_repo_root_url)
         self.action.append(self.populate_table, 0)
@@ -166,7 +166,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
             self.repo_root_url = action.run_single(self.svn.get_repo_root_url, self.url)
 
     def on_refresh_clicked(self, widget):
-        rabbitvcs.util.helper.save_repository_path(self.urls.get_active_text())
+        helper.save_repository_path(self.urls.get_active_text())
         self.load()
 
     def on_row_activated(self, treeview, data, col):
@@ -178,14 +178,14 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
             self.url = path
 
         if self.file_column_callback(self.url) == "dir" or self.url != path:
-            self.urls.set_child_text(rabbitvcs.util.helper.unquote_url(self.url))
+            self.urls.set_child_text(helper.unquote_url(self.url))
             self.load()
         else:
             self._open([self.url])
 
     def on_urls_key_released(self, widget, data, userdata):
         if Gdk.keyval_name(data.keyval) == "Return":
-            rabbitvcs.util.helper.save_repository_path(self.urls.get_active_text())
+            helper.save_repository_path(self.urls.get_active_text())
             self.load()
 
     def file_column_callback(self, filename):
@@ -232,7 +232,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         """
 
         if self.file_column_callback(row[0]) == "file":
-            return rabbitvcs.util.helper.pretty_filesize(int(row[column]))
+            return helper.pretty_filesize(int(row[column]))
 
         return ""
 
@@ -256,7 +256,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         
         if row[column]:
             change_time = datetime.fromtimestamp(float(row[column]))
-            return rabbitvcs.util.helper.format_datetime(change_time)
+            return helper.format_datetime(change_time)
         
         return str(row[column])
 
@@ -303,13 +303,13 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         
         exported_paths = []
         for path in paths:
-            export_path = rabbitvcs.util.helper.get_tmp_path(os.path.basename(paths[0]))
+            export_path = helper.get_tmp_path(os.path.basename(paths[0]))
             exported_paths.append(export_path)
             self.action.append(self.svn.export, paths[0], 
                 export_path, revision=self.revision_selector.get_revision_object())
 
         for path in exported_paths:
-            self.action.append(rabbitvcs.util.helper.open_item, path)
+            self.action.append(helper.open_item, path)
 
         self.action.run()
 
@@ -442,28 +442,28 @@ class BrowserContextMenuCallbacks:
         self.caller._open(self.paths)
     
     def show_log(self, data=None, user_data=None):
-        rabbitvcs.util.helper.launch_ui_window("log", ["--vcs=%s" % self.guess, self.paths[0]])
+        helper.launch_ui_window("log", ["--vcs=%s" % self.guess, self.paths[0]])
     
     def annotate(self, data=None, user_data=None):
         urlrev = self.paths[0]
         revision = self.__get_browser_revision()
         if revision.kind == "number":
             urlrev += "@" + revision.value
-        rabbitvcs.util.helper.launch_ui_window("annotate", [urlrev])
+        helper.launch_ui_window("annotate", [urlrev])
     
     def checkout(self, data=None, user_data=None):
         args = [self.paths[0]]
         revision = self.__get_browser_revision()
         if revision.kind == "number":
             args = ["-r", revision.value] + args
-        rabbitvcs.util.helper.launch_ui_window("checkout", args)
+        helper.launch_ui_window("checkout", args)
     
     def export(self, data=None, user_data=None):
         args = [self.paths[0]]
         revision = self.__get_browser_revision()
         if revision.kind == "number":
             args = ["-r", revision.value] + args
-        rabbitvcs.util.helper.launch_ui_window("export", args)
+        helper.launch_ui_window("export", args)
         
     def rename(self, data=None, user_data=None):
         (base, filename) = os.path.split(self.paths[0])

--- a/rabbitvcs/ui/browser.py
+++ b/rabbitvcs/ui/browser.py
@@ -184,7 +184,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
             self._open([self.url])
 
     def on_urls_key_released(self, widget, data, userdata):
-        if Gtk.gdk.keyval_name(data.keyval) == "Return":
+        if Gdk.keyval_name(data.keyval) == "Return":
             rabbitvcs.util.helper.save_repository_path(self.urls.get_active_text())
             self.load()
 

--- a/rabbitvcs/ui/changes.py
+++ b/rabbitvcs/ui/changes.py
@@ -28,13 +28,13 @@ from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 from rabbitvcs.util.contextmenu import GtkContextMenu
 from rabbitvcs.util.contextmenuitems import *
 import rabbitvcs.ui.action
 from rabbitvcs.ui.dialog import MessageBox
+
 from rabbitvcs import gettext
-import six
 _ = gettext.gettext
 
 class Changes(InterfaceView):
@@ -68,7 +68,7 @@ class Changes(InterfaceView):
         )
         self.more_actions.set_active(0)
 
-        repo_paths = rabbitvcs.util.helper.get_repository_paths()
+        repo_paths = helper.get_repository_paths()
         self.first_urls = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("first_urls"), 
             repo_paths
@@ -207,14 +207,14 @@ class Changes(InterfaceView):
                 url1 = ""
                 url2 = ""
 
-            url1 = rabbitvcs.util.helper.url_join(self.first_urls.get_active_text(), url1)
-            url2 = rabbitvcs.util.helper.url_join(self.second_urls.get_active_text(), url2)
+            url1 = helper.url_join(self.first_urls.get_active_text(), url1)
+            url2 = helper.url_join(self.second_urls.get_active_text(), url2)
             rev1 = self.get_first_revision()
             rev2 = self.get_second_revision()
             
-            rabbitvcs.util.helper.launch_ui_window("diff", [
-                "%s@%s" % (url1, six.text_type(rev1)),
-                "%s@%s" % (url2, six.text_type(rev2)),
+            helper.launch_ui_window("diff", [
+                "%s@%s" % (url1, helper.to_text(rev1)),
+                "%s@%s" % (url2, helper.to_text(rev2)),
                 "%s" % (sidebyside and "-s" or ""),
                 "--vcs=%s" % self.get_vcs_name()
             ])
@@ -230,9 +230,9 @@ class Changes(InterfaceView):
         rev2 = self.get_second_revision()        
         url2 = self.second_urls.get_active_text()
 
-        rabbitvcs.util.helper.launch_ui_window("diff", [
-            "%s@%s" % (url1, six.text_type(rev1)),
-            "%s@%s" % (url2, six.text_type(rev2)),
+        helper.launch_ui_window("diff", [
+            "%s@%s" % (url1, helper.to_text(rev1)),
+            "%s@%s" % (url2, helper.to_text(rev2)),
             "--vcs=%s" % self.get_vcs_name()
         ])
 
@@ -310,8 +310,8 @@ class SVNChanges(Changes):
             second_url,
             second_rev
         )
-        self.action.append(rabbitvcs.util.helper.save_repository_path, first_url)
-        self.action.append(rabbitvcs.util.helper.save_repository_path, second_url)
+        self.action.append(helper.save_repository_path, first_url)
+        self.action.append(helper.save_repository_path, second_url)
         self.action.append(self.populate_table)
         self.action.append(self.enable_more_actions)
         self.action.run()
@@ -404,8 +404,8 @@ class GitChanges(Changes):
             second_url,
             second_rev
         )
-        self.action.append(rabbitvcs.util.helper.save_repository_path, first_url)
-        self.action.append(rabbitvcs.util.helper.save_repository_path, second_url)
+        self.action.append(helper.save_repository_path, first_url)
+        self.action.append(helper.save_repository_path, second_url)
         self.action.append(self.populate_table)
         self.action.append(self.enable_more_actions)
         self.action.run()
@@ -481,13 +481,13 @@ class ChangesContextMenuCallbacks:
         if path == ".":
             path = ""
 
-        url = rabbitvcs.util.helper.url_join(self.caller.first_urls.get_active_text(), path)
+        url = helper.url_join(self.caller.first_urls.get_active_text(), path)
         rev = self.caller.get_first_revision()
 
-        rabbitvcs.util.helper.launch_ui_window("open", [
+        helper.launch_ui_window("open", [
             "--vcs=%s" % self.caller.get_vcs_name(),
             url,
-            "-r%s" % six.text_type(rev)            
+            "-r%s" % helper.to_text(rev)            
         ])
 
     def open_second(self, widget, data=None):
@@ -495,12 +495,12 @@ class ChangesContextMenuCallbacks:
         if path == ".":
             path = ""
 
-        url = rabbitvcs.util.helper.url_join(self.caller.second_urls.get_active_text(), path)
+        url = helper.url_join(self.caller.second_urls.get_active_text(), path)
         rev = self.caller.get_second_revision()
-        rabbitvcs.util.helper.launch_ui_window("open", [
+        helper.launch_ui_window("open", [
             "--vcs=%s" % self.caller.get_vcs_name(),
             url,
-            "-r%s" % six.text_type(rev)            
+            "-r%s" % helper.to_text(rev)            
         ])
 
     def view_diff(self, widget, data=None):
@@ -514,14 +514,14 @@ class ChangesContextMenuCallbacks:
                 url1 = ""
                 url2 = ""
 
-            url1 = rabbitvcs.util.helper.url_join(self.caller.first_urls.get_active_text(), url1)
-            url2 = rabbitvcs.util.helper.url_join(self.caller.second_urls.get_active_text(), url2)
+            url1 = helper.url_join(self.caller.first_urls.get_active_text(), url1)
+            url2 = helper.url_join(self.caller.second_urls.get_active_text(), url2)
             rev1 = self.caller.get_first_revision()
             rev2 = self.caller.get_second_revision()
             
-            rabbitvcs.util.helper.launch_ui_window("diff", [
-                "%s@%s" % (url1, six.text_type(rev1)), 
-                "%s@%s" % (url2, six.text_type(rev2)), 
+            helper.launch_ui_window("diff", [
+                "%s@%s" % (url1, helper.to_text(rev1)), 
+                "%s@%s" % (url2, helper.to_text(rev2)), 
                 "-s",
                 "--vcs=%s" % self.caller.get_vcs_name()
             ])
@@ -588,10 +588,10 @@ if __name__ == "__main__":
         usage="Usage: rabbitvcs changes [url1@rev1] [url2@rev2]"
     )
     
-    pathrev1 = rabbitvcs.util.helper.parse_path_revision_string(args.pop(0))
+    pathrev1 = helper.parse_path_revision_string(args.pop(0))
     pathrev2 = (None, None)
     if len(args) > 0:
-        pathrev2 = rabbitvcs.util.helper.parse_path_revision_string(args.pop(0))
+        pathrev2 = helper.parse_path_revision_string(args.pop(0))
 
     window = changes_factory(options.vcs, pathrev1[0], pathrev1[1], pathrev2[0], pathrev2[1])
     window.register_gtk_quit()

--- a/rabbitvcs/ui/changes.py
+++ b/rabbitvcs/ui/changes.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 
 import os.path
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -314,7 +314,7 @@ class SVNChanges(Changes):
         self.action.append(helper.save_repository_path, second_url)
         self.action.append(self.populate_table)
         self.action.append(self.enable_more_actions)
-        self.action.run()
+        self.action.schedule()
 
     def populate_table(self):
         # returns a list of dicts(path, summarize_kind, node_kind, prop_changed)
@@ -330,7 +330,7 @@ class SVNChanges(Changes):
                 
             self.changes_table.append([
                 path,
-                item["summarize_kind"],
+                str(item["summarize_kind"]),
                 prop_changed
             ])
 
@@ -408,7 +408,7 @@ class GitChanges(Changes):
         self.action.append(helper.save_repository_path, second_url)
         self.action.append(self.populate_table)
         self.action.append(self.enable_more_actions)
-        self.action.run()
+        self.action.schedule()
 
     def populate_table(self):
         # returns a list of dicts(path, summarize_kind, node_kind, prop_changed)
@@ -425,12 +425,12 @@ class GitChanges(Changes):
 class MenuOpenFirst(MenuItem):
     identifier = "RabbitVCS::Open_First"
     label = _("Open from first revision")
-    icon = Gtk.STOCK_OPEN
+    icon = "document-open"
 
 class MenuOpenSecond(MenuItem):
     identifier = "RabbitVCS::Open_Second"
     label = _("Open from second revision") 
-    icon = Gtk.STOCK_OPEN
+    icon = "document-open"
     
 class MenuViewDiff(MenuItem):
     identifier = "RabbitVCS::View_Diff"

--- a/rabbitvcs/ui/checkmods.py
+++ b/rabbitvcs/ui/checkmods.py
@@ -25,7 +25,7 @@ import six.moves._thread
 import threading
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -136,7 +136,7 @@ class SVNCheckLocalModifications(GtkContextMenuCaller):
         )
         self.action.append(self.svn.get_items, self.paths, self.svn.STATUSES_FOR_CHECK)
         self.action.append(self.populate_files_table)
-        self.action.run()
+        self.action.schedule()
 
     @gtk_unsafe
     def populate_files_table(self):
@@ -201,7 +201,7 @@ class SVNCheckRemoteModifications(GtkContextMenuCaller):
         )
         self.action.append(self.svn.get_remote_updates, self.paths)
         self.action.append(self.populate_files_table)
-        self.action.run()
+        self.action.schedule()
 
     @gtk_unsafe
     def populate_files_table(self):
@@ -242,7 +242,7 @@ class SVNCheckRemoteModifications(GtkContextMenuCaller):
             path_remote,
             "HEAD"
         )
-        self.action.run()
+        self.action.schedule()
 
     def on_context_menu_command_finished(self):
         self.refresh()
@@ -308,7 +308,7 @@ class CheckRemoteModsContextMenuCallbacks:
             "HEAD",
             sidebyside=True
         )
-        self.action.run()
+        self.action.schedule()
 
 class CheckRemoteModsContextMenu:
     def __init__(self, caller, event, base_dir, vcs, paths=[]):

--- a/rabbitvcs/ui/checkmods.py
+++ b/rabbitvcs/ui/checkmods.py
@@ -36,7 +36,7 @@ from rabbitvcs.util.contextmenuitems import MenuItem, MenuUpdate, \
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.decorators import gtk_unsafe
 
@@ -45,7 +45,7 @@ log = Log("rabbitvcs.ui.checkmods")
 from rabbitvcs import gettext
 _ = gettext.gettext
 
-GObject.threads_init()
+helper.gobject_threads_init()
 
 class SVNCheckForModifications(InterfaceView):
     """
@@ -146,11 +146,11 @@ class SVNCheckLocalModifications(GtkContextMenuCaller):
             self.files_table.append([
                 item.path, 
                 item.simple_content_status(),
-                rabbitvcs.util.helper.get_file_extension(item.path)
+                helper.get_file_extension(item.path)
             ])
 
     def diff_local(self, path):
-        rabbitvcs.util.helper.launch_diff_tool(path)
+        helper.launch_diff_tool(path)
 
     def on_context_menu_command_finished(self):
         self.refresh()
@@ -218,7 +218,7 @@ class SVNCheckRemoteModifications(GtkContextMenuCaller):
 
             self.files_table.append([
                 item.path, 
-                rabbitvcs.util.helper.get_file_extension(item.path),
+                helper.get_file_extension(item.path),
                 item.remote_content,
                 item.remote_metadata,
                 str(revision),
@@ -281,7 +281,7 @@ class CheckRemoteModsContextMenuCallbacks:
         self.paths = paths
 
     def update(self, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window(
+        proc = helper.launch_ui_window(
             "update", 
             self.paths
         )

--- a/rabbitvcs/ui/checkout.py
+++ b/rabbitvcs/ui/checkout.py
@@ -22,17 +22,16 @@ from __future__ import absolute_import
 #
 
 import os.path
-import urllib
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 import rabbitvcs.vcs
 from rabbitvcs.ui.updateto import GitUpdateToRevision
 from rabbitvcs import gettext
@@ -54,7 +53,7 @@ class Checkout(InterfaceView):
 
         self.repositories = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("repositories"), 
-            rabbitvcs.util.helper.get_repository_paths()
+            helper.get_repository_paths()
         )
         
         # We must set a signal handler for the Gtk.Entry inside the combobox
@@ -64,7 +63,7 @@ class Checkout(InterfaceView):
             self.on_repositories_key_released
         )
 
-        self.destination = rabbitvcs.util.helper.get_user_path()
+        self.destination = helper.get_user_path()
         if path is not None:
             self.destination = path
             self.get_widget("destination").set_text(path)
@@ -80,7 +79,7 @@ class Checkout(InterfaceView):
 
     def _parse_path(self, path):
         if path.startswith("file://"):
-            path = urllib.unquote(path)
+            path = helper.unquote(path)
             path = path[7:]
         return path
             
@@ -165,10 +164,10 @@ class SVNCheckout(Checkout):
         )
         self.action.append(self.action.set_header, _("Checkout"))
         self.action.append(self.action.set_status, _("Running Checkout Command..."))
-        self.action.append(rabbitvcs.util.helper.save_repository_path, url)
+        self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.svn.checkout,
-            rabbitvcs.util.helper.quote_url(url),
+            helper.quote_url(url),
             path,
             recurse=recursive,
             revision=revision,
@@ -176,7 +175,7 @@ class SVNCheckout(Checkout):
         )
         self.action.append(self.action.set_status, _("Completed Checkout"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_repositories_changed(self, widget, data=None):
         # Do not use quoting for this bit
@@ -216,7 +215,7 @@ class GitCheckoutQuiet:
         )
 
         self.action.append(self.git.checkout, [path])
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNCheckout,

--- a/rabbitvcs/ui/clean.py
+++ b/rabbitvcs/ui/clean.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk, Pango
 
 from datetime import datetime
@@ -76,7 +76,7 @@ class GitClean(InterfaceView):
         )
         self.action.append(self.action.set_status, _("Completed Clean"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_remove_ignored_too_toggled(self, widget):
         remove_ignored_too = self.get_widget("remove_ignored_too")

--- a/rabbitvcs/ui/cleanup.py
+++ b/rabbitvcs/ui/cleanup.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceNonView
@@ -58,7 +58,7 @@ class SVNCleanup(InterfaceNonView):
         self.action.append(self.svn.cleanup, self.path)
         self.action.append(self.action.set_status, _("Completed Cleanup"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
         
 if __name__ == "__main__":

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -22,10 +22,9 @@ from __future__ import absolute_import
 #
 
 import os.path
-import urllib
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -74,7 +73,7 @@ class GitClone(Checkout):
         )
         self.action.append(self.action.set_status, _("Completed Clone"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_repositories_changed(self, widget, data=None):
         url = self.repositories.get_active_text()
@@ -101,7 +100,7 @@ class GitClone(Checkout):
 
     def default_text(self):
         # Use a repo url from the clipboard by default.
-        clipboard = Gtk.clipboard_get()
+        clipboard = Gtk.Clipboard.get(Gdk.Atom.intern("CLIPBOARD", False))
         text = clipboard.wait_for_text()
         if text and text.endswith(('.git', '.git/')):
             self.repositories.set_child_text(text)

--- a/rabbitvcs/ui/commit.py
+++ b/rabbitvcs/ui/commit.py
@@ -26,7 +26,7 @@ import six.moves._thread
 
 from gi import require_version
 require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject, Gdk
+from gi.repository import Gtk, GObject, Gdk, GLib
 
 from time import sleep
 
@@ -36,7 +36,7 @@ import rabbitvcs.ui.action
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.decorators import gtk_unsafe
 import rabbitvcs.vcs.status
@@ -46,7 +46,7 @@ log = Log("rabbitvcs.ui.commit")
 from rabbitvcs import gettext
 _ = gettext.gettext
 
-GObject.threads_init()
+helper.gobject_threads_init()
 
 class Commit(InterfaceView, GtkContextMenuCaller):
     """
@@ -164,7 +164,7 @@ class Commit(InterfaceView, GtkContextMenuCaller):
         Initializes the activated cache and loads the file items in a new thread
         """
         
-        GObject.idle_add(self.load)
+        GLib.idle_add(self.load)
 
     def show_files_table_popup_menu(self, treeview, data):
         paths = self.files_table.get_selected_row_items(1)
@@ -173,7 +173,7 @@ class Commit(InterfaceView, GtkContextMenuCaller):
     def delete_items(self, widget, data=None):
         paths = self.files_table.get_selected_row_items(1)
         if len(paths) > 0:
-            proc = rabbitvcs.util.helper.launch_ui_window("delete", paths)
+            proc = helper.launch_ui_window("delete", paths)
             self.rescan_after_process_exit(proc, paths)
             
     #
@@ -214,9 +214,9 @@ class Commit(InterfaceView, GtkContextMenuCaller):
 
     def on_files_table_row_activated(self, treeview, event, col):
         paths = self.files_table.get_selected_row_items(1)
-        pathrev1 = rabbitvcs.util.helper.create_path_revision_string(paths[0], "base")
-        pathrev2 = rabbitvcs.util.helper.create_path_revision_string(paths[0], "working")
-        proc = rabbitvcs.util.helper.launch_ui_window("diff", ["-s", pathrev1, pathrev2])
+        pathrev1 = helper.create_path_revision_string(paths[0], "base")
+        pathrev2 = helper.create_path_revision_string(paths[0], "working")
+        proc = helper.launch_ui_window("diff", ["-s", pathrev1, pathrev2])
         self.rescan_after_process_exit(proc, paths)
 
     def on_files_table_key_event(self, treeview, data=None):
@@ -255,7 +255,7 @@ class Commit(InterfaceView, GtkContextMenuCaller):
             self.files_table.append([
                 checked,
                 item.path, 
-                rabbitvcs.util.helper.get_file_extension(item.path),
+                helper.get_file_extension(item.path),
                 item.simple_content_status(),
                 item.simple_metadata_status()
             ])
@@ -309,7 +309,7 @@ class SVNCommit(Commit):
         self.action.append(self.action.set_header, _("Commit"))
         self.action.append(self.action.set_status, _("Running Commit Command..."))
         self.action.append(
-            rabbitvcs.util.helper.save_log_message, 
+            helper.save_log_message, 
             self.message.get_text()
         ),
         self.action.append(self.do_commit, items, recurse)
@@ -377,7 +377,7 @@ class GitCommit(Commit):
         self.action.append(self.action.set_header, _("Commit"))
         self.action.append(self.action.set_status, _("Running Commit Command..."))
         self.action.append(
-            rabbitvcs.util.helper.save_log_message,
+            helper.save_log_message,
             self.message.get_text()
         )
         self.action.append(

--- a/rabbitvcs/ui/commit.py
+++ b/rabbitvcs/ui/commit.py
@@ -25,7 +25,7 @@ import os
 import six.moves._thread
 
 from gi import require_version
-require_version('Gtk', '3.0')
+require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk, GLib
 
 from time import sleep
@@ -314,7 +314,7 @@ class SVNCommit(Commit):
         ),
         self.action.append(self.do_commit, items, recurse)
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def do_commit(self, items, recurse):
         # pysvn.Revision
@@ -386,7 +386,7 @@ class GitCommit(Commit):
         )
         self.action.append(self.action.set_status, _("Completed Commit"))
         self.action.append(self.action.finish)
-        self.action.run() 
+        self.action.schedule() 
 
     def on_files_table_toggle_event(self, row, col):
         # Adds path: True/False to the dict

--- a/rabbitvcs/ui/commit.py
+++ b/rabbitvcs/ui/commit.py
@@ -220,7 +220,7 @@ class Commit(InterfaceView, GtkContextMenuCaller):
         self.rescan_after_process_exit(proc, paths)
 
     def on_files_table_key_event(self, treeview, data=None):
-        if Gtk.gdk.keyval_name(data.keyval) == "Delete":
+        if Gdk.keyval_name(data.keyval) == "Delete":
             self.delete_items(treeview, data)
 
     def on_files_table_mouse_event(self, treeview, data=None):

--- a/rabbitvcs/ui/create.py
+++ b/rabbitvcs/ui/create.py
@@ -25,7 +25,7 @@ import os
 import subprocess
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 import rabbitvcs.ui.dialog
@@ -70,7 +70,7 @@ class GitCreate:
         self.action.append(self.git.initialize_repository, self.path)
         self.action.append(self.action.set_status, _("Completed repository setup"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNCreate,

--- a/rabbitvcs/ui/createpatch.py
+++ b/rabbitvcs/ui/createpatch.py
@@ -36,8 +36,7 @@ from rabbitvcs.ui.action import SVNAction, GitAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util
-import rabbitvcs.util.helper
-from rabbitvcs.util.helper import get_common_directory
+from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from rabbitvcs.ui.commit import SVNCommit, GitCommit
 
@@ -46,7 +45,7 @@ log = Log("rabbitvcs.ui.createpatch")
 from rabbitvcs import gettext
 _ = gettext.gettext
 
-GObject.threads_init()
+helper.gobject_threads_init()
 
 class CreatePatch:
     """
@@ -76,7 +75,7 @@ class CreatePatch:
         self.vcs = rabbitvcs.vcs.VCS()
         self.activated_cache = {}
         
-        self.common = rabbitvcs.util.helper.get_common_directory(paths)
+        self.common = helper.get_common_directory(paths)
 
         if not self.vcs.is_versioned(self.common):
             rabbitvcs.ui.dialog.MessageBox(_("The given path is not a working copy"))
@@ -125,7 +124,7 @@ class CreatePatch:
         dialog.set_do_overwrite_confirmation(True)
         dialog.set_default_response(Gtk.ResponseType.OK)
         dialog.set_current_folder_uri(
-            get_common_directory(self.paths).replace("file://", "")
+            helper.get_common_directory(self.paths).replace("file://", "")
         )
         response = dialog.run()
         
@@ -178,7 +177,7 @@ class SVNCreatePatch(CreatePatch, SVNCommit):
            
             # Add to the Patch file only the selected items
             for item in patch_items:
-                rel_path = rabbitvcs.util.helper.get_relative_path(base_dir, item)
+                rel_path = helper.get_relative_path(base_dir, item)
                 diff_text = self.svn.diff(
                     temp_dir, 
                     rel_path, 
@@ -201,7 +200,7 @@ class SVNCreatePatch(CreatePatch, SVNCommit):
         self.action.run()
         
         # TODO: Open the diff file (meld is going to add support in a future version :()
-        # rabbitvcs.util.helper.launch_diff_tool(path)
+        # helper.launch_diff_tool(path)
 
 class GitCreatePatch(CreatePatch, GitCommit):
     def __init__(self, paths, base_dir=None):
@@ -245,7 +244,7 @@ class GitCreatePatch(CreatePatch, GitCommit):
            
             # Add to the Patch file only the selected items
             for item in patch_items:
-                rel_path = rabbitvcs.util.helper.get_relative_path(base_dir, item)
+                rel_path = helper.get_relative_path(base_dir, item)
                 diff_text = self.git.diff(
                     rel_path, 
                     self.git.revision("HEAD"), 

--- a/rabbitvcs/ui/createpatch.py
+++ b/rabbitvcs/ui/createpatch.py
@@ -25,7 +25,7 @@ import os
 import six.moves._thread
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 import os
 import tempfile
@@ -117,10 +117,11 @@ class CreatePatch:
         path = ""
         
         dialog = Gtk.FileChooserDialog(
-            _("Create Patch"),
-            None,
-            Gtk.FILE_CHOOSER_ACTION_SAVE,(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                          Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
+            title = _("Create Patch"),
+            parent = None,
+            action = Gtk.FileChooserAction.SAVE)
+        dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        dialog.add_button(_("_Create"), Gtk.ResponseType.OK)
         dialog.set_do_overwrite_confirmation(True)
         dialog.set_default_response(Gtk.ResponseType.OK)
         dialog.set_current_folder_uri(
@@ -197,7 +198,7 @@ class SVNCreatePatch(CreatePatch, SVNCommit):
         
         self.action.append(self.action.set_status, _("Patch File Created"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
         
         # TODO: Open the diff file (meld is going to add support in a future version :()
         # helper.launch_diff_tool(path)
@@ -263,7 +264,7 @@ class GitCreatePatch(CreatePatch, GitCommit):
         
         self.action.append(self.action.set_status, _("Patch File Created"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNCreatePatch,

--- a/rabbitvcs/ui/delete.py
+++ b/rabbitvcs/ui/delete.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os.path
 
 from gi import require_version
-require_version('Gtk', '3.0')
+require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject
 
 from rabbitvcs.ui import InterfaceNonView

--- a/rabbitvcs/ui/dialog.py
+++ b/rabbitvcs/ui/dialog.py
@@ -25,7 +25,7 @@ from gettext import gettext as _
 import os.path
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject, Pango
+from gi.repository import Gtk, GObject, Gdk, Pango
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
@@ -391,7 +391,7 @@ class OneLineTextChange(InterfaceView):
         # The Gtk.Dialog.response() method emits the "response" signal,
         # which tells Gtk.Dialog.run() asyncronously to stop.  This allows the
         # user to press the "Return" button when done writing in the new text
-        if Gtk.gdk.keyval_name(data.keyval) == "Return":
+        if Gdk.keyval_name(data.keyval) == "Return":
             self.dialog.response(Gtk.ResponseType.OK)
     
     def run(self):
@@ -463,7 +463,7 @@ class NameEmailPrompt(InterfaceView):
         # The Gtk.Dialog.response() method emits the "response" signal,
         # which tells Gtk.Dialog.run() asyncronously to stop.  This allows the
         # user to press the "Return" button when done writing in the new text
-        if Gtk.gdk.keyval_name(data.keyval) == "Return":
+        if Gdk.keyval_name(data.keyval) == "Return":
             self.dialog.response(Gtk.ResponseType.OK)
     
     def run(self):

--- a/rabbitvcs/ui/dialog.py
+++ b/rabbitvcs/ui/dialog.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 from gettext import gettext as _
 import os.path
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk, Pango
 
 from rabbitvcs.ui import InterfaceView
@@ -102,11 +102,12 @@ class PreviousMessages(InterfaceView):
         
 class FolderChooser:
     def __init__(self):
-        self.dialog = Gtk.FileChooserDialog(_("Select a Folder"), 
-            None, 
-            Gtk.FileChooserAction.SELECT_FOLDER, 
-            (Gtk.STOCK_CANCEL,Gtk.ResponseType.CANCEL,
-                Gtk.STOCK_OPEN,Gtk.ResponseType.OK))
+        self.dialog = Gtk.FileChooserDialog(
+            title = _("Select a Folder"), 
+            parent = None, 
+            action = Gtk.FileChooserAction.SELECT_FOLDER)
+        self.dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        self.dialog.add_button(_("_Select"), Gtk.ResponseType.OK)
         self.dialog.set_default_response(Gtk.ResponseType.OK)
 
     def run(self):
@@ -273,11 +274,12 @@ class Property(InterfaceView):
 
 class FileChooser:
     def __init__(self, title=_("Select a File"), folder=None):
-        self.dialog = Gtk.FileChooserDialog(title, 
-            None, 
-            Gtk.FILE_CHOOSER_ACTION_OPEN, 
-            (Gtk.STOCK_CANCEL,Gtk.ResponseType.CANCEL,
-                Gtk.STOCK_OPEN,Gtk.ResponseType.OK))
+        self.dialog = Gtk.FileChooserDialog(
+            title = title, 
+            parent = None, 
+            action = Gtk.FileChooserAction.OPEN)
+        self.dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        self.dialog.add_button(_("_Open"),   Gtk.ResponseType.OK)
         if folder is not None:
             self.dialog.set_current_folder(folder)
         self.dialog.set_default_response(Gtk.ResponseType.OK)
@@ -292,11 +294,12 @@ class FileChooser:
 
 class FileSaveAs:
     def __init__(self, title=_("Save As..."), folder=None):
-        self.dialog = Gtk.FileChooserDialog(title, 
-            None, 
-            Gtk.FileChooserAction.SAVE, 
-            (Gtk.STOCK_CANCEL,Gtk.ResponseType.CANCEL,
-                Gtk.STOCK_SAVE,Gtk.ResponseType.OK))
+        self.dialog = Gtk.FileChooserDialog(
+            title = title, 
+            parent = None, 
+            action = Gtk.FileChooserAction.SAVE)
+        self.dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        self.dialog.add_button(_("_Save"),   Gtk.ResponseType.OK)
         if folder is not None:
             self.dialog.set_current_folder(folder)
         self.dialog.set_default_response(Gtk.ResponseType.OK)

--- a/rabbitvcs/ui/diff.py
+++ b/rabbitvcs/ui/diff.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject, Gdk, GLib
+from gi.repository import Gtk, Gdk, GLib
 import os
 from shutil import rmtree
 import tempfile
@@ -102,7 +102,7 @@ class SVNDiff(Diff):
         self.revision1 = self.get_revision_object(revision1, "base")
         self.revision2 = self.get_revision_object(revision2, "working")
 
-        GObject.idle_add(self.launch)
+        GLib.idle_add(self.launch)
         self.start_loading()
 
     def get_revision_object(self, value, default):
@@ -199,7 +199,7 @@ class GitDiff(Diff):
         self.revision1 = self.get_revision_object(revision1, "HEAD")
         self.revision2 = self.get_revision_object(revision2, "WORKING")
 
-        GObject.idle_add(self.launch)        
+        GLib.idle_add(self.launch)        
         self.start_loading()
 
     def get_revision_object(self, value, default):

--- a/rabbitvcs/ui/diff.py
+++ b/rabbitvcs/ui/diff.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GLib
 import os
 from shutil import rmtree

--- a/rabbitvcs/ui/editconflicts.py
+++ b/rabbitvcs/ui/editconflicts.py
@@ -27,7 +27,7 @@ import six.moves._thread
 import shutil
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceNonView

--- a/rabbitvcs/ui/export.py
+++ b/rabbitvcs/ui/export.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os.path
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -104,7 +104,7 @@ class SVNExport(SVNCheckout):
         )
         self.action.append(self.action.set_status, _("Completed Export"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 class GitExport(GitClone):
     def __init__(self, path=None, revision=None):
@@ -170,7 +170,7 @@ class GitExport(GitClone):
         )
         self.action.append(self.action.set_status, _("Completed Export"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_repositories_changed(self, widget, data=None):
         # Do not use quoting for this bit

--- a/rabbitvcs/ui/ignore.py
+++ b/rabbitvcs/ui/ignore.py
@@ -25,7 +25,7 @@ from os import getcwd
 import os.path
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceNonView, InterfaceView

--- a/rabbitvcs/ui/import.py
+++ b/rabbitvcs/ui/import.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -83,7 +83,7 @@ class SVNImport(InterfaceView):
         )
         self.action.append(self.action.set_status, _("Completed Import"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_previous_messages_clicked(self, widget, data=None):
         dialog = rabbitvcs.ui.dialog.PreviousMessages()

--- a/rabbitvcs/ui/lock.py
+++ b/rabbitvcs/ui/lock.py
@@ -34,7 +34,7 @@ from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.vcs
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.lock")
@@ -42,7 +42,7 @@ log = Log("rabbitvcs.ui.lock")
 from rabbitvcs import gettext
 _ = gettext.gettext
 
-GObject.threads_init()
+helper.gobject_threads_init()
 
 class SVNLock(InterfaceView, GtkContextMenuCaller):
     """
@@ -125,7 +125,7 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
             self.files_table.append([
                 True, 
                 item.path, 
-                rabbitvcs.util.helper.get_file_extension(item.path),
+                helper.get_file_extension(item.path),
                 locked
             ])
 
@@ -155,7 +155,7 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
         
         self.action.append(self.action.set_header, _("Get Lock"))
         self.action.append(self.action.set_status, _("Running Lock Command..."))
-        self.action.append(rabbitvcs.util.helper.save_log_message, message)
+        self.action.append(helper.save_log_message, message)
         for path in items:
             self.action.append(
                 self.svn.lock, 

--- a/rabbitvcs/ui/lock.py
+++ b/rabbitvcs/ui/lock.py
@@ -25,7 +25,7 @@ import six.moves._thread
 
 import os
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -165,7 +165,7 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
             )
         self.action.append(self.action.set_status, _("Completed Lock"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_files_table_mouse_event(self, treeview, data=None):
         if data is not None and data.button == 3:

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -1532,6 +1532,7 @@ class LogBottomContextMenuCallbacks:
 
     def show_changes_previous_revision(self, widget, data=None):
         rev_first = six.text_type(self.revisions[0]["revision"])
+        rev_last = six.text_type(self.revisions[-1]["revision"])
         
         parent = self.find_parent(self.revisions[0])
 

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -31,8 +31,6 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GObject
 
-import cgi
-
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import SVNAction, GitAction, vcs_action_factory
 from rabbitvcs.ui.dialog import MessageBox
@@ -456,7 +454,7 @@ class SVNLog(Log):
         self.display_items = []
 
         for item in self.revision_items:
-            msg = cgi.escape(item.message).lower()
+            msg = rabbitvcs.util.helper.html_escape(item.message).lower()
 
             should_add = not self.filter_text
             should_add = should_add or msg.find(self.filter_text) > -1
@@ -474,7 +472,7 @@ class SVNLog(Log):
         self.check_next_sensitive()
 
         for item in self.display_items:
-            msg = cgi.escape(rabbitvcs.util.helper.format_long_text(item.message, 80))
+            msg = rabbitvcs.util.helper.html_escape(rabbitvcs.util.helper.format_long_text(item.message, 80))
             rev = item.revision
             color = "#000000"
             if (self.merge_candidate_revisions != None and
@@ -736,7 +734,7 @@ class GitLog(Log):
         self.display_items = []
 
         for item in self.revision_items:
-            msg = cgi.escape(item.message).lower()
+            msg = rabbitvcs.util.helper.html_escape(item.message).lower()
 
             should_add = not self.filter_text
             should_add = should_add or msg.find(self.filter_text) > -1
@@ -765,7 +763,7 @@ class GitLog(Log):
         index = 0
         for (item, node, in_lines, out_lines) in grapher:
             revision = six.text_type(item.revision)
-            msg = cgi.escape(rabbitvcs.util.helper.format_long_text(item.message, 80))
+            msg = rabbitvcs.util.helper.html_escape(rabbitvcs.util.helper.format_long_text(item.message, 80))
             author = item.author
             date = rabbitvcs.util.helper.format_datetime(item.date)
             

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -29,7 +29,7 @@ import os.path
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject
+from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import SVNAction, GitAction, vcs_action_factory
@@ -163,8 +163,8 @@ class Log(InterfaceView):
     
     def on_key_pressed(self, widget, data):
         InterfaceView.on_key_pressed(self, widget, data)
-        if (data.state & Gtk.gdk.CONTROL_MASK and
-            Gtk.gdk.keyval_name(data.keyval).lower() == "c"):
+        if (data.state & Gdk.CONTROL_MASK and
+            Gdk.keyval_name(data.keyval).lower() == "c"):
             if len(self.revisions_table.get_selected_rows()) > 0:
                 self.copy_revision_text()
 

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -163,7 +163,7 @@ class Log(InterfaceView):
     
     def on_key_pressed(self, widget, data):
         InterfaceView.on_key_pressed(self, widget, data)
-        if (data.state & Gdk.CONTROL_MASK and
+        if (data.state & Gdk.ModifierType.CONTROL_MASK and
             Gdk.keyval_name(data.keyval).lower() == "c"):
             if len(self.revisions_table.get_selected_rows()) > 0:
                 self.copy_revision_text()

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -37,15 +37,15 @@ from rabbitvcs.ui.dialog import MessageBox
 from rabbitvcs.util.contextmenu import GtkContextMenu
 from rabbitvcs.util.contextmenuitems import *
 import rabbitvcs.ui.widget
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
-import six
-from six.moves import range
 _ = gettext.gettext
 
-DATETIME_FORMAT = rabbitvcs.util.helper.LOCAL_DATETIME_FORMAT
+from six.moves import range
+
+DATETIME_FORMAT = helper.LOCAL_DATETIME_FORMAT
 
 REVISION_LABEL = _("Revision")
 DATE_LABEL = _("Date")
@@ -66,10 +66,10 @@ def revision_grapher(history):
     last_lines = []
     color = "#d3b9d3"
     for item in history:
-        commit = six.text_type(item.revision)
+        commit = helper.to_text(item.revision)
         parents = []
         for parent in item.parents:
-            parents.append(six.text_type(parent))
+            parents.append(helper.to_text(parent))
 
         if commit not in revisions:
             revisions.append(commit)
@@ -200,7 +200,7 @@ class Log(InterfaceView):
     def on_revisions_table_row_activated(self, treeview, event, col):
         paths = self.revisions_table.get_displayed_row_items(1)
 
-        rabbitvcs.util.helper.launch_diff_tool(*paths)
+        helper.launch_diff_tool(*paths)
 
     def on_revisions_table_mouse_event(self, treeview, data=None):
         if len(self.revisions_table.get_selected_rows()) == 0:
@@ -223,11 +223,11 @@ class Log(InterfaceView):
 
     def on_paths_table_row_activated(self, treeview, data=None, col=None):
         try:
-            revision1 = six.text_type(self.display_items[self.revisions_table.get_selected_rows()[0]].revision)
-            revision2 = six.text_type(self.display_items[self.revisions_table.get_selected_rows()[0]+1].revision)
+            revision1 = helper.to_text(self.display_items[self.revisions_table.get_selected_rows()[0]].revision)
+            revision2 = helper.to_text(self.display_items[self.revisions_table.get_selected_rows()[0]+1].revision)
             path_item = self.paths_table.get_row(self.paths_table.get_selected_rows()[0])[1]
             url = self.root_url + path_item
-            self.view_diff_for_path(url, six.text_type(revision1), six.text_type(revision2), sidebyside=True)
+            self.view_diff_for_path(url, helper.to_text(revision1), helper.to_text(revision2), sidebyside=True)
         except IndexError:
             pass
 
@@ -286,7 +286,7 @@ class Log(InterfaceView):
             revisions.append(int(self.revisions_table.get_row(row)[self.revision_number_column]))
 
         revisions.sort()
-        return rabbitvcs.util.helper.encode_revisions(revisions)
+        helper.encode_revisions(revisions)
 
     def get_selected_revision_number(self):
         if len(self.revisions_table.get_selected_rows()):
@@ -346,7 +346,7 @@ class Log(InterfaceView):
         if sidebyside:
             options += ["-s"] 
 
-        rabbitvcs.util.helper.launch_ui_window("diff", options)
+        helper.launch_ui_window("diff", options)
 
     def get_vcs_name(self):
         vcs = rabbitvcs.vcs.VCS_DUMMY
@@ -438,8 +438,8 @@ class SVNLog(Log):
             return
         
         # Get the starting/ending point from the actual returned revisions
-        self.rev_start = int(six.text_type(self.revision_items[0].revision))
-        self.rev_end = int(six.text_type(self.revision_items[-1].revision))
+        self.rev_start = int(helper.to_text(self.revision_items[0].revision))
+        self.rev_end = int(helper.to_text(self.revision_items[-1].revision))
 
         if not self.rev_first:
             self.rev_first = self.rev_start
@@ -454,7 +454,7 @@ class SVNLog(Log):
         self.display_items = []
 
         for item in self.revision_items:
-            msg = rabbitvcs.util.helper.html_escape(item.message).lower()
+            msg = helper.html_escape(item.message).lower()
 
             should_add = not self.filter_text
             should_add = should_add or msg.find(self.filter_text) > -1
@@ -472,7 +472,7 @@ class SVNLog(Log):
         self.check_next_sensitive()
 
         for item in self.display_items:
-            msg = rabbitvcs.util.helper.html_escape(rabbitvcs.util.helper.format_long_text(item.message, 80))
+            msg = helper.html_escape(helper.format_long_text(item.message, 80))
             rev = item.revision
             color = "#000000"
             if (self.merge_candidate_revisions != None and
@@ -493,9 +493,9 @@ class SVNLog(Log):
 
     def populate_table(self, revision, author, date, msg, color):
         self.revisions_table.append([
-            six.text_type(revision),
+            helper.to_text(revision),
             author,
-            rabbitvcs.util.helper.format_datetime(date),
+            helper.format_datetime(date),
             msg,
             color
         ])
@@ -561,9 +561,9 @@ class SVNLog(Log):
         for selected_row in self.revisions_table.get_selected_rows():
             item = self.display_items[selected_row]
             
-            text += "%s: %s\n" % (REVISION_LABEL, six.text_type(item.revision))
-            text += "%s: %s\n" % (AUTHOR_LABEL, six.text_type(item.author))
-            text += "%s: %s\n" % (DATE_LABEL, six.text_type(item.date))
+            text += "%s: %s\n" % (REVISION_LABEL, helper.to_text(item.revision))
+            text += "%s: %s\n" % (AUTHOR_LABEL, helper.to_text(item.author))
+            text += "%s: %s\n" % (DATE_LABEL, helper.to_text(item.date))
             text += "%s\n\n"   % item.message
             if item.changed_paths is not None:
                 for subitem in item.changed_paths:
@@ -591,7 +591,7 @@ class SVNLog(Log):
                 indented_message = item.message.replace("\n","\n\t")
                 self.message.append_text(
 					"%s %s:\n\t%s\n" % (REVISION_LABEL,
-                                        six.text_type(item.revision),
+                                        helper.to_text(item.revision),
                                         indented_message))
             if item.changed_paths is not None:
                 for subitem in item.changed_paths:
@@ -602,7 +602,7 @@ class SVNLog(Log):
                             subitem.action,
                             subitem.path,
                             subitem.copy_from_path,
-                            six.text_type(subitem.copy_from_revision)
+                            helper.to_text(subitem.copy_from_revision)
                         ])
 
         subitems.sort(key = lambda x: x[1])
@@ -611,7 +611,7 @@ class SVNLog(Log):
                 subitem[0],
                 subitem[1],
                 subitem[2],
-                six.text_type(subitem[3])
+                helper.to_text(subitem[3])
             ])
 
     def on_previous_clicked(self, widget):
@@ -734,12 +734,12 @@ class GitLog(Log):
         self.display_items = []
 
         for item in self.revision_items:
-            msg = rabbitvcs.util.helper.html_escape(item.message).lower()
+            msg = helper.html_escape(item.message).lower()
 
             should_add = not self.filter_text
             should_add = should_add or msg.find(self.filter_text) > -1
             should_add = should_add or item.author.lower().find(self.filter_text) > -1
-            should_add = should_add or six.text_type(item.revision).lower().find(self.filter_text) > -1
+            should_add = should_add or helper.to_text(item.revision).lower().find(self.filter_text) > -1
             should_add = should_add or str(item.date).lower().find(self.filter_text) > -1
 
             if should_add:
@@ -762,10 +762,10 @@ class GitLog(Log):
 
         index = 0
         for (item, node, in_lines, out_lines) in grapher:
-            revision = six.text_type(item.revision)
-            msg = rabbitvcs.util.helper.html_escape(rabbitvcs.util.helper.format_long_text(item.message, 80))
+            revision = helper.to_text(item.revision)
+            msg = helper.html_escape(helper.format_long_text(item.message, 80))
             author = item.author
-            date = rabbitvcs.util.helper.format_datetime(item.date)
+            date = helper.format_datetime(item.date)
             
             if item.head:
                 self.head_row = index
@@ -849,9 +849,9 @@ class GitLog(Log):
         for selected_row in self.revisions_table.get_selected_rows():
             item = self.display_items[selected_row]
 
-            text += "%s: %s\n" % (REVISION_LABEL, six.text_type(item.revision.short()))
-            text += "%s: %s\n" % (AUTHOR_LABEL, six.text_type(item.author))
-            text += "%s: %s\n" % (DATE_LABEL, six.text_type(item.date))
+            text += "%s: %s\n" % (REVISION_LABEL, helper.to_text(item.revision.short()))
+            text += "%s: %s\n" % (AUTHOR_LABEL, helper.to_text(item.author))
+            text += "%s: %s\n" % (DATE_LABEL, helper.to_text(item.date))
             text += "%s\n\n" % item.message
             
         self.revision_clipboard.set_text(text)
@@ -1147,17 +1147,17 @@ class LogTopContextMenuCallbacks:
 
     def find_parent(self, revision):
         if ("parents" in revision) and len(revision["parents"]) > 0:
-            parent = six.text_type(revision["parents"][0])
+            parent = helper.to_text(revision["parents"][0])
         elif ("next_revision" in revision):
-            parent = six.text_type(revision["next_revision"])
+            parent = helper.to_text(revision["next_revision"])
         else:
-            parent = six.text_type(int(six.text_type(revision["revision"])) - 1)
+            parent = helper.to_text(int(helper.to_text(revision["revision"])) - 1)
 
         return parent
         
     def view_diff_working_copy(self, widget, data=None):
-        rabbitvcs.util.helper.launch_ui_window("diff", [
-            "%s@%s" % (self.path, six.text_type(self.revisions[0]["revision"])),
+        helper.launch_ui_window("diff", [
+            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1167,9 +1167,9 @@ class LogTopContextMenuCallbacks:
     def view_diff_previous_revision(self, widget, data=None):
         parent = self.find_parent(self.revisions[0])
 
-        rabbitvcs.util.helper.launch_ui_window("diff", [
+        helper.launch_ui_window("diff", [
             "%s@%s" % (self.path, parent),
-            "%s@%s" % (self.path, six.text_type(self.revisions[0]["revision"])),
+            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1178,9 +1178,9 @@ class LogTopContextMenuCallbacks:
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path_older = self.vcs.svn().get_repo_url(self.path)
     
-        rabbitvcs.util.helper.launch_ui_window("diff", [
+        helper.launch_ui_window("diff", [
             "%s@%s" % (path_older, self.revisions[1]["revision"].value),
-            "%s@%s" % (self.path, six.text_type(self.revisions[0]["revision"])),
+            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1189,9 +1189,9 @@ class LogTopContextMenuCallbacks:
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path_older = self.vcs.svn().get_repo_url(self.path)
     
-        rabbitvcs.util.helper.launch_ui_window("diff", [
+        helper.launch_ui_window("diff", [
             "-s",
-            "%s@%s" % (path_older, six.text_type(self.revisions[0]["revision"])),
+            "%s@%s" % (path_older, helper.to_text(self.revisions[0]["revision"])),
             "%s" % (self.path),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
@@ -1199,10 +1199,10 @@ class LogTopContextMenuCallbacks:
     def compare_previous_revision(self, widget, data=None):
         parent = self.find_parent(self.revisions[0])
 
-        rabbitvcs.util.helper.launch_ui_window("diff", [
+        helper.launch_ui_window("diff", [
             "-s",
             "%s@%s" % (self.path, parent),
-            "%s@%s" % (self.path, six.text_type(self.revisions[0]["revision"])),
+            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1211,52 +1211,52 @@ class LogTopContextMenuCallbacks:
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path_older = self.vcs.svn().get_repo_url(self.path)
 
-        rabbitvcs.util.helper.launch_ui_window("diff", [
+        helper.launch_ui_window("diff", [
             "-s",
             "%s@%s" % (path_older, self.revisions[1]["revision"].value),
-            "%s@%s" % (self.path, six.text_type(self.revisions[0]["revision"])),
+            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def show_changes_previous_revision(self, widget, data=None):
-        rev_first = six.text_type(self.revisions[0]["revision"])
+        rev_first = helper.to_text(self.revisions[0]["revision"])
         parent = self.find_parent(self.revisions[0])
         
         path = self.path
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path = self.vcs.svn().get_repo_url(self.path)
 
-        rabbitvcs.util.helper.launch_ui_window("changes", [
+        helper.launch_ui_window("changes", [
             "%s@%s" % (path, parent),
-            "%s@%s" % (path, six.text_type(rev_first)),
+            "%s@%s" % (path, helper.to_text(rev_first)),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def show_changes_revisions(self, widget, data=None):
-        rev_first = six.text_type(self.revisions[0]["revision"])
-        rev_last = six.text_type(self.revisions[0]["next_revision"])
+        rev_first = helper.to_text(self.revisions[0]["revision"])
+        rev_last = helper.to_text(self.revisions[0]["next_revision"])
 
         path = self.path
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path = self.vcs.svn().get_repo_url(self.path)
 
-        rabbitvcs.util.helper.launch_ui_window("changes", [
-            "%s@%s" % (path, six.text_type(rev_first)),
-            "%s@%s" % (path, six.text_type(rev_last)),
+        helper.launch_ui_window("changes", [
+            "%s@%s" % (path, helper.to_text(rev_first)),
+            "%s@%s" % (path, helper.to_text(rev_last)),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def update_to_this_revision(self, widget, data=None):        
-        rabbitvcs.util.helper.launch_ui_window("updateto", [
+        helper.launch_ui_window("updateto", [
             self.path,
-            "-r", six.text_type(self.revisions[0]["revision"]),
+            "-r", helper.to_text(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def revert_changes_from_this_revision(self, widget, data=None):        
-        rabbitvcs.util.helper.launch_ui_window("merge", [
+        helper.launch_ui_window("merge", [
             self.path,
-            six.text_type(self.revisions[0]["revision"]) + "-" + str(int(six.text_type(self.revisions[0]["revision"])) - 1),
+            helper.to_text(self.revisions[0]["revision"]) + "-" + str(int(helper.to_text(self.revisions[0]["revision"])) - 1),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])        
         
@@ -1265,59 +1265,59 @@ class LogTopContextMenuCallbacks:
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             url = self.vcs.svn().get_repo_url(self.path)
 
-        rabbitvcs.util.helper.launch_ui_window("checkout", [
+        helper.launch_ui_window("checkout", [
             self.path, 
             url, 
-            "-r", six.text_type(self.revisions[0]["revision"]),
+            "-r", helper.to_text(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def branch_tag(self, widget, data=None):
-        rabbitvcs.util.helper.launch_ui_window("branch", [
+        helper.launch_ui_window("branch", [
             self.path, 
-            "-r", six.text_type(self.revisions[0]["revision"]),
+            "-r", helper.to_text(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def branches(self, widget, data=None):
-        rabbitvcs.util.helper.launch_ui_window("branches", [
+        helper.launch_ui_window("branches", [
             self.path, 
-            "-r", six.text_type(self.revisions[0]["revision"]),
+            "-r", helper.to_text(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def tags(self, widget, data=None):
-        rabbitvcs.util.helper.launch_ui_window("tags", [
+        helper.launch_ui_window("tags", [
             self.path, 
-            "-r", six.text_type(self.revisions[0]["revision"]),
+            "-r", helper.to_text(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
         
     def export(self, widget, data=None):
-        rabbitvcs.util.helper.launch_ui_window("export", [
+        helper.launch_ui_window("export", [
             self.path, 
-            "-r", six.text_type(self.revisions[0]["revision"]),
+            "-r", helper.to_text(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def merge(self, widget, data=None):
         extra = []
         if self.vcs_name == rabbitvcs.vcs.VCS_GIT:
-            extra.append(six.text_type(self.revisions[0]["revision"]))
+            extra.append(helper.to_text(self.revisions[0]["revision"]))
             try:
-                fromrev = six.text_type(self.revisions[1]["revision"])
+                fromrev = helper.to_text(self.revisions[1]["revision"])
                 extra.append(fromrev)
             except IndexError as e:
                 pass
         
         extra += ["--vcs=%s" % self.caller.get_vcs_name()]
         
-        rabbitvcs.util.helper.launch_ui_window("merge", [self.path] + extra)
+        helper.launch_ui_window("merge", [self.path] + extra)
 
     def reset(self, widget, data=None):
-        rabbitvcs.util.helper.launch_ui_window("reset", [
+        helper.launch_ui_window("reset", [
             self.path, 
-            "-r", six.text_type(self.revisions[0]["revision"]),
+            "-r", helper.to_text(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1348,8 +1348,8 @@ class LogTopContextMenuCallbacks:
     def edit_revision_properties(self, widget, data=None):
         url = self.vcs.svn().get_repo_url(self.path)
         
-        rabbitvcs.util.helper.launch_ui_window("revprops", [
-            "%s@%s" % (url, six.text_type(self.revisions[0]["revision"])),
+        helper.launch_ui_window("revprops", [
+            "%s@%s" % (url, helper.to_text(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1486,16 +1486,16 @@ class LogBottomContextMenuCallbacks:
 
     def find_parent(self, revision):
         if ("parents" in revision) and len(revision["parents"]) > 0:
-            parent = six.text_type(revision["parents"][0])
+            parent = helper.to_text(revision["parents"][0])
         elif ("next_revision" in revision):
-            parent = six.text_type(revision["next_revision"])
+            parent = helper.to_text(revision["next_revision"])
         else:
-            parent = six.text_type(int(six.text_type(revision["revision"])) - 1)
+            parent = helper.to_text(int(helper.to_text(revision["revision"])) - 1)
 
         return parent
 
     def view_diff_previous_revision(self, widget, data=None):
-        rev = six.text_type(self.revisions[0]["revision"])
+        rev = helper.to_text(self.revisions[0]["revision"])
 
         parent = self.find_parent(self.revisions[0])
 
@@ -1504,15 +1504,15 @@ class LogBottomContextMenuCallbacks:
         self.caller.view_diff_for_path(url, rev, parent)
 
     def view_diff_revisions(self, widget, data=None):
-        rev_first = six.text_type(self.revisions[0]["revision"])
-        rev_last = six.text_type(self.revisions[-1]["revision"])
+        rev_first = helper.to_text(self.revisions[0]["revision"])
+        rev_last = helper.to_text(self.revisions[-1]["revision"])
         path_item = self.paths[0]
         url = self.caller.root_url + path_item
         self.caller.view_diff_for_path(url, latest_revision_number=rev_last,
                                        earliest_revision_number=rev_first)
 
     def compare_previous_revision(self, widget, data=None):
-        rev = six.text_type(self.revisions[0]["revision"])
+        rev = helper.to_text(self.revisions[0]["revision"])
         
         parent = self.find_parent(self.revisions[0])
             
@@ -1521,8 +1521,8 @@ class LogBottomContextMenuCallbacks:
         self.caller.view_diff_for_path(url, rev, parent, sidebyside=True)
     
     def compare_revisions(self, widget, data=None):
-        earliest_rev = six.text_type(self.revisions[0]["revision"])
-        latest_rev = six.text_type(self.revisions[-1]["revision"])
+        earliest_rev = helper.to_text(self.revisions[0]["revision"])
+        latest_rev = helper.to_text(self.revisions[-1]["revision"])
         path_item = self.paths[0]
         url = self.caller.root_url + path_item
         self.caller.view_diff_for_path(url,
@@ -1531,8 +1531,8 @@ class LogBottomContextMenuCallbacks:
                                         earliest_revision_number=earliest_rev)
 
     def show_changes_previous_revision(self, widget, data=None):
-        rev_first = six.text_type(self.revisions[0]["revision"])
-        rev_last = six.text_type(self.revisions[-1]["revision"])
+        rev_first = helper.to_text(self.revisions[0]["revision"])
+        rev_last = helper.to_text(self.revisions[-1]["revision"])
         
         parent = self.find_parent(self.revisions[0])
 
@@ -1540,21 +1540,21 @@ class LogBottomContextMenuCallbacks:
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             url = self.caller.root_url + self.paths[0]
 
-        rabbitvcs.util.helper.launch_ui_window("changes", [
+        helper.launch_ui_window("changes", [
             "%s@%s" % (url, parent),
             "%s@%s" % (url, rev_last),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
     
     def show_changes_revisions(self, widget, data=None):
-        rev_first = six.text_type(self.revisions[0]["revision"])
-        rev_last = six.text_type(self.revisions[-1]["revision"])
+        rev_first = helper.to_text(self.revisions[0]["revision"])
+        rev_last = helper.to_text(self.revisions[-1]["revision"])
 
         url = self.paths[0]
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             url = self.caller.root_url + self.paths[0]
         
-        rabbitvcs.util.helper.launch_ui_window("changes", [
+        helper.launch_ui_window("changes", [
             "%s@%s" % (url, rev_first),
             "%s@%s" % (url, rev_last),
             "--vcs=%s" % self.caller.get_vcs_name()
@@ -1564,10 +1564,10 @@ class LogBottomContextMenuCallbacks:
     def _open(self, widget, data=None):
         for path in self.paths:
             path = self.caller.root_url + path
-            rabbitvcs.util.helper.launch_ui_window("open", [
+            helper.launch_ui_window("open", [
                 path, 
                 "--vcs=%s" % self.vcs_name, 
-                "-r", six.text_type(self.revisions[0]["revision"])
+                "-r", helper.to_text(self.revisions[0]["revision"])
             ])
 
     def annotate(self, widget, data=None):
@@ -1575,10 +1575,10 @@ class LogBottomContextMenuCallbacks:
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             url = self.caller.root_url + self.paths[0]
 
-        rabbitvcs.util.helper.launch_ui_window("annotate", [
+        helper.launch_ui_window("annotate", [
             url, 
             "--vcs=%s" % self.vcs_name, 
-            "-r", six.text_type(self.revisions[0]["revision"])
+            "-r", helper.to_text(self.revisions[0]["revision"])
         ])
 
 class LogBottomContextMenu:

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -1575,10 +1575,7 @@ class LogBottomContextMenuCallbacks:
             ])
 
     def annotate(self, widget, data=None):
-        url = self.paths[0]
-        if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
-            url = self.caller.root_url + self.paths[0]
-
+        url = self.caller.root_url + self.paths[0]
         helper.launch_ui_window("annotate", [
             url, 
             "--vcs=%s" % self.vcs_name, 

--- a/rabbitvcs/ui/markresolved.py
+++ b/rabbitvcs/ui/markresolved.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import six.moves._thread
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.add import Add
@@ -42,39 +42,16 @@ _ = gettext.gettext
 
 class SVNMarkResolved(Add):
     def __init__(self, paths, base_dir):
-        InterfaceView.__init__(self, "add", "Add")
+        Add.__init__(self, paths, base_dir)
 
-        self.window = self.get_widget("Add")
-        self.window.set_title(_("Mark as Resolved"))
-
-        self.paths = paths
-        self.base_dir = base_dir
-        self.last_row_clicked = None
-        self.vcs = rabbitvcs.vcs.VCS()
+    def setup(self, window, columns):
+        window.set_title(_("Mark as Resolved"))
         self.svn = self.vcs.svn()
-        self.items = None
         self.statuses = self.svn.STATUSES_FOR_RESOLVE
-        self.files_table = rabbitvcs.ui.widget.Table(
-            self.get_widget("files_table"), 
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH,
-                GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING], 
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension"), 
-                _("Text Status"), _("Property Status")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 1
-                }
-            }],
-            callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event,
-                "key-event":     self.on_files_table_key_event
-            }
-        )
-
-        self.initialize_items()
+        columns[0] = [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH,
+                GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
+        columns[1] = [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"),
+                _("Extension"), _("Text Status"), _("Property Status")]
 
     def populate_files_table(self):
         self.files_table.clear()
@@ -105,7 +82,7 @@ class SVNMarkResolved(Add):
             self.action.append(self.svn.resolve, item, recurse=True)
         self.action.append(self.action.set_status, _("Completed Mark as Resolved"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNMarkResolved

--- a/rabbitvcs/ui/markresolved.py
+++ b/rabbitvcs/ui/markresolved.py
@@ -41,9 +41,6 @@ from rabbitvcs import gettext
 _ = gettext.gettext
 
 class SVNMarkResolved(Add):
-    def __init__(self, paths, base_dir):
-        Add.__init__(self, paths, base_dir)
-
     def setup(self, window, columns):
         window.set_title(_("Mark as Resolved"))
         self.svn = self.vcs.svn()

--- a/rabbitvcs/ui/merge.py
+++ b/rabbitvcs/ui/merge.py
@@ -30,10 +30,9 @@ from rabbitvcs.ui.log import SVNLogDialog
 from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.vcs
 import rabbitvcs.ui.widget
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 
 from rabbitvcs import gettext
-import six
 _ = gettext.gettext
 
 class SVNMerge(InterfaceView):
@@ -64,7 +63,7 @@ class SVNMerge(InterfaceView):
         self.assistant.set_page_complete(self.page, True)
         self.assistant.set_forward_page_func(self.on_forward_clicked)
         
-        self.repo_paths = rabbitvcs.util.helper.get_repository_paths()
+        self.repo_paths = helper.get_repository_paths()
 
         # Keeps track of which stages should be marked as complete
         self.type = None
@@ -159,7 +158,7 @@ class SVNMerge(InterfaceView):
                         self.svn.revision("number", number=high).primitive(),
                     ))
 
-            action.append(rabbitvcs.util.helper.save_repository_path, url)
+            action.append(helper.save_repository_path, url)
             
             # Build up args and kwargs because some args are not supported
             # with older versions of pysvn/svn
@@ -181,7 +180,7 @@ class SVNMerge(InterfaceView):
             url = self.merge_reintegrate_repos.get_active_text()
             revision = self.merge_reintegrate_revision.get_revision_object()
 
-            action.append(rabbitvcs.util.helper.save_repository_path, url)
+            action.append(helper.save_repository_path, url)
             
             # Build up args and kwargs because some args are not supported
             # with older versions of pysvn/svn
@@ -211,8 +210,8 @@ class SVNMerge(InterfaceView):
                     number=int(self.get_widget("mergetree_to_revision_number").get_text())
                 )
 
-            action.append(rabbitvcs.util.helper.save_repository_path, from_url)
-            action.append(rabbitvcs.util.helper.save_repository_path, to_url)
+            action.append(helper.save_repository_path, from_url)
+            action.append(helper.save_repository_path, to_url)
 
             # Build up args and kwargs because some args are not supported
             # with older versions of pysvn/svn
@@ -539,9 +538,9 @@ class GitMerge(BranchMerge):
             if log:
                 from_info = log[0]
                 self.info['from']['author'].set_text(from_info.author)
-                self.info['from']['date'].set_text(rabbitvcs.util.helper.format_datetime(from_info.date))
-                self.info['from']['revision'].set_text(six.text_type(from_info.revision)[0:7])
-                self.info['from']['message'].set_text(rabbitvcs.util.helper.html_escape(rabbitvcs.util.helper.format_long_text(from_info.message, 500)))
+                self.info['from']['date'].set_text(helper.format_datetime(from_info.date))
+                self.info['from']['revision'].set_text(helper.to_text(from_info.revision)[0:7])
+                self.info['from']['message'].set_text(helper.html_escape(helper.format_long_text(from_info.message, 500)))
 
     def on_from_branches_changed(self, widget):
         self.update_branch_info()

--- a/rabbitvcs/ui/merge.py
+++ b/rabbitvcs/ui/merge.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -233,7 +233,7 @@ class SVNMerge(InterfaceView):
                        
         action.append(action.set_status, endcmd)
         action.append(action.finish)
-        action.run()
+        action.schedule()
 
     def on_prepare(self, widget, page):
         self.page = page
@@ -481,49 +481,49 @@ class GitMerge(BranchMerge):
         from_container = self.get_widget("from_branch_info")
         
         # Set up the Author line
-        author = Gtk.Label(_("Author:"))
+        author = Gtk.Label(label = _("Author:"))
         author.set_size_request(90, -1)
         author.set_properties(xalign=0,yalign=0)
-        self.info['from']['author'] = Gtk.Label("")
+        self.info['from']['author'] = Gtk.Label(label = "")
         self.info['from']['author'].set_properties(xalign=0,yalign=0,selectable=True)
         self.info['from']['author'].set_line_wrap(True)
-        author_container = Gtk.HBox(False, 0)
+        author_container = Gtk.HBox(homogeneous = False, spacing = 0)
         author_container.pack_start(author, False, False, 0)
         author_container.pack_start(self.info['from']['author'], False, False, 0)
         from_container.pack_start(author_container, False, False, 0)
 
         # Set up the Date line
-        date = Gtk.Label(_("Date:"))
+        date = Gtk.Label(label = _("Date:"))
         date.set_size_request(90, -1)
         date.set_properties(xalign=0,yalign=0)
-        self.info['from']['date'] = Gtk.Label("")
+        self.info['from']['date'] = Gtk.Label(label = "")
         self.info['from']['date'].set_properties(xalign=0,yalign=0,selectable=True)
-        date_container = Gtk.HBox(False, 0)
+        date_container = Gtk.HBox(homogeneous = False, spacing = 0)
         date_container.pack_start(date, False, False, 0)
         date_container.pack_start(self.info['from']['date'], False, False, 0)
         from_container.pack_start(date_container, False, False, 0)
 
         # Set up the Revision line
-        revision = Gtk.Label(_("Revision:"))
+        revision = Gtk.Label(label = _("Revision:"))
         revision.set_size_request(90, -1)
         revision.set_properties(xalign=0,yalign=0)
-        self.info['from']['revision'] = Gtk.Label("")
+        self.info['from']['revision'] = Gtk.Label(label = "")
         self.info['from']['revision'].set_properties(xalign=0,selectable=True)
         self.info['from']['revision'].set_line_wrap(True)
-        revision_container = Gtk.HBox(False, 0)
+        revision_container = Gtk.HBox(homogeneous = False, spacing = 0)
         revision_container.pack_start(revision, False, False, 0)
         revision_container.pack_start(self.info['from']['revision'], False, False, 0)
         from_container.pack_start(revision_container, False, False, 0)
 
         # Set up the Log Message line
-        message = Gtk.Label(_("Message:"))
+        message = Gtk.Label(label = _("Message:"))
         message.set_size_request(90, -1)
         message.set_properties(xalign=0,yalign=0)
-        self.info['from']['message'] = Gtk.Label("")
+        self.info['from']['message'] = Gtk.Label(label = "")
         self.info['from']['message'].set_properties(xalign=0,yalign=0,selectable=True)
         self.info['from']['message'].set_line_wrap(True)
         self.info['from']['message'].set_size_request(250, -1)
-        message_container = Gtk.HBox(False, 0)
+        message_container = Gtk.HBox(homogeneous = False, spacing = 0)
         message_container.pack_start(message, False, False, 0)
         message_container.pack_start(self.info['from']['message'], False, False, 0)
         from_container.pack_start(message_container, False, False, 0)
@@ -564,7 +564,7 @@ class GitMerge(BranchMerge):
 
         self.action.append(self.action.set_status, _("Completed Merge"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def __revision_changed(self, widget):
         self.update_branch_info()

--- a/rabbitvcs/ui/merge.py
+++ b/rabbitvcs/ui/merge.py
@@ -122,7 +122,7 @@ class SVNMerge(InterfaceView):
         kwargs = {}
         
         if self.type == "range":
-            url = self.get_widget("mergerange_from_urls").get_active_text()
+            url = self.mergerange_repos.get_active_text()
             head_revision = self.svn.get_head(self.path)
             revisions = self.get_widget("mergerange_revisions").get_text()
             if revisions == "":
@@ -195,14 +195,14 @@ class SVNMerge(InterfaceView):
             }
 
         elif self.type == "tree":
-            from_url = self.get_widget("mergetree_from_urls").get_active_text()
+            from_url = self.mergetree_from_repos.get_active_text()
             from_revision = self.svn.revision("head")
             if self.get_widget("mergetree_from_revision_number_opt").get_active():
                 from_revision = self.svn.revision(
                     "number",
                     number=int(self.get_widget("mergetree_from_revision_number").get_text())
                 )
-            to_url = self.get_widget("mergetree_to_urls").get_active_text()
+            to_url = self.mergetree_to_repos.get_active_text()
             to_revision = self.svn.revision("head")
             if self.get_widget("mergetree_to_revision_number_opt").get_active():
                 to_revision = self.svn.revision(
@@ -286,11 +286,11 @@ class SVNMerge(InterfaceView):
         
     def on_mergerange_show_log1_clicked(self, widget):
         merge_candidate_revisions = self.svn.find_merge_candidate_revisions(
-            self.get_widget("mergerange_from_urls").get_active_text(),
+            self.mergerange_repos.get_active_text(),
             self.path
         )
         SVNLogDialog(
-            self.get_widget("mergerange_from_urls").get_active_text(),
+            self.mergerange_repos.get_active_text(),
             ok_callback=self.on_mergerange_log1_closed, 
             multiple=True,
             merge_candidate_revisions=merge_candidate_revisions
@@ -307,13 +307,13 @@ class SVNMerge(InterfaceView):
 
     def mergerange_check_ready(self):
         ready = True
-        if self.get_widget("mergerange_from_urls").get_active_text() == "":
+        if self.mergerange_repos.get_active_text() == "":
             ready = False
 
         self.assistant.set_page_complete(self.page, ready)
 
         allow_log = False
-        if self.get_widget("mergerange_from_urls").get_active_text():
+        if self.mergerange_repos.get_active_text():
             allow_log = True        
         self.get_widget("mergerange_show_log1").set_sensitive(allow_log)
 
@@ -351,7 +351,7 @@ class SVNMerge(InterfaceView):
     
     def merge_reintegrate_check_ready(self):
         ready = True
-        if self.get_widget("merge_reintegrate_repos").get_active_text() == "":
+        if self.merge_reintegrate_repos.get_active_text() == "":
             ready = False
 
         self.assistant.set_page_complete(self.page, ready)
@@ -411,9 +411,9 @@ class SVNMerge(InterfaceView):
 
     def mergetree_check_ready(self):
         ready = True
-        if self.get_widget("mergetree_from_urls").get_active_text() == "":
+        if self.mergetree_from_repos.get_active_text() == "":
             ready = False
-        if self.get_widget("mergetree_to_urls").get_active_text() == "":
+        if self.mergetree_to_repos.get_active_text() == "":
             ready = False
 
         self.assistant.set_page_complete(self.page, ready)

--- a/rabbitvcs/ui/merge.py
+++ b/rabbitvcs/ui/merge.py
@@ -21,8 +21,6 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import cgi
-
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GObject, Gdk
@@ -543,7 +541,7 @@ class GitMerge(BranchMerge):
                 self.info['from']['author'].set_text(from_info.author)
                 self.info['from']['date'].set_text(rabbitvcs.util.helper.format_datetime(from_info.date))
                 self.info['from']['revision'].set_text(six.text_type(from_info.revision)[0:7])
-                self.info['from']['message'].set_text(cgi.escape(rabbitvcs.util.helper.format_long_text(from_info.message, 500)))
+                self.info['from']['message'].set_text(rabbitvcs.util.helper.html_escape(rabbitvcs.util.helper.format_long_text(from_info.message, 500)))
 
     def on_from_branches_changed(self, widget):
         self.update_branch_info()

--- a/rabbitvcs/ui/open.py
+++ b/rabbitvcs/ui/open.py
@@ -32,10 +32,12 @@ from rabbitvcs.ui import InterfaceNonView
 from rabbitvcs.ui.action import SVNAction, GitAction
 
 import rabbitvcs.vcs
+from rabbitvcs.util import helper
 
 from rabbitvcs import gettext
-import six
 _ = gettext.gettext
+
+import six
 
 class SVNOpen(InterfaceNonView):
     """
@@ -66,7 +68,7 @@ class SVNOpen(InterfaceNonView):
         url = path
         if not self.svn.is_path_repository_url(path):
             url = self.svn.get_repo_root_url(path) + '/' + path
-        dest = rabbitvcs.util.helper.get_tmp_path("rabbitvcs-" + revision + "-" + os.path.basename(path))
+        dest = helper.get_tmp_path("rabbitvcs-" + revision + "-" + os.path.basename(path))
         
         self.svn.export(
             url,
@@ -75,7 +77,7 @@ class SVNOpen(InterfaceNonView):
             force=True
         )
         
-        rabbitvcs.util.helper.open_item(dest)
+        helper.open_item(dest)
 
         raise SystemExit()
 
@@ -105,7 +107,7 @@ class GitOpen(InterfaceNonView):
         else:
             revision_obj = self.git.revision("HEAD")
 
-        dest_dir = rabbitvcs.util.helper.get_tmp_path("rabbitvcs-" + six.text_type(revision))
+        dest_dir = helper.get_tmp_path("rabbitvcs-" + helper.to_text(revision))
         
         self.git.export(
             path,
@@ -120,7 +122,7 @@ class GitOpen(InterfaceNonView):
         
         dest_path = "%s/%s" % (dest_dir, relative_path)
         
-        rabbitvcs.util.helper.open_item(dest_path)
+        helper.open_item(dest_path)
 
         raise SystemExit()
 

--- a/rabbitvcs/ui/open.py
+++ b/rabbitvcs/ui/open.py
@@ -25,7 +25,7 @@ from os import getcwd
 import os.path
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceNonView

--- a/rabbitvcs/ui/properties.py
+++ b/rabbitvcs/ui/properties.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView

--- a/rabbitvcs/ui/property_editor.py
+++ b/rabbitvcs/ui/property_editor.py
@@ -200,7 +200,7 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
             self.edit_property(name)
 
     def on_table_key_event(self, treeview, data=None):
-        if Gtk.gdk.keyval_name(data.keyval) == "Delete":
+        if Gdk.keyval_name(data.keyval) == "Delete":
             names = self.table.get_selected_row_items(0)
             self.delete_properties(names)
 

--- a/rabbitvcs/ui/property_editor.py
+++ b/rabbitvcs/ui/property_editor.py
@@ -34,7 +34,7 @@ from __future__ import print_function
 import os.path
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -89,7 +89,7 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
         note = rabbitvcs.ui.wraplabel.WrapLabel(PROP_EDITOR_NOTE)
         note.set_use_markup(True)
         
-        self.get_widget("note_box").pack_start(note)        
+        self.get_widget("note_box").pack_start(note, True, True, 0)        
         self.get_widget("note_box").show_all()
                 
         self.path = path

--- a/rabbitvcs/ui/property_page.py
+++ b/rabbitvcs/ui/property_page.py
@@ -19,21 +19,13 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import os
 import os.path
 
-import os
-import six
-if "REQUIRE_GTK3" in os.environ and os.environ["REQUIRE_GTK3"]:
-    from gi.repository import Gtk as Gtk
-    GTK3 = True
-    ICON_SIZE_BUTTON = Gtk.IconSize.BUTTON
-    ICON_SIZE_DIALOG = Gtk.IconSize.DIALOG
-else:
-    import Gtk
-    GTK3 = False
-    ICON_SIZE_BUTTON = Gtk.ICON_SIZE_BUTTON
-    ICON_SIZE_DIALOG = Gtk.ICON_SIZE_DIALOG
-    
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 from collections import defaultdict
 import rabbitvcs.ui
 import rabbitvcs.ui.widget
@@ -42,6 +34,7 @@ import rabbitvcs.vcs
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 from rabbitvcs.ui import STATUS_EMBLEMS
 
+from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.ui.property_page")
 
@@ -103,8 +96,8 @@ class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
 
         self.get_widget("vcs_type").set_text(self.status.vcs_type)
         
-        self.get_widget("content_status").set_text(six.text_type(self.status.simple_content_status()))
-        self.get_widget("prop_status").set_text(six.text_type(self.status.simple_metadata_status()))
+        self.get_widget("content_status").set_text(helper.to_text(self.status.simple_content_status()))
+        self.get_widget("prop_status").set_text(helper.to_text(self.status.simple_metadata_status()))
         
 
         self.set_icon_from_status(self.get_widget("content_status_icon"),
@@ -116,7 +109,7 @@ class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
         
 
         self.set_icon_from_status(self.get_widget("vcs_icon"),
-                                  self.status.single, ICON_SIZE_DIALOG)
+                                  self.status.single, Gtk.IconSize.DIALOG)
         
         additional_props_table = rabbitvcs.ui.widget.KeyValueTable(
                                     self.get_additional_info())
@@ -128,7 +121,7 @@ class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
                                                         fill=False,
                                                         padding=0)
                         
-    def set_icon_from_status(self, icon, status, size=ICON_SIZE_BUTTON):
+    def set_icon_from_status(self, icon, status, size=Gtk.IconSize.BUTTON):
         if status in rabbitvcs.ui.STATUS_EMBLEMS:
             icon.set_from_icon_name("emblem-" + STATUS_EMBLEMS[status], size)
 

--- a/rabbitvcs/ui/push.py
+++ b/rabbitvcs/ui/push.py
@@ -115,17 +115,17 @@ class GitPush(Push):
             log.exception(e)
 
     def load_logs(self):
-        Gtk.gdk.threads_enter()
+        Gdk.threads_enter()
         self.get_widget("status").set_text(_("Loading..."))
 
-        Gtk.gdk.threads_leave()
+        Gdk.threads_leave()
 
         self.load_push_log()
 
-        Gtk.gdk.threads_enter()
+        Gdk.threads_enter()
         self.get_widget("status").set_text("")
         self.update_widgets()
-        Gtk.gdk.threads_leave()
+        Gdk.threads_leave()
         
     def load_push_log(self):
         repository = self.repository_selector.repository_opt.get_active_text()

--- a/rabbitvcs/ui/push.py
+++ b/rabbitvcs/ui/push.py
@@ -25,7 +25,7 @@ import os.path
 import six.moves._thread
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 from datetime import datetime
 
@@ -102,7 +102,7 @@ class GitPush(Push):
         self.action.append(self.git.push, repository, branch, tags)
         self.action.append(self.action.set_status, _("Completed Push"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def initialize_logs(self):
         """

--- a/rabbitvcs/ui/push.py
+++ b/rabbitvcs/ui/push.py
@@ -33,16 +33,16 @@ from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
 import six
 _ = gettext.gettext
 
-DATETIME_FORMAT = rabbitvcs.util.helper.DT_FORMAT_THISWEEK
+DATETIME_FORMAT = helper.DT_FORMAT_THISWEEK
 
-GObject.threads_init()
+helper.gobject_threads_init()
 
 class Push(InterfaceView):
     def __init__(self, path):
@@ -151,8 +151,8 @@ class GitPush(Push):
         has_commits = False
         for item in self.push_log:
             self.log_table.append([
-                rabbitvcs.util.helper.format_datetime(item.date),
-                rabbitvcs.util.helper.format_long_text(item.message.rstrip("\n"))
+                helper.format_datetime(item.date),
+                helper.format_long_text(item.message.rstrip("\n"))
             ])
             has_commits = True
 

--- a/rabbitvcs/ui/push.py
+++ b/rabbitvcs/ui/push.py
@@ -114,19 +114,16 @@ class GitPush(Push):
         except Exception as e:
             log.exception(e)
 
-    def load_logs(self):
-        Gdk.threads_enter()
-        self.get_widget("status").set_text(_("Loading..."))
-
-        Gdk.threads_leave()
-
-        self.load_push_log()
-
-        Gdk.threads_enter()
+    def load_logs_exit(self):
         self.get_widget("status").set_text("")
         self.update_widgets()
-        Gdk.threads_leave()
-        
+
+    def load_logs(self):
+        helper.run_in_main_thread(self.get_widget("status").set_text, _("Loading..."))
+
+        self.load_push_log()
+        helper.run_in_main_thread(self.load_logs_exit)
+
     def load_push_log(self):
         repository = self.repository_selector.repository_opt.get_active_text()
         branch = self.repository_selector.branch_opt.get_active_text()

--- a/rabbitvcs/ui/relocate.py
+++ b/rabbitvcs/ui/relocate.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -89,7 +89,7 @@ class Relocate(InterfaceView):
         )
         self.action.append(self.action.set_status, _("Completed Relocate"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/remotes.py
+++ b/rabbitvcs/ui/remotes.py
@@ -129,7 +129,7 @@ class GitRemotes(InterfaceView):
             self.load()
 
     def on_treeview_key_event(self, treeview, data=None):
-        if Gtk.gdk.keyval_name(data.keyval) in ("Up", "Down", "Return"):
+        if Gdk.keyval_name(data.keyval) in ("Up", "Down", "Return"):
             self.on_treeview_event(treeview, data)
 
     def on_treeview_mouse_event(self, treeview, data=None):

--- a/rabbitvcs/ui/remotes.py
+++ b/rabbitvcs/ui/remotes.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 import os
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk, Pango
 
 from datetime import datetime

--- a/rabbitvcs/ui/rename.py
+++ b/rabbitvcs/ui/rename.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os.path
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceNonView
@@ -93,7 +93,7 @@ class SVNRename(Rename):
         self.action.append(self.action.set_status, _("Completed Rename"))
         self.action.append(self.action.finish)
         self.action.append(self.close)
-        self.action.run()
+        self.action.schedule()
 
 class GitRename(Rename):
     def __init__(self, path):
@@ -122,7 +122,7 @@ class GitRename(Rename):
         self.action.append(self.action.set_status, _("Completed Rename"))
         self.action.append(self.action.finish)
         self.action.append(self.close)
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNRename,

--- a/rabbitvcs/ui/renderers/graphcell.py
+++ b/rabbitvcs/ui/renderers/graphcell.py
@@ -16,7 +16,7 @@ __author__    = "Scott James Remnant <scott@ubuntu.com>"
 import math
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Pango
 
 import cairo

--- a/rabbitvcs/ui/reset.py
+++ b/rabbitvcs/ui/reset.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk, Pango
 
 from datetime import datetime
@@ -103,7 +103,7 @@ class GitReset(InterfaceView):
         )
         self.action.append(self.action.set_status, _("Completed Reset"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_browse_clicked(self, widget, data=None):
         chooser = rabbitvcs.ui.dialog.FolderChooser()

--- a/rabbitvcs/ui/revert.py
+++ b/rabbitvcs/ui/revert.py
@@ -34,8 +34,8 @@ from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
 import rabbitvcs.vcs
+from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from rabbitvcs.vcs.status import Status
 
@@ -44,7 +44,7 @@ log = Log("rabbitvcs.ui.revert")
 from rabbitvcs import gettext
 _ = gettext.gettext
 
-GObject.threads_init()
+helper.gobject_threads_init()
 
 import rabbitvcs.vcs
 
@@ -94,7 +94,7 @@ class Revert(InterfaceView, GtkContextMenuCaller):
             self.files_table.append([
                 True, 
                 item.path, 
-                rabbitvcs.util.helper.get_file_extension(item.path),
+                helper.get_file_extension(item.path),
                 item.simple_content_status(),
                 item.simple_metadata_status()
             ])
@@ -115,7 +115,7 @@ class Revert(InterfaceView, GtkContextMenuCaller):
             self.files_table.append([
                 True,
                 item.path,
-                rabbitvcs.util.helper.get_file_extension(item.path)
+                helper.get_file_extension(item.path)
             ])
 
     # Overrides the GtkContextMenuCaller method
@@ -139,7 +139,7 @@ class Revert(InterfaceView, GtkContextMenuCaller):
 
     def on_files_table_row_activated(self, treeview, event, col):
         paths = self.files_table.get_selected_row_items(1)
-        rabbitvcs.util.helper.launch_diff_tool(*paths)
+        helper.launch_diff_tool(*paths)
 
     def on_files_table_key_event(self, treeview, data=None):
         if Gdk.keyval_name(data.keyval) == "Delete":

--- a/rabbitvcs/ui/revert.py
+++ b/rabbitvcs/ui/revert.py
@@ -142,7 +142,7 @@ class Revert(InterfaceView, GtkContextMenuCaller):
         rabbitvcs.util.helper.launch_diff_tool(*paths)
 
     def on_files_table_key_event(self, treeview, data=None):
-        if Gtk.gdk.keyval_name(data.keyval) == "Delete":
+        if Gdk.keyval_name(data.keyval) == "Delete":
             self.delete_items(treeview, data)
 
     def on_files_table_mouse_event(self, treeview, data=None):

--- a/rabbitvcs/ui/revert.py
+++ b/rabbitvcs/ui/revert.py
@@ -26,7 +26,7 @@ import six.moves._thread
 from time import sleep
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -177,7 +177,7 @@ class SVNRevert(Revert):
         self.action.append(self.vcs.svn().revert, items, recurse=True)
         self.action.append(self.action.set_status, _("Completed Revert"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 
 class GitRevert(Revert):
@@ -203,7 +203,7 @@ class GitRevert(Revert):
         self.action.append(self.git.checkout, items)
         self.action.append(self.action.set_status, _("Completed Revert"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 class SVNRevertQuiet:
     def __init__(self, paths, base_dir=None):
@@ -214,7 +214,7 @@ class SVNRevertQuiet:
         )
         
         self.action.append(self.vcs.svn().revert, paths)
-        self.action.run()
+        self.action.schedule()
 
 class GitRevertQuiet:
     def __init__(self, paths, base_dir=None):
@@ -226,7 +226,7 @@ class GitRevertQuiet:
         )
         
         self.action.append(self.git.checkout, paths)
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNRevert, 

--- a/rabbitvcs/ui/revprops.py
+++ b/rabbitvcs/ui/revprops.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui.properties import PropertiesBase
@@ -98,7 +98,7 @@ class SVNRevisionProperties(PropertiesBase):
                 force=True
             )
         
-        self.action.run()
+        self.action.schedule()
 
         self.close()
 

--- a/rabbitvcs/ui/settings.py
+++ b/rabbitvcs/ui/settings.py
@@ -244,7 +244,7 @@ class Settings(InterfaceView):
     def save(self):
         self.settings.set(
             "general", "language",
-            self.get_widget("language").get_active_text()
+            self.language.get_active_text()
         )
         self.settings.set(
             "general", "enable_attributes",

--- a/rabbitvcs/ui/settings.py
+++ b/rabbitvcs/ui/settings.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk, Pango
 import dbus
 
@@ -164,21 +164,6 @@ class Settings(InterfaceView):
         # GTK2 Builder
 
         checker_service = self._get_checker_service(report_failure)
-        
-        self.get_widget("restart_checker").set_image(
-                                        Gtk.image_new_from_stock(
-                                            Gtk.STOCK_EXECUTE,
-                                            Gtk.ICON_SIZE_BUTTON))
-
-        self.get_widget("refresh_info").set_image(
-                                        Gtk.image_new_from_stock(
-                                            Gtk.STOCK_REFRESH,
-                                            Gtk.ICON_SIZE_BUTTON))
-
-        self.get_widget("stop_checker").set_image(
-                                        Gtk.image_new_from_stock(
-                                            Gtk.STOCK_STOP,
-                                            Gtk.ICON_SIZE_BUTTON))
 
         self.get_widget("stop_checker").set_sensitive(bool(checker_service))
 
@@ -202,9 +187,7 @@ class Settings(InterfaceView):
             self._clear_info_table()
 
     def _clear_info_table(self):
-        info_table = self.get_widget("info_table_area").get_child()
-        
-        if info_table:
+        for info_table in self.get_widget("info_table_area").get_children():
             info_table.destroy()
 
     def _populate_info_table(self, info):

--- a/rabbitvcs/ui/stage.py
+++ b/rabbitvcs/ui/stage.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import six.moves._thread
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -45,39 +45,12 @@ _ = gettext.gettext
 
 class GitStage(Add):
     def __init__(self, paths, base_dir=None):
-        InterfaceView.__init__(self, "add", "Add")
+        Add.__init__(self, paths, base_dir)
 
-        self.window = self.get_widget("Add")
-        self.window.set_title(_("Stage"))
-
-        self.paths = paths
-        self.base_dir = base_dir
-        self.last_row_clicked = None
-        self.vcs = rabbitvcs.vcs.VCS()
+    def setup(self, window, columns):
+        window.set_title(_("Stage"))
         self.git = self.vcs.git(self.paths[0])
-        self.items = None
         self.statuses = self.git.STATUSES_FOR_STAGE
-        self.show_ignored = False
-        self.files_table = rabbitvcs.ui.widget.Table(
-            self.get_widget("files_table"), 
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH, 
-                GObject.TYPE_STRING], 
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 1
-                }
-            }],
-            callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event,
-                "key-event":     self.on_files_table_key_event
-            }
-        )
-
-        self.initialize_items()
 
     def populate_files_table(self):
         self.files_table.clear()
@@ -106,7 +79,7 @@ class GitStage(Add):
             self.action.append(self.git.stage, item)
         self.action.append(self.action.set_status, _("Completed Stage"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 class GitStageQuiet:
     def __init__(self, paths, base_dir=None):
@@ -119,7 +92,7 @@ class GitStageQuiet:
         
         for path in paths:
             self.action.append(self.git.stage, path)
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_GIT: GitStage

--- a/rabbitvcs/ui/stage.py
+++ b/rabbitvcs/ui/stage.py
@@ -44,9 +44,6 @@ from rabbitvcs import gettext
 _ = gettext.gettext
 
 class GitStage(Add):
-    def __init__(self, paths, base_dir=None):
-        Add.__init__(self, paths, base_dir)
-
     def setup(self, window, columns):
         window.set_title(_("Stage"))
         self.git = self.vcs.git(self.paths[0])

--- a/rabbitvcs/ui/switch.py
+++ b/rabbitvcs/ui/switch.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -83,7 +83,7 @@ class SVNSwitch(InterfaceView):
         )
         self.action.append(self.action.set_status, _("Completed Switch"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNSwitch

--- a/rabbitvcs/ui/tags.py
+++ b/rabbitvcs/ui/tags.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk, Pango
 
 from datetime import datetime
@@ -88,25 +88,25 @@ class GitTagManager(InterfaceView):
     def initialize_detail(self):
         self.detail_container = self.get_widget("detail_container")
 
-        vbox = Gtk.VBox(False, 6)
+        vbox = Gtk.VBox(homogeneous = False, spacing = 6)
 
         # Set up the Tag line
-        label = Gtk.Label(_("Name:"))
+        label = Gtk.Label(label = _("Name:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=.5)
         self.tag_entry = Gtk.Entry()
-        self.tag_name_container = Gtk.HBox(False, 0)
+        self.tag_name_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.tag_name_container.pack_start(label, False, False, 0)
         self.tag_name_container.pack_start(self.tag_entry, False, False, 0)
         vbox.pack_start(self.tag_name_container, False, False, 0)
 
         # Set up the Commit-sha line
-        label = Gtk.Label(_("Revision:"))
+        label = Gtk.Label(label = _("Revision:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=.5)
         self.start_point_entry = Gtk.Entry()
         self.start_point_entry.set_size_request(300, -1)
-        self.start_point_container = Gtk.HBox(False, 0)
+        self.start_point_container = Gtk.HBox(homogeneous = False, spacing = 0)
         if self.revision_obj.value:
             self.start_point_entry.set_text(helper.to_text(self.revision_obj))
         self.log_dialog_button = Gtk.Button()
@@ -120,74 +120,74 @@ class GitTagManager(InterfaceView):
         vbox.pack_start(self.start_point_container, False, False, 0)
 
         # Set up the Log Message Entry line
-        label = Gtk.Label(_("Message:"))
+        label = Gtk.Label(label = _("Message:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=0)
         self.message_entry = rabbitvcs.ui.widget.TextView()
         self.message_entry.view.set_size_request(300, 75)
         swin = Gtk.ScrolledWindow()
-        swin.set_shadow_type(Gtk.SHADOW_ETCHED_IN)
-        swin.set_policy(Gtk.POLICY_AUTOMATIC, Gtk.POLICY_AUTOMATIC)
+        swin.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        swin.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         swin.add(self.message_entry.view)
-        self.message_entry_container = Gtk.HBox(False, 0)
+        self.message_entry_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.message_entry_container.pack_start(label, False, False, 0)
         self.message_entry_container.pack_start(swin, False, False, 0)
         vbox.pack_start(self.message_entry_container, False, False, 0)
 
         # Set up Save button
-        label = Gtk.Label("")
+        label = Gtk.Label(label = "")
         label.set_size_request(90, -1)
         self.save_button = Gtk.Button(label=_("Save"))
         self.save_button.connect("clicked", self.on_save_clicked)
-        self.save_container = Gtk.HBox(False, 0)
+        self.save_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.save_container.pack_start(label, False, False, 0)
         self.save_container.pack_start(self.save_button, False, False, 0)
         vbox.pack_start(self.save_container, False, False, 0)
 
         # Set up the tagger line
-        label = Gtk.Label(_("Tagger:"))
+        label = Gtk.Label(label = _("Tagger:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=0)
-        self.tagger_label = Gtk.Label("")
+        self.tagger_label = Gtk.Label(label = "")
         self.tagger_label.set_properties(xalign=0,yalign=0,selectable=True)
         self.tagger_label.set_line_wrap(True)
-        self.tagger_container = Gtk.HBox(False, 0)
+        self.tagger_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.tagger_container.pack_start(label, False, False, 0)
         self.tagger_container.pack_start(self.tagger_label, False, False, 0)
         vbox.pack_start(self.tagger_container, False, False, 0)
 
         # Set up the Date line
-        label = Gtk.Label(_("Date:"))
+        label = Gtk.Label(label = _("Date:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=0)
-        self.date_label = Gtk.Label("")
+        self.date_label = Gtk.Label(label = "")
         self.date_label.set_properties(xalign=0,yalign=0,selectable=True)
-        self.date_container = Gtk.HBox(False, 0)
+        self.date_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.date_container.pack_start(label, False, False, 0)
         self.date_container.pack_start(self.date_label, False, False, 0)
         vbox.pack_start(self.date_container, False, False, 0)
 
         # Set up the Revision line
-        label = Gtk.Label(_("Revision:"))
+        label = Gtk.Label(label = _("Revision:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=0)
-        self.revision_label = Gtk.Label("")
+        self.revision_label = Gtk.Label(label = "")
         self.revision_label.set_properties(xalign=0,selectable=True)
         self.revision_label.set_line_wrap(True)
-        self.revision_container = Gtk.HBox(False, 0)
+        self.revision_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.revision_container.pack_start(label, False, False, 0)
         self.revision_container.pack_start(self.revision_label, False, False, 0)
         vbox.pack_start(self.revision_container, False, False, 0)
 
         # Set up the Log Message line
-        label = Gtk.Label(_("Message:"))
+        label = Gtk.Label(label = _("Message:"))
         label.set_size_request(90, -1)
         label.set_properties(xalign=0,yalign=0)
-        self.message_label = Gtk.Label("")
+        self.message_label = Gtk.Label(label = "")
         self.message_label.set_properties(xalign=0,yalign=0,selectable=True)
         self.message_label.set_line_wrap(True)
         self.message_label.set_size_request(250, -1)
-        self.message_container = Gtk.HBox(False, 0)
+        self.message_container = Gtk.HBox(homogeneous = False, spacing = 0)
         self.message_container.pack_start(label, False, False, 0)
         self.message_container.pack_start(self.message_label, False, False, 0)
         vbox.pack_start(self.message_container, False, False, 0)

--- a/rabbitvcs/ui/tags.py
+++ b/rabbitvcs/ui/tags.py
@@ -35,11 +35,10 @@ from rabbitvcs.ui.action import GitAction
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.dialog import DeleteConfirmation
 from rabbitvcs.ui.log import log_dialog_factory
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
-import six
 _ = gettext.gettext
 
 STATE_ADD = 0
@@ -109,7 +108,7 @@ class GitTagManager(InterfaceView):
         self.start_point_entry.set_size_request(300, -1)
         self.start_point_container = Gtk.HBox(False, 0)
         if self.revision_obj.value:
-            self.start_point_entry.set_text(six.text_type(self.revision_obj))
+            self.start_point_entry.set_text(helper.to_text(self.revision_obj))
         self.log_dialog_button = Gtk.Button()
         self.log_dialog_button.connect("clicked", self.on_log_dialog_button_clicked)
         image = Gtk.Image()
@@ -283,7 +282,7 @@ class GitTagManager(InterfaceView):
             self.revision_label.set_text(self.selected_tag.sha)
             self.message_label.set_text(self.selected_tag.message.rstrip("\n"))
             self.tagger_label.set_text(self.selected_tag.tagger)
-            self.date_label.set_text(rabbitvcs.util.helper.format_datetime(datetime.fromtimestamp(self.selected_tag.tag_time)))
+            self.date_label.set_text(helper.format_datetime(datetime.fromtimestamp(self.selected_tag.tag_time)))
 
             self.show_containers(self.view_containers)
             self.get_widget("detail_label").set_markup(_("<b>Tag Detail</b>"))

--- a/rabbitvcs/ui/tags.py
+++ b/rabbitvcs/ui/tags.py
@@ -241,7 +241,7 @@ class GitTagManager(InterfaceView):
         self.load(self.show_detail, tag_name)
 
     def on_treeview_key_event(self, treeview, data=None):
-        if Gtk.gdk.keyval_name(data.keyval) in ("Up", "Down", "Return"):
+        if Gdk.keyval_name(data.keyval) in ("Up", "Down", "Return"):
             self.on_treeview_event(treeview, data)
 
     def on_treeview_mouse_event(self, treeview, data=None):

--- a/rabbitvcs/ui/unlock.py
+++ b/rabbitvcs/ui/unlock.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import six.moves._thread
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView, InterfaceNonView
@@ -43,40 +43,13 @@ _ = gettext.gettext
 
 class SVNUnlock(Add):
     def __init__(self, paths, base_dir):
-        InterfaceView.__init__(self, "add", "Add")
+        Add.__init__(self, paths, base_dir)
 
-        self.window = self.get_widget("Add")
-        self.window.set_title(_("Unlock"))
-
-        self.paths = paths
-        self.base_dir = base_dir
-        self.last_row_clicked = None
-        self.vcs = rabbitvcs.vcs.VCS()
+    def setup(self, window, columns):
+        window.set_title(_("Unlock"))
         self.svn = self.vcs.svn()
-        self.items = None
         self.statuses = None
-        self.files_table = rabbitvcs.ui.widget.Table(
-            self.get_widget("files_table"), 
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH, 
-                GObject.TYPE_STRING], 
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 1
-                }
-            }],
-            callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event,
-                "key-event":     self.on_files_table_key_event
-            }
-        )
 
-        self.initialize_items()
-        
-        
     #
     # Helpers
     #
@@ -141,7 +114,7 @@ class SVNUnlock(Add):
             self.action.append(self.svn.unlock, item, force=True)
         self.action.append(self.action.set_status, _("Completed Unlock"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 class SVNUnlockQuiet:
     """

--- a/rabbitvcs/ui/unlock.py
+++ b/rabbitvcs/ui/unlock.py
@@ -42,9 +42,6 @@ from rabbitvcs import gettext
 _ = gettext.gettext
 
 class SVNUnlock(Add):
-    def __init__(self, paths, base_dir):
-        Add.__init__(self, paths, base_dir)
-
     def setup(self, window, columns):
         window.set_title(_("Unlock"))
         self.svn = self.vcs.svn()

--- a/rabbitvcs/ui/unstage.py
+++ b/rabbitvcs/ui/unstage.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import six.moves._thread
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -45,38 +45,12 @@ _ = gettext.gettext
 
 class GitUnstage(Add):
     def __init__(self, paths, base_dir=None):
-        InterfaceView.__init__(self, "add", "Add")
+        Add.__init__(self, paths, base_dir)
 
-        self.window = self.get_widget("Add")
-        self.window.set_title(_("Unstage"))
-
-        self.paths = paths
-        self.base_dir = base_dir
-        self.last_row_clicked = None
-        self.vcs = rabbitvcs.vcs.VCS()
+    def setup(self, window, columns):
+        window.set_title(_("Unstage"))
         self.git = self.vcs.git(self.paths[0])
-        self.items = None
         self.statuses = self.git.STATUSES_FOR_UNSTAGE
-        self.files_table = rabbitvcs.ui.widget.Table(
-            self.get_widget("files_table"), 
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH, 
-                GObject.TYPE_STRING], 
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 1
-                }
-            }],
-            callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event,
-                "key-event":     self.on_files_table_key_event
-            }
-        )
-
-        self.initialize_items()
 
     def populate_files_table(self):
         self.files_table.clear()
@@ -105,7 +79,7 @@ class GitUnstage(Add):
             self.action.append(self.git.unstage, item)
         self.action.append(self.action.set_status, _("Completed Unstage"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 class GitUnstageQuiet:
     def __init__(self, paths, base_dir=None):
@@ -118,7 +92,7 @@ class GitUnstageQuiet:
         
         for path in paths:
             self.action.append(self.git.unstage, path)
-        self.action.run()
+        self.action.schedule()
 
 classes_map = {
     rabbitvcs.vcs.VCS_GIT: GitUnstage

--- a/rabbitvcs/ui/unstage.py
+++ b/rabbitvcs/ui/unstage.py
@@ -44,9 +44,6 @@ from rabbitvcs import gettext
 _ = gettext.gettext
 
 class GitUnstage(Add):
-    def __init__(self, paths, base_dir=None):
-        Add.__init__(self, paths, base_dir)
-
     def setup(self, window, columns):
         window.set_title(_("Unstage"))
         self.git = self.vcs.git(self.paths[0])

--- a/rabbitvcs/ui/update.py
+++ b/rabbitvcs/ui/update.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceNonView, InterfaceView
@@ -57,7 +57,7 @@ class SVNUpdate(InterfaceNonView):
         self.action.append(self.svn.update, self.paths)
         self.action.append(self.action.set_status, _("Completed Update"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 class GitUpdate(InterfaceView):
     """
@@ -122,7 +122,7 @@ class GitUpdate(InterfaceView):
                 
         self.action.append(self.action.set_status, _("Completed Update"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
 
 classes_map = {

--- a/rabbitvcs/ui/updateto.py
+++ b/rabbitvcs/ui/updateto.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 #
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Gdk
 
 from rabbitvcs.ui import InterfaceView
@@ -100,7 +100,7 @@ class SVNUpdateToRevision(UpdateToRevision):
             self.action.append(self.action.set_status, _("Completed Update"))
             
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_revision_changed(self, revision_selector):
         # Only allow rollback when a revision number is specified
@@ -144,7 +144,7 @@ class GitUpdateToRevision(UpdateToRevision):
         )
         self.action.append(self.action.set_status, _("Completed Checkout"))
         self.action.append(self.action.finish)
-        self.action.run()
+        self.action.schedule()
 
     def on_revision_changed(self, revision_selector):
         pass

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -797,25 +797,25 @@ class ComboBox:
                 self.cb.set_active(index)
                 return
             index += 1
-    
+
     def get_active_text(self):
-        return self.cb.get_active_text()
-    
+        return self.cb.get_child().get_text()
+
     def get_active(self):
         return self.cb.get_active()
     
     def set_active(self, index):
         self.cb.set_active(index)
-    
+
     def set_child_text(self, text):
         self.cb.get_child().set_text(text)
-    
+
     def set_sensitive(self, val):
         self.cb.set_sensitive(val)
 
     def set_child_signal(self, signal, callback, userdata=None):
         self.cb.get_child().connect(signal, callback, userdata)
-        
+
 class TextView:
     def __init__(self, widget=None, value="", spellcheck=True):
         if widget is None:

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import six
 from six.moves import range
 #
 # This is an extension to the Nautilus file manager to allow better 
@@ -29,12 +28,6 @@ import os.path
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GObject, Pango
-GTK_FILL = Gtk.AttachOptions.FILL
-GTK_EXPAND = Gtk.AttachOptions.EXPAND
-GTK3 = True
-PANGO_ELLIPSIZE_MIDDLE = Pango.EllipsizeMode.MIDDLE
-PANGO_ELLIPSIZE_END = Pango.EllipsizeMode.END
-HAS_PANGO = True
 
 HAS_GTKSPELL = False
 try:
@@ -52,7 +45,8 @@ try:
 except ImportError:
     pass
 
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
+import rabbitvcs.vcs
 
 from rabbitvcs import gettext
 _ = gettext.gettext
@@ -146,7 +140,7 @@ def path_filter(row, column, user_data=None):
     base_dir = user_data["base_dir"]
 
     if row[column]:
-        relpath = rabbitvcs.util.helper.get_relative_path(base_dir, row[column])
+        relpath = helper.get_relative_path(base_dir, row[column])
         if relpath == "":
             relpath = os.path.basename(row[column])
         return relpath
@@ -163,13 +157,13 @@ def long_text_filter(row, column, user_data=None):
     
     
     if text:
-        text = rabbitvcs.util.helper.format_long_text(text, cols)
+        text = helper.format_long_text(text, cols)
         
     return text
 
 def git_revision_filter(row, column, user_data=None):
     """
-    Only show the first six characters of a git revision hash
+    Only show the first seven characters of a git revision hash
     """
     
     text = row[column]
@@ -314,7 +308,7 @@ class TableBase:
                     }
                 else:
                     data = {
-                        "callback": rabbitvcs.util.helper.get_node_kind,
+                        "callback": helper.get_node_kind,
                         "column": i
                     }
                 col.set_cell_data_func(cellpb, self.file_pixbuf, data)
@@ -353,9 +347,8 @@ class TableBase:
                 cell = Gtk.CellRendererText()
                 cell.set_property('yalign', 0)
                 cell.set_property('xalign', 0)
-                if HAS_PANGO:
-                    cell.set_property('ellipsize', PANGO_ELLIPSIZE_END)
-                    cell.set_property('width-chars', ELLIPSIZE_COLUMN_CHARS)
+                cell.set_property('ellipsize', Pango.EllipsizeMode.END)
+                cell.set_property('width-chars', ELLIPSIZE_COLUMN_CHARS)
                 col = Gtk.TreeViewColumn(name, cell)
                 col.set_attributes(cell, text=i)
             elif coltypes[i] == TYPE_GRAPH:
@@ -596,7 +589,7 @@ class TableBase:
         for row in self.data:
             line = []
             for cell in row:
-                line.append(six.text_type(cell))
+                line.append(helper.to_text(cell))
             lines.append("\t".join(line))
         
         return "\n".join(lines)
@@ -1150,22 +1143,19 @@ class KeyValueTable(Gtk.Table):
                 label_key.set_properties(xalign=0, use_markup=True)
                 
                 label_value = Gtk.Label("%s" % value)
-                if HAS_PANGO:
-                    label_value.set_properties(xalign=0,                    \
-                                           ellipsize=PANGO_ELLIPSIZE_MIDDLE, \
+                label_value.set_properties(xalign=0,                    \
+                                           ellipsize=Pango.EllipsizeMode.MIDDLE, \
                                            selectable=True)
-                else:
-                    label_value.set_properties(xalign=0,selectable=True)
-                    
+
                 self.attach(label_key,
                              0,1,
                              row, row+1,
-                             xoptions=GTK_FILL)
+                             xoptions=Gtk.AttachOptions.FILL)
     
                 self.attach(label_value,
                              1,2,
                              row, row+1,
-                             xoptions=GTK_FILL|GTK_EXPAND)
+                             xoptions=Gtk.AttachOptions.FILL|Gtk.AttachOptions.EXPAND)
                         
                 label_key.show()
                 label_value.show()

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -802,7 +802,13 @@ class ComboBox:
             index += 1
 
     def get_active_text(self):
-        return self.cb.get_child().get_text()
+        child = self.cb.get_child()
+        if isinstance(child, Gtk.Entry):
+            return child.get_text()
+        index = self.cb.get_active()
+        if index < 0:
+            return ""
+        return self.model[index][0]
 
     def get_active(self):
         return self.cb.get_active()

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -808,13 +808,13 @@ class ComboBox:
         self.cb.set_active(index)
     
     def set_child_text(self, text):
-        self.cell.set_text(text)
+        self.cb.get_child().set_text(text)
     
     def set_sensitive(self, val):
         self.cb.set_sensitive(val)
 
     def set_child_signal(self, signal, callback, userdata=None):
-        self.cb.connect(signal, callback, userdata)
+        self.cb.get_child().connect(signal, callback, userdata)
         
 class TextView:
     def __init__(self, widget=None, value="", spellcheck=True):

--- a/rabbitvcs/ui/wraplabel.py
+++ b/rabbitvcs/ui/wraplabel.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 
 # Python translation from wrapLabel.{cc|h} by Gian Mario Tagliaretti
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Pango
 
 class WrapLabel(Gtk.Label):
@@ -36,7 +36,7 @@ class WrapLabel(Gtk.Label):
 
         self.__wrap_width = 0
         self.layout = self.get_layout()
-        self.layout.set_wrap(Pango.WRAP_WORD_CHAR)
+        self.layout.set_wrap(Pango.WrapMode.WORD_CHAR)
 
         if str != None:
             self.set_text(str)

--- a/rabbitvcs/ui/xml/about.xml
+++ b/rabbitvcs/ui/xml/about.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="window-close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkWindow" id="About">
     <property name="width_request">775</property>
     <property name="height_request">575</property>
@@ -12,6 +17,9 @@
     <property name="icon_name">rabbitvcs-small</property>
     <property name="gravity">center</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
@@ -20,18 +28,12 @@
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkAlignment" id="alignment1">
+          <object class="GtkLabel" id="label1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="top_padding">12</property>
-            <child>
-              <object class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">&lt;span size="xx-large"&gt;&lt;b&gt;RabbitVCS&lt;/b&gt;&lt;/span&gt;</property>
-                <property name="use_markup">True</property>
-              </object>
-            </child>
+            <property name="label" translatable="yes">&lt;span size="xx-large"&gt;&lt;b&gt;RabbitVCS&lt;/b&gt;&lt;/span&gt;</property>
+            <property name="use_markup">True</property>
+            <property name="justify">center</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -40,50 +42,24 @@
           </packing>
         </child>
         <child>
-          <object class="GtkAlignment" id="alignment2">
+          <object class="GtkBox" id="vbox2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="left_padding">12</property>
+            <property name="margin_left">12</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
             <child>
-              <object class="GtkBox" id="vbox2">
+              <object class="GtkBox" id="hbox1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="hbox1">
+                  <object class="GtkLabel" id="label2">
+                    <property name="width_request">100</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkLabel" id="label2">
-                        <property name="width_request">100</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Authors:</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="authors">
-                        <property name="width_request">600</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="wrap">True</property>
-                        <property name="selectable">True</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
+                    <property name="label" translatable="yes">Authors:</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -91,12 +67,32 @@
                     <property name="position">0</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkLabel" id="authors">
+                    <property name="width_request">600</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="wrap">True</property>
+                    <property name="selectable">True</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
@@ -121,22 +117,16 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment3">
+              <object class="GtkLabel" id="versions">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkLabel" id="versions">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="use_markup">True</property>
-                    <property name="xalign">0</property>
-                  </object>
-                </child>
+                <property name="margin_left">12</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -167,26 +157,20 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment4">
+              <object class="GtkLabel" id="links">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkLabel" id="links">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label">http://code.googlecode.com/p/rabbitvcs
+                <property name="margin_left">12</property>
+                <property name="label">http://code.googlecode.com/p/rabbitvcs
 http://subversion.tigris.org
 http://pysvn.tigris.org/
 http://voidspace.org.uk/python/configobj.html</property>
-                    <property name="use_markup">True</property>
-                    <property name="xalign">0</property>
-                  </object>
-                </child>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -205,11 +189,11 @@ http://voidspace.org.uk/python/configobj.html</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">window-close</property>
                 <signal name="clicked" handler="on_close_clicked" swapped="no"/>
               </object>
               <packing>
@@ -227,9 +211,6 @@ http://voidspace.org.uk/python/configobj.html</property>
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/add.xml
+++ b/rabbitvcs/ui/xml/add.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Add">
     <property name="width_request">450</property>
     <property name="visible">True</property>
@@ -14,6 +24,9 @@
     <property name="gravity">center</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
@@ -98,11 +111,12 @@
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="cancel">
-                    <property name="label">gtk-cancel</property>
+                    <property name="label" translatable="yes">_Cancel</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
+                    <property name="image">rabbitvcs-cancel</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -113,11 +127,12 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="ok">
-                    <property name="label">gtk-ok</property>
+                    <property name="label" translatable="yes">_OK</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
+                    <property name="image">rabbitvcs-ok</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -143,9 +158,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/annotate.xml
+++ b/rabbitvcs/ui/xml/annotate.xml
@@ -311,8 +311,5 @@
         </child>
       </object>
     </child>
-    <child>
-      <placeholder/>
-    </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/annotate.xml
+++ b/rabbitvcs/ui/xml/annotate.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="document-save-as">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">document-save-as</property>
+  </object>
+  <object class="GtkImage" id="window-close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkWindow" id="Annotate">
     <property name="width_request">750</property>
     <property name="height_request">550</property>
@@ -12,6 +22,9 @@
     <property name="icon_name">rabbitvcs-small</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
@@ -105,6 +118,7 @@
                                     <property name="icon_name">rabbitvcs-show_log</property>
                                   </object>
                                 </child>
+                                <accelerator key="f" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -176,6 +190,7 @@
                                     <property name="icon_name">rabbitvcs-show_log</property>
                                   </object>
                                 </child>
+                                <accelerator key="t" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -193,9 +208,10 @@
                                   <object class="GtkImage" id="image3">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="stock">gtk-refresh</property>
+                                    <property name="icon_name">view-refresh</property>
                                   </object>
                                 </child>
+                                <accelerator key="r" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -256,12 +272,13 @@
                     <property name="layout_style">end</property>
                     <child>
                       <object class="GtkButton" id="save">
-                        <property name="label">gtk-save-as</property>
+                        <property name="label" translatable="yes">Save _As</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_stock">True</property>
+                        <property name="image">document-save-as</property>
+                        <property name="use_underline">True</property>
                         <signal name="clicked" handler="on_save_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -272,11 +289,12 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="close">
-                        <property name="label">gtk-close</property>
+                        <property name="label" translatable="yes">_Close</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="use_stock">True</property>
+                        <property name="image">window-close</property>
+                        <property name="use_underline">True</property>
                         <signal name="clicked" handler="on_close_clicked" swapped="no"/>
                       </object>
                       <packing>

--- a/rabbitvcs/ui/xml/branch-merge.xml
+++ b/rabbitvcs/ui/xml/branch-merge.xml
@@ -9,16 +9,19 @@
     <signal name="destroy" handler="on_destroy"/>
     <signal handler="on_key_pressed" name="key_press_event"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="horizontal" id="hbox1">
+          <object class="GtkBox" id="hbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox2">
+              <object class="GtkBox" id="vbox2">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="spacing">6</property>
                 <child>
@@ -39,11 +42,13 @@
                     <property name="visible">True</property>
                     <property name="left_padding">12</property>
                     <child>
-                      <object class="GtkBox" orientation="vertical" id="from_container">
+                      <object class="GtkBox" id="from_container">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="from_branch_container">
+                          <object class="GtkBox" id="from_branch_container">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <child>
                               <placeholder/>
@@ -56,7 +61,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" orientation="vertical" id="from_branch_info">
+                          <object class="GtkBox" id="from_branch_info">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="spacing">6</property>
                             <child>
@@ -87,7 +93,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox3">
+          <object class="GtkBox" id="vbox3">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <child>
@@ -128,7 +135,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>

--- a/rabbitvcs/ui/xml/branch-merge.xml
+++ b/rabbitvcs/ui/xml/branch-merge.xml
@@ -1,35 +1,68 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.12 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Merge">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Merge</property>
     <property name="icon_name">rabbitvcs</property>
-    <signal name="destroy" handler="on_destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" id="hbox1">
-	    <property name="orientation">horizontal</property>
+          <object class="GtkBox" id="vbox2">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkBox" id="vbox2">
-                <property name="orientation">vertical</property>
+              <object class="GtkLabel" id="from_branch_label">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;From&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="from_container">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkLabel" id="from_branch_label">
+                  <object class="GtkBox" id="from_branch_container">
                     <property name="visible">True</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">&lt;b&gt;From&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <placeholder/>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -38,71 +71,48 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment1">
+                  <object class="GtkBox" id="from_branch_info">
                     <property name="visible">True</property>
-                    <property name="left_padding">12</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="from_container">
-                        <property name="orientation">vertical</property>
-                        <property name="visible">True</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkBox" id="from_branch_container">
-                            <property name="orientation">horizontal</property>
-                            <property name="visible">True</property>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="from_branch_info">
-                            <property name="orientation">vertical</property>
-                            <property name="visible">True</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="position">0</property>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="vbox3">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="to_branch_label">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Will be merged into&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -111,19 +121,15 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
+              <object class="GtkLabel" id="to_branch">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkLabel" id="to_branch">
-                    <property name="visible">True</property>
-                    <property name="xalign">0</property>
-                  </object>
-                </child>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -136,18 +142,19 @@
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox1">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_cancel_clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -157,12 +164,13 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_ok_clicked"/>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/branch.xml
+++ b/rabbitvcs/ui/xml/branch.xml
@@ -62,8 +62,9 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxEntry" id="from_urls">
+                          <object class="GtkComboBoxText" id="from_urls">
                             <property name="visible">True</property>
+                            <property name="has-entry">True</property>
                           </object>
                           <packing>
                             <property name="position">1</property>
@@ -113,8 +114,9 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxEntry" id="to_urls">
+                          <object class="GtkComboBoxText" id="to_urls">
                             <property name="visible">True</property>
+                            <property name="has-entry">True</property>
                           </object>
                           <packing>
                             <property name="position">1</property>

--- a/rabbitvcs/ui/xml/branch.xml
+++ b/rabbitvcs/ui/xml/branch.xml
@@ -1,32 +1,49 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.6 -->
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Branch">
     <property name="width_request">550</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Branch/tag</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox7">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox8">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Repository&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -35,104 +52,126 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
+              <object class="GtkBox" id="vbox1">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox1">
+                  <object class="GtkBox" id="hbox9">
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="hbox9">
+                      <object class="GtkLabel" id="label17">
+                        <property name="width_request">90</property>
                         <property name="visible">True</property>
-                        <property name="orientation">horizontal</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="label17">
-                            <property name="width_request">90</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">From:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBoxText" id="from_urls">
-                            <property name="visible">True</property>
-                            <property name="has-entry">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="repo_browser">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <signal handler="on_repo_browser_clicked" name="clicked"/>
-                            <child>
-                              <object class="GtkImage" id="image1">
-                                <property name="visible">True</property>
-                                <property name="stock">gtk-find</property>
-                                <property name="icon-size">1</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">From:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox10">
+                      <object class="GtkComboBoxText" id="from_urls">
                         <property name="visible">True</property>
-                        <property name="spacing">6</property>
-                        <property name="orientation">horizontal</property>
-                        <child>
-                          <object class="GtkLabel" id="label18">
-                            <property name="width_request">90</property>
+                        <property name="can_focus">False</property>
+                        <property name="has_entry">True</property>
+                        <child internal-child="entry">
+                          <object class="GtkEntry">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">To:</property>
+                            <property name="can_focus">True</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBoxText" id="to_urls">
-                            <property name="visible">True</property>
-                            <property name="has-entry">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
                       <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="repo_browser">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_repo_browser_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="image1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">edit-find</property>
+                            <property name="icon_size">1</property>
+                          </object>
+                        </child>
+                        <accelerator key="f" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox10">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label18">
+                        <property name="width_request">90</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">To:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="to_urls">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="has_entry">True</property>
+                        <child internal-child="entry">
+                          <object class="GtkEntry">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -146,14 +185,16 @@
         <child>
           <object class="GtkBox" id="vbox9">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Create copy from&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -162,16 +203,18 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="revision_container">
+              <object class="GtkBox" id="revision_container">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -185,14 +228,16 @@
         <child>
           <object class="GtkBox" id="vbox3">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Add Message&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -201,32 +246,45 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment1">
+              <object class="GtkBox" id="vbox10">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox10">
+                  <object class="GtkScrolledWindow" id="scrolledwindow6">
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">etched-in</property>
                     <child>
-                      <object class="GtkButtonBox" id="hbuttonbox6">
+                      <object class="GtkTextView" id="message">
+                        <property name="height_request">100</property>
                         <property name="visible">True</property>
-                        <property name="layout_style">start</property>
-                        <child>
-                          <object class="GtkButton" id="previous_messages">
-                            <property name="label" translatable="yes">Previous Messages</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <signal handler="on_previous_messages_clicked" name="clicked"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="wrap_mode">word</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">-1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButtonBox" id="hbuttonbox6">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="layout_style">start</property>
+                    <child>
+                      <object class="GtkButton" id="previous_messages">
+                        <property name="label" translatable="yes">Previous Messages</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_previous_messages_clicked" swapped="no"/>
+                        <accelerator key="p" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -234,51 +292,42 @@
                         <property name="position">0</property>
                       </packing>
                     </child>
-                    <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow6">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">automatic</property>
-                        <property name="vscrollbar_policy">automatic</property>
-                        <property name="shadow_type">etched-in</property>
-                        <child>
-                          <object class="GtkTextView" id="message">
-                            <property name="height_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="wrap_mode">word</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">-1</property>
-                      </packing>
-                    </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox5">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -288,12 +337,13 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/browser.xml
+++ b/rabbitvcs/ui/xml/browser.xml
@@ -48,6 +48,7 @@
                     <child>
                       <object class="GtkComboBoxText" id="urls">
                         <property name="visible">True</property>
+                        <property name="has-entry">True</property>
                       </object>
                       <packing>
                         <property name="position">1</property>

--- a/rabbitvcs/ui/xml/browser.xml
+++ b/rabbitvcs/ui/xml/browser.xml
@@ -1,43 +1,56 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="window-close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkWindow" id="Browser">
     <property name="width_request">640</property>
     <property name="height_request">480</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Repository Browser</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox2">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkBox" id="vbox3">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox" id="hbox1">
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label1">
                         <property name="width_request">90</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">URL:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -48,9 +61,18 @@
                     <child>
                       <object class="GtkComboBoxText" id="urls">
                         <property name="visible">True</property>
-                        <property name="has-entry">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="has_entry">True</property>
+                        <child internal-child="entry">
+                          <object class="GtkEntry">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                          </object>
+                        </child>
                       </object>
                       <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -64,14 +86,15 @@
                 <child>
                   <object class="GtkBox" id="hbox2">
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label2">
                         <property name="width_request">90</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Revision:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -82,12 +105,14 @@
                     <child>
                       <object class="GtkBox" id="revision_container">
                         <property name="visible">True</property>
-                        <property name="orientation">horizontal</property>
+                        <property name="can_focus">False</property>
                         <child>
                           <placeholder/>
                         </child>
                       </object>
                       <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -107,55 +132,53 @@
             </child>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow2">
+                <property name="height_request">330</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
                 <property name="shadow_type">etched-in</property>
                 <child>
                   <object class="GtkTreeView" id="list">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="hbox3">
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can_focus">False</property>
             <child>
-              <object class="GtkBox" id="hbox4">
+              <object class="GtkLabel" id="status">
                 <property name="visible">True</property>
-                <property name="orientation">horizontal</property>
-                <child>
-                  <object class="GtkLabel" id="status">
-                    <property name="visible">True</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkButtonBox" id="hbuttonbox1">
                 <property name="visible">True</property>
-                <property name="orientation">horizontal</property>
+                <property name="can_focus">False</property>
                 <property name="spacing">6</property>
                 <property name="layout_style">end</property>
                 <child>
@@ -163,31 +186,38 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <signal handler="on_refresh_clicked" name="clicked"/>
+                    <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
                     <child>
                       <object class="GtkBox" id="hbox5">
                         <property name="visible">True</property>
-                        <property name="orientation">horizontal</property>
+                        <property name="can_focus">False</property>
                         <child>
                           <object class="GtkImage" id="image1">
                             <property name="visible">True</property>
-                            <property name="stock">gtk-refresh</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">view-refresh</property>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label3">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Load/Refresh</property>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
                     </child>
+                    <accelerator key="r" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -197,12 +227,13 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="close">
-                    <property name="label">gtk-close</property>
+                    <property name="label" translatable="yes">_Close</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
-                    <signal handler="on_close_clicked" name="clicked"/>
+                    <property name="image">window-close</property>
+                    <property name="use_underline">True</property>
+                    <signal name="clicked" handler="on_close_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -212,8 +243,8 @@
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>

--- a/rabbitvcs/ui/xml/changes.xml
+++ b/rabbitvcs/ui/xml/changes.xml
@@ -1,46 +1,56 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.6 -->
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="window-close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkWindow" id="Changes">
     <property name="width_request">640</property>
     <property name="height_request">500</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="title" translatable="yes">Changes</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox2">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="orientation">vertical</property>
             <property name="spacing">12</property>
             <child>
               <object class="GtkBox" id="vbox3">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">&lt;b&gt;First:&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -49,80 +59,26 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment1">
+                  <object class="GtkBox" id="vbox4">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="margin_left">12</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="vbox4">
-                        <property name="orientation">vertical</property>
+                      <object class="GtkBox" id="hbox1">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="hbox1">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkLabel" id="label2">
+                            <property name="width_request">100</property>
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <child>
-                              <object class="GtkLabel" id="label2">
-                                <property name="width_request">100</property>
-                                <property name="visible">True</property>
-                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">URL</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="hbox12">
-                                <property name="orientation">horizontal</property>
-                                <property name="visible">True</property>
-                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="spacing">4</property>
-                                <child>
-                                  <object class="GtkComboBoxText" id="first_urls">
-                                    <property name="visible">True</property>
-                                    <property name="has-entry">True</property>
-                                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <signal handler="on_first_urls_changed" name="changed"/>
-                                  </object>
-                                  <packing>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="first_urls_browse">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <signal handler="on_first_urls_browse_clicked" name="clicked"/>
-                                    <child>
-                                      <object class="GtkImage" id="image5">
-                                        <property name="visible">True</property>
-                                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="stock">gtk-zoom-fit</property>
-                                        <property name="icon-size">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="label" translatable="yes">URL</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -131,49 +87,114 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="hbox2">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkBox" id="hbox12">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                            <property name="spacing">4</property>
                             <child>
-                              <object class="GtkLabel" id="label3">
-                                <property name="width_request">100</property>
+                              <object class="GtkComboBoxText" id="first_urls">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Revision</property>
+                                <property name="has_entry">True</property>
+                                <signal name="changed" handler="on_first_urls_changed" swapped="no"/>
+                                <child internal-child="entry">
+                                  <object class="GtkEntry">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                  </object>
+                                </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" id="first_revision_container">
-                                <property name="orientation">horizontal</property>
+                              <object class="GtkButton" id="first_urls_browse">
                                 <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                                <signal name="clicked" handler="on_first_urls_browse_clicked" swapped="no"/>
                                 <child>
-                                  <placeholder/>
+                                  <object class="GtkImage" id="image5">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                                    <property name="icon_name">zoom-fit-best</property>
+                                    <property name="icon_size">1</property>
+                                  </object>
                                 </child>
+                                <accelerator key="f" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                               </object>
                               <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="hbox2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <child>
+                          <object class="GtkLabel" id="label3">
+                            <property name="width_request">100</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                            <property name="label" translatable="yes">Revision</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="first_revision_container">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -186,18 +207,19 @@
             </child>
             <child>
               <object class="GtkBox" id="vbox7">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label6">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">&lt;b&gt;Second:&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -206,80 +228,26 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment3">
+                  <object class="GtkBox" id="vbox8">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="left_padding">12</property>
+                    <property name="margin_left">12</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="vbox8">
-                        <property name="orientation">vertical</property>
+                      <object class="GtkBox" id="hbox7">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="hbox7">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkLabel" id="label7">
+                            <property name="width_request">100</property>
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <child>
-                              <object class="GtkLabel" id="label7">
-                                <property name="width_request">100</property>
-                                <property name="visible">True</property>
-                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">URL</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="hbox14">
-                                <property name="orientation">horizontal</property>
-                                <property name="visible">True</property>
-                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="spacing">4</property>
-                                <child>
-                                  <object class="GtkComboBoxText" id="second_urls">
-                                    <property name="visible">True</property>
-                                    <property name="has-entry">True</property>
-                                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <signal handler="on_second_urls_changed" name="changed"/>
-                                  </object>
-                                  <packing>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="second_urls_browse">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <signal handler="on_second_urls_browse_clicked" name="clicked"/>
-                                    <child>
-                                      <object class="GtkImage" id="image7">
-                                        <property name="visible">True</property>
-                                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="stock">gtk-zoom-fit</property>
-                                        <property name="icon-size">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="label" translatable="yes">URL</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -288,49 +256,114 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="hbox17">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkBox" id="hbox14">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                            <property name="spacing">4</property>
                             <child>
-                              <object class="GtkLabel" id="label11">
-                                <property name="width_request">100</property>
+                              <object class="GtkComboBoxText" id="second_urls">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Revision</property>
+                                <property name="has_entry">True</property>
+                                <signal name="changed" handler="on_second_urls_changed" swapped="no"/>
+                                <child internal-child="entry">
+                                  <object class="GtkEntry">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                  </object>
+                                </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" id="second_revision_container">
-                                <property name="orientation">horizontal</property>
+                              <object class="GtkButton" id="second_urls_browse">
                                 <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                                <signal name="clicked" handler="on_second_urls_browse_clicked" swapped="no"/>
                                 <child>
-                                  <placeholder/>
+                                  <object class="GtkImage" id="image7">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                                    <property name="icon_name">zoom-fit-best</property>
+                                    <property name="icon_size">1</property>
+                                  </object>
                                 </child>
+                                <accelerator key="s" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                               </object>
                               <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="hbox17">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                        <child>
+                          <object class="GtkLabel" id="label11">
+                            <property name="width_request">100</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                            <property name="label" translatable="yes">Revision</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="second_revision_container">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -343,20 +376,21 @@
             </child>
             <child>
               <object class="GtkBox" id="vbox5">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox" id="hbox5">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkLabel" id="label4">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Differences&lt;/b&gt; (double-click to compare with base)</property>
                         <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -373,8 +407,8 @@
                 </child>
                 <child>
                   <object class="GtkBox" id="hbox19">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="spacing">4</property>
                     <child>
@@ -382,50 +416,59 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="hscrollbar_policy">automatic</property>
-                        <property name="vscrollbar_policy">automatic</property>
                         <property name="shadow_type">etched-in</property>
+                        <property name="propagate_natural_height">True</property>
                         <child>
                           <object class="GtkTreeView" id="changes_table">
+                            <property name="height_request">200</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <!--<signal handler="on_changes_table_button_pressed" name="button_press_event"/>-->
-                            <signal handler="on_changes_table_cursor_changed" name="cursor_changed"/>
-                            <signal handler="on_changes_table_row_doubleclicked" name="row_activated"/>
-                            <!--<signal handler="on_changes_table_key_released" name="key_release_event"/>-->
+                            <signal name="cursor-changed" handler="on_changes_table_cursor_changed" swapped="no"/>
+                            <signal name="row-activated" handler="on_changes_table_row_doubleclicked" swapped="no"/>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
+                            </child>
                           </object>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="hbox4">
-            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkComboBox" id="more_actions">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
-                <signal handler="on_more_actions_changed" name="changed"/>
+                <property name="can_focus">False</property>
+                <signal name="changed" handler="on_more_actions_changed" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -435,8 +478,8 @@
             </child>
             <child>
               <object class="GtkButtonBox" id="hbuttonbox1">
-                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="spacing">6</property>
                 <property name="layout_style">end</property>
@@ -445,34 +488,41 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <signal handler="on_refresh_clicked" name="clicked"/>
+                    <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
                     <child>
                       <object class="GtkBox" id="hbox6">
-                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <child>
                           <object class="GtkImage" id="image2">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="stock">gtk-refresh</property>
+                            <property name="icon_name">view-refresh</property>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label5">
                             <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="label" translatable="yes">Load/Refresh</property>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
                     </child>
+                    <accelerator key="r" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -482,13 +532,13 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="close">
-                    <property name="label">gtk-close</property>
+                    <property name="label" translatable="yes">_Close</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="use_stock">True</property>
-                    <signal handler="on_close_clicked" name="clicked"/>
+                    <property name="image">window-close</property>
+                    <signal name="clicked" handler="on_close_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/changes.xml
+++ b/rabbitvcs/ui/xml/changes.xml
@@ -398,6 +398,7 @@
                         </child>
                       </object>
                       <packing>
+                        <property name="expand">True</property>
                         <property name="position">0</property>
                       </packing>
                     </child>

--- a/rabbitvcs/ui/xml/changes.xml
+++ b/rabbitvcs/ui/xml/changes.xml
@@ -13,20 +13,23 @@
     <signal handler="on_destroy" name="destroy"/>
     <signal handler="on_key_pressed" name="key_press_event"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox2">
+          <object class="GtkBox" id="vbox2">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="orientation">vertical</property>
             <property name="spacing">12</property>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox3">
+              <object class="GtkBox" id="vbox3">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="orientation">vertical</property>
@@ -51,13 +54,15 @@
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="left_padding">12</property>
                     <child>
-                      <object class="GtkBox" orientation="vertical" id="vbox4">
+                      <object class="GtkBox" id="vbox4">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox1">
+                          <object class="GtkBox" id="hbox1">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
@@ -75,13 +80,15 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" orientation="horizontal" id="hbox12">
+                              <object class="GtkBox" id="hbox12">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">4</property>
                                 <child>
-                                  <object class="GtkComboBoxEntry" id="first_urls">
+                                  <object class="GtkComboBoxText" id="first_urls">
                                     <property name="visible">True</property>
+                                    <property name="has-entry">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <signal handler="on_first_urls_changed" name="changed"/>
                                   </object>
@@ -124,7 +131,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox2">
+                          <object class="GtkBox" id="hbox2">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
@@ -142,7 +150,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" orientation="horizontal" id="first_revision_container">
+                              <object class="GtkBox" id="first_revision_container">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <child>
                                   <placeholder/>
@@ -176,7 +185,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox7">
+              <object class="GtkBox" id="vbox7">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="orientation">vertical</property>
@@ -201,13 +211,15 @@
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="left_padding">12</property>
                     <child>
-                      <object class="GtkBox" orientation="vertical" id="vbox8">
+                      <object class="GtkBox" id="vbox8">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox7">
+                          <object class="GtkBox" id="hbox7">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
@@ -225,13 +237,15 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" orientation="horizontal" id="hbox14">
+                              <object class="GtkBox" id="hbox14">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">4</property>
                                 <child>
-                                  <object class="GtkComboBoxEntry" id="second_urls">
+                                  <object class="GtkComboBoxText" id="second_urls">
                                     <property name="visible">True</property>
+                                    <property name="has-entry">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <signal handler="on_second_urls_changed" name="changed"/>
                                   </object>
@@ -274,7 +288,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox17">
+                          <object class="GtkBox" id="hbox17">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
@@ -292,7 +307,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" orientation="horizontal" id="second_revision_container">
+                              <object class="GtkBox" id="second_revision_container">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <child>
                                   <placeholder/>
@@ -326,12 +342,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox5">
+              <object class="GtkBox" id="vbox5">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" orientation="horizontal" id="hbox5">
+                  <object class="GtkBox" id="hbox5">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <child>
                       <object class="GtkLabel" id="label4">
@@ -354,7 +372,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" orientation="horizontal" id="hbox19">
+                  <object class="GtkBox" id="hbox19">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="spacing">4</property>
@@ -398,7 +417,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="horizontal" id="hbox4">
+          <object class="GtkBox" id="hbox4">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <child>
               <object class="GtkComboBox" id="more_actions">
@@ -413,7 +433,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox1">
+              <object class="GtkButtonBox" id="hbuttonbox1">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="spacing">6</property>
@@ -425,7 +446,8 @@
                     <property name="receives_default">True</property>
                     <signal handler="on_refresh_clicked" name="clicked"/>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox6">
+                      <object class="GtkBox" id="hbox6">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <child>

--- a/rabbitvcs/ui/xml/checkmods.xml
+++ b/rabbitvcs/ui/xml/checkmods.xml
@@ -1,40 +1,56 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.6 -->
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="view-refresh">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">view-refresh</property>
+  </object>
+  <object class="GtkImage" id="window-close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkWindow" id="CheckMods">
     <property name="width_request">550</property>
     <property name="height_request">300</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Check for Modifications</property>
     <property name="window_position">center</property>
     <property name="default_width">400</property>
     <property name="default_height">300</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="gravity">center</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkNotebook" id="notebook">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <signal handler="on_notebook_switch_page" name="switch_page"/>
+            <signal name="switch-page" handler="on_notebook_switch_page" swapped="no"/>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow1">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
                 <property name="shadow_type">etched-in</property>
                 <child>
                   <object class="GtkTreeView" id="local_files_table">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -42,6 +58,7 @@
             <child type="tab">
               <object class="GtkLabel" id="local_mods">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Local</property>
               </object>
               <packing>
@@ -52,19 +69,24 @@
               <object class="GtkScrolledWindow" id="scrolledwindow2">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
                 <child>
                   <object class="GtkTreeView" id="remote_files_table">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
+              <packing>
+                <property name="position">1</property>
+              </packing>
             </child>
             <child type="tab">
               <object class="GtkLabel" id="remote_mods">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Remote</property>
               </object>
               <packing>
@@ -80,23 +102,26 @@
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox2">
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="refresh">
-                <property name="label">gtk-refresh</property>
+                <property name="label" translatable="yes">_Refresh</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_refresh_clicked" name="clicked"/>
+                <property name="image">view-refresh</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -106,12 +131,13 @@
             </child>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_close_clicked" name="clicked"/>
+                <property name="image">window-close</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_close_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/checkout.xml
+++ b/rabbitvcs/ui/xml/checkout.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Checkout">
     <property name="width_request">550</property>
     <property name="visible">True</property>
@@ -12,6 +22,9 @@
     <property name="icon_name">rabbitvcs-small</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox2">
         <property name="visible">True</property>
@@ -40,76 +53,24 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment1">
+              <object class="GtkBox" id="vbox1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox1">
+                  <object class="GtkBox" id="hbox2">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="hbox2">
+                      <object class="GtkLabel" id="label3">
+                        <property name="width_request">90</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="label3">
-                            <property name="width_request">90</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">URL:</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBoxText" id="repositories">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="has_entry">True</property>
-                            <signal name="changed" handler="on_repositories_changed" swapped="no"/>
-                            <child internal-child="entry">
-                              <object class="GtkEntry">
-                                <property name="can_focus">False</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="repo_chooser">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="has_tooltip">True</property>
-                            <property name="tooltip_text" translatable="yes">Browse...</property>
-                            <signal name="clicked" handler="on_repo_chooser_clicked" swapped="no"/>
-                            <child>
-                              <object class="GtkImage" id="image3">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="stock">gtk-find</property>
-                                <property name="icon_size">1</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
+                        <property name="label" translatable="yes">URL:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -118,89 +79,121 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox3">
+                      <object class="GtkComboBoxText" id="repositories">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="label4">
-                            <property name="width_request">90</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Destination:</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="destination">
+                        <property name="has_entry">True</property>
+                        <signal name="changed" handler="on_repositories_changed" swapped="no"/>
+                        <child internal-child="entry">
+                          <object class="GtkEntry">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <signal name="changed" handler="on_destination_changed" swapped="no"/>
-                            <signal name="key-release-event" handler="on_destination_key_released" swapped="no"/>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="file_chooser">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="tooltip_text" translatable="yes">Browse...</property>
-                            <signal name="clicked" handler="on_file_chooser_clicked" swapped="no"/>
-                            <child>
-                              <object class="GtkImage" id="image2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="stock">gtk-harddisk</property>
-                                <property name="icon_size">2</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
+                        <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkComboBoxText">
+                      <object class="GtkButton" id="repo_chooser">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="has_entry">True</property>
-                        <child internal-child="entry">
-                          <object class="GtkEntry">
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="has_tooltip">True</property>
+                        <property name="tooltip_text" translatable="yes">Browse...</property>
+                        <signal name="clicked" handler="on_repo_chooser_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="image3">
+                            <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="icon_name">edit-find</property>
+                            <property name="icon_size">1</property>
                           </object>
                         </child>
+                        <accelerator key="u" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">True</property>
+                        <property name="fill">False</property>
                         <property name="position">2</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label4">
+                        <property name="width_request">90</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Destination:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="destination">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <signal name="changed" handler="on_destination_changed" swapped="no"/>
+                        <signal name="key-release-event" handler="on_destination_key_released" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="file_chooser">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Browse...</property>
+                        <signal name="clicked" handler="on_file_chooser_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="image2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">drive-harddisk</property>
+                            <property name="icon_size">2</property>
+                          </object>
+                        </child>
+                        <accelerator key="d" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -231,16 +224,16 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
+              <object class="GtkBox" id="vbox4">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">2</property>
                 <child>
-                  <object class="GtkBox" id="vbox4">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
                     <child>
                       <object class="GtkCheckButton" id="recursive">
                         <property name="label" translatable="yes">Recursive</property>
@@ -256,6 +249,17 @@
                         <property name="position">0</property>
                       </packing>
                     </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkCheckButton" id="omit_externals">
                         <property name="label" translatable="yes">Omit Externals</property>
@@ -267,15 +271,20 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">1</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -306,17 +315,18 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="revision_container">
+              <object class="GtkBox" id="revision_container">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -335,11 +345,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -350,12 +361,13 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
@@ -372,9 +384,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/clean.xml
+++ b/rabbitvcs/ui/xml/clean.xml
@@ -1,148 +1,182 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.12 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Clean">
     <property name="width_request">400</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Clean</property>
     <property name="window_position">center-always</property>
-    <signal handler="on_destroy" name="destroy"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox3">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Clean your Repository&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
-                <property name="xalign">0.10000000149011612</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Remove untracked files from the working tree</property>
+                <property name="xalign">0.10000000149011612</property>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment1">
+              <object class="GtkBox" id="vbox2">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">3</property>
                 <child>
-                  <object class="GtkBox" id="vbox2">
+                  <object class="GtkCheckButton" id="remove_directories">
+                    <property name="label" translatable="yes">Remove directories</property>
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">3</property>
-                    <child>
-                      <object class="GtkCheckButton" id="remove_directories">
-                        <property name="label" translatable="yes">Remove directories</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="remove_ignored_too">
-                        <property name="label" translatable="yes">Remove ignored files, too</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
-                        <signal handler="on_remove_ignored_too_toggled" name="toggled"/>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="remove_only_ignored">
-                        <property name="label" translatable="yes">Remove only ignored files</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
-                        <signal handler="on_remove_only_ignored_toggled" name="toggled"/>
-                      </object>
-                      <packing>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="dryrun">
-                        <property name="label" translatable="yes">Dry run</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="position">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="force">
-                        <property name="label" translatable="yes">Force</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="position">4</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="remove_ignored_too">
+                    <property name="label" translatable="yes">Remove ignored files, too</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="on_remove_ignored_too_toggled" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="remove_only_ignored">
+                    <property name="label" translatable="yes">Remove only ignored files</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="on_remove_only_ignored_toggled" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="dryrun">
+                    <property name="label" translatable="yes">Dry run</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="force">
+                    <property name="label" translatable="yes">Force</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox1">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -152,12 +186,13 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/clean.xml
+++ b/rabbitvcs/ui/xml/clean.xml
@@ -9,13 +9,13 @@
     <property name="window_position">center-always</property>
     <signal handler="on_destroy" name="destroy"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox1">
+      <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox3">
+          <object class="GtkBox" id="vbox3">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -45,7 +45,7 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox2">
+                  <object class="GtkBox" id="vbox2">
                     <property name="visible">True</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">3</property>
@@ -130,7 +130,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>

--- a/rabbitvcs/ui/xml/cleanup.xml
+++ b/rabbitvcs/ui/xml/cleanup.xml
@@ -9,7 +9,7 @@
     <property name="icon_name">rabbitvcs-small</property>
     <signal handler="on_destroy" name="destroy"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox24">
+      <object class="GtkBox" id="vbox24">
         <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="border_width">12</property>
@@ -42,7 +42,8 @@ Begin working copy cleanup?</property>
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox15">
+          <object class="GtkButtonBox" id="hbuttonbox15">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <property name="layout_style">GTK_BUTTONBOX_END</property>

--- a/rabbitvcs/ui/xml/cleanup.xml
+++ b/rabbitvcs/ui/xml/cleanup.xml
@@ -1,39 +1,59 @@
-<?xml version="1.0"?>
-<!--Generated with glade3 3.4.5 on Thu Jan 29 16:44:10 2009 -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Cleanup">
     <property name="width_request">400</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Cleaning Up...</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
-    <signal handler="on_destroy" name="destroy"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox24">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkImage" id="icon">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="xalign">0.10000000149011612</property>
             <property name="ypad">5</property>
-            <property name="stock">gtk-directory</property>
+            <property name="pixel_size">64</property>
+            <property name="icon_name">folder</property>
             <property name="icon_size">6</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel" id="label">
             <property name="visible">True</property>
-            <property name="xalign">0.10000000149011612</property>
+            <property name="can_focus">False</property>
             <property name="ypad">5</property>
             <property name="label" translatable="yes">Cleanup Requested....
 
 Begin working copy cleanup?</property>
+            <property name="xalign">0.10000000149011612</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -43,33 +63,36 @@ Begin working copy cleanup?</property>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox15">
-            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="label">gtk-cancel</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="ok">
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="label">gtk-ok</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/commit.xml
+++ b/rabbitvcs/ui/xml/commit.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Commit">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -12,6 +22,9 @@
     <property name="icon_name">rabbitvcs-small</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox4">
         <property name="visible">True</property>
@@ -90,58 +103,47 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment3">
+                  <object class="GtkBox" id="vbox6">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
+                    <property name="margin_left">12</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="vbox6">
+                      <object class="GtkScrolledWindow" id="scrolledwindow3">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">etched-in</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow3">
+                          <object class="GtkTextView" id="message">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="shadow_type">etched-in</property>
-                            <child>
-                              <object class="GtkTextView" id="message">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="has_focus">True</property>
-                                <property name="pixels_below_lines">7</property>
-                                <property name="wrap_mode">word</property>
-                                <property name="accepts_tab">False</property>
-                              </object>
-                            </child>
+                            <property name="has_focus">True</property>
+                            <property name="pixels_below_lines">7</property>
+                            <property name="wrap_mode">word</property>
+                            <property name="accepts_tab">False</property>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">-1</property>
-                          </packing>
                         </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">-1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButtonBox" id="hbuttonbox4">
+                        <property name="width_request">0</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="layout_style">start</property>
                         <child>
-                          <object class="GtkButtonBox" id="hbuttonbox4">
-                            <property name="width_request">0</property>
+                          <object class="GtkButton" id="previous_messages">
+                            <property name="label" translatable="yes">Previous Messages</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="layout_style">start</property>
-                            <child>
-                              <object class="GtkButton" id="previous_messages">
-                                <property name="label" translatable="yes">Previous Messages</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_previous_messages_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <signal name="clicked" handler="on_previous_messages_clicked" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -150,6 +152,11 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -186,73 +193,64 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment1">
+                  <object class="GtkBox" id="vbox3">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
+                    <property name="margin_left">12</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="vbox3">
+                      <object class="GtkScrolledWindow" id="scrolledwindow2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">etched-in</property>
+                        <child>
+                          <object class="GtkTreeView" id="files_table">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="options_box">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow2">
+                          <object class="GtkCheckButton" id="toggle_show_all">
+                            <property name="label" translatable="yes">Select / Deselect all</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="shadow_type">etched-in</property>
-                            <child>
-                              <object class="GtkTreeView" id="files_table">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <child internal-child="selection">
-                                  <object class="GtkTreeSelection"/>
-                                </child>
-                              </object>
-                            </child>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="on_toggle_show_all_toggled" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="options_box">
+                          <object class="GtkCheckButton" id="toggle_show_unversioned">
+                            <property name="label" translatable="yes">Show unversioned files</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkCheckButton" id="toggle_show_all">
-                                <property name="label" translatable="yes">Select / Deselect all</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="on_toggle_show_all_toggled" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="toggle_show_unversioned">
-                                <property name="label" translatable="yes">Show unversioned files</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="active">True</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="on_toggle_show_unversioned_toggled" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="on_toggle_show_unversioned_toggled" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -261,6 +259,11 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -295,8 +298,8 @@
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -311,9 +314,10 @@
                   <object class="GtkImage" id="image1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="stock">gtk-refresh</property>
+                    <property name="icon_name">view-refresh</property>
                   </object>
                 </child>
+                <accelerator key="r" signal="clicked" modifiers="GDK_MOD1_MASK"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -329,11 +333,12 @@
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="cancel">
-                    <property name="label">gtk-cancel</property>
+                    <property name="label" translatable="yes">_Cancel</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
+                    <property name="image">rabbitvcs-cancel</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -344,11 +349,12 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="ok">
-                    <property name="label">gtk-ok</property>
+                    <property name="label" translatable="yes">_OK</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
+                    <property name="image">rabbitvcs-ok</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -373,9 +379,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child>
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/authentication.xml
+++ b/rabbitvcs/ui/xml/dialogs/authentication.xml
@@ -1,35 +1,47 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="Authentication">
     <property name="width_request">450</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Authentication</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
-    <property name="has_separator">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox4">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
-        <child>
-          <object class="GtkBox" id="vbox1">
-            <property name="orientation">vertical</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area4">
             <property name="visible">True</property>
-            <property name="border_width">6</property>
-            <property name="spacing">6</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
             <child>
-              <object class="GtkLabel" id="label2">
+              <object class="GtkButton" id="auth_cancel">
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">&lt;b&gt;Please add your authentication details&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -38,152 +50,218 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment11">
+              <object class="GtkButton" id="auth_ok">
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">6</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Please add your authentication details&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox3">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkBox" id="hbox2">
                     <property name="visible">True</property>
-                    <property name="spacing">6</property>
+                    <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkBox" id="hbox2">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkLabel" id="label3">
+                        <property name="width_request">100</property>
                         <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label3">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Realm:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="auth_realm">
-                            <property name="width_request">300</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="wrap">True</property>
-                            <property name="wrap_mode">char</property>
-                            <property name="selectable">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Realm:</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox3">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkLabel" id="auth_realm">
+                        <property name="width_request">300</property>
                         <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label4">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Login:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="auth_login">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="activates_default">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">False</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap_mode">char</property>
+                        <property name="selectable">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
                       </object>
                       <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkBox" id="hbox4">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkLabel" id="label4">
+                        <property name="width_request">100</property>
                         <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label5">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Password:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="auth_password">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="visibility">False</property>
-                            <property name="activates_default">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Login:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
-                        <property name="position">2</property>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox5">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkEntry" id="auth_login">
                         <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label6">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="auth_save">
-                            <property name="label" translatable="yes">Save Authentication</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="activates_default">True</property>
                       </object>
                       <packing>
-                        <property name="position">3</property>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label5">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Password:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="auth_password">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="visibility">False</property>
+                        <property name="activates_default">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox5">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label6">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="auth_save">
+                        <property name="label" translatable="yes">Save Authentication</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
                 </child>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -194,48 +272,6 @@
             <property name="position">1</property>
           </packing>
         </child>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area4">
-	    <property name="orientation">horizontal</property>
-            <property name="visible">True</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="auth_cancel">
-                <property name="label">gtk-cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="auth_ok">
-                <property name="label">gtk-ok</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
       </object>
     </child>
     <action-widgets>
@@ -243,7 +279,4 @@
       <action-widget response="-5">auth_ok</action-widget>
     </action-widgets>
   </object>
-
-
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/authentication.xml
+++ b/rabbitvcs/ui/xml/dialogs/authentication.xml
@@ -14,11 +14,13 @@
     <property name="type_hint">dialog</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox4">
+      <object class="GtkBox" id="dialog-vbox4">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox1">
+          <object class="GtkBox" id="vbox1">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="border_width">6</property>
             <property name="spacing">6</property>
@@ -40,11 +42,13 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox3">
+                  <object class="GtkBox" id="vbox3">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox2">
+                      <object class="GtkBox" id="hbox2">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label3">
@@ -80,7 +84,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox3">
+                      <object class="GtkBox" id="hbox3">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label4">
@@ -111,7 +116,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox4">
+                      <object class="GtkBox" id="hbox4">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label5">
@@ -143,7 +149,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox5">
+                      <object class="GtkBox" id="hbox5">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label6">
@@ -188,7 +195,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area4">
+          <object class="GtkButtonBox" id="dialog-action_area4">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>

--- a/rabbitvcs/ui/xml/dialogs/cert_authentication.xml
+++ b/rabbitvcs/ui/xml/dialogs/cert_authentication.xml
@@ -1,177 +1,46 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="CertAuthentication">
     <property name="width_request">400</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
-    <property name="has_separator">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox9">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
-        <child>
-          <object class="GtkBox" id="vbox2">
-            <property name="orientation">vertical</property>
-            <property name="visible">True</property>
-            <property name="border_width">6</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">&lt;b&gt;Please add your authentication details&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkAlignment" id="alignment3">
-                <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkBox" id="vbox10">
-                    <property name="orientation">vertical</property>
-                    <property name="visible">True</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkBox" id="hbox14">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label19">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Realm:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="certauth_realm">
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="wrap">True</property>
-                            <property name="selectable">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox1">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label21">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Password:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="certauth_password">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="visibility">False</property>
-                            <property name="activates_default">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox13">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label20">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="certauth_save">
-                            <property name="label" translatable="yes">Save Authentication</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area9">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="certauth_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -181,13 +50,14 @@
             </child>
             <child>
               <object class="GtkButton" id="certauth_ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -198,8 +68,168 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">6</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Please add your authentication details&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox10">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox" id="hbox14">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label19">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Realm:</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="certauth_realm">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="wrap">True</property>
+                        <property name="selectable">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label21">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Password:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="certauth_password">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="visibility">False</property>
+                        <property name="activates_default">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox13">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label20">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="certauth_save">
+                        <property name="label" translatable="yes">Save Authentication</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -209,8 +239,4 @@
       <action-widget response="-5">certauth_ok</action-widget>
     </action-widgets>
   </object>
-
-
-
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/cert_authentication.xml
+++ b/rabbitvcs/ui/xml/dialogs/cert_authentication.xml
@@ -12,11 +12,13 @@
     <property name="type_hint">dialog</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox9">
+      <object class="GtkBox" id="dialog-vbox9">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox2">
+          <object class="GtkBox" id="vbox2">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="border_width">6</property>
             <property name="spacing">6</property>
@@ -38,11 +40,13 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox10">
+                  <object class="GtkBox" id="vbox10">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox14">
+                      <object class="GtkBox" id="hbox14">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label19">
@@ -78,7 +82,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox1">
+                      <object class="GtkBox" id="hbox1">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label21">
@@ -110,7 +115,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox13">
+                      <object class="GtkBox" id="hbox13">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label20">
@@ -155,7 +161,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area9">
+          <object class="GtkButtonBox" id="dialog-action_area9">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>

--- a/rabbitvcs/ui/xml/dialogs/certificate.xml
+++ b/rabbitvcs/ui/xml/dialogs/certificate.xml
@@ -13,12 +13,14 @@
     <property name="type_hint">dialog</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox3">
+      <object class="GtkBox" id="dialog-vbox3">
+        <property name="orientation">vertical</property>
         <property name="width_request">400</property>
         <property name="visible">True</property>
         <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox4">
+          <object class="GtkBox" id="vbox4">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="border_width">6</property>
             <property name="spacing">6</property>
@@ -40,11 +42,13 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox5">
+                  <object class="GtkBox" id="vbox5">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox6">
+                      <object class="GtkBox" id="hbox6">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label7">
@@ -80,7 +84,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox7">
+                      <object class="GtkBox" id="hbox7">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label8">
@@ -116,7 +121,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox8">
+                      <object class="GtkBox" id="hbox8">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label9">
@@ -152,7 +158,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox9">
+                      <object class="GtkBox" id="hbox9">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label10">
@@ -188,7 +195,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox10">
+                      <object class="GtkBox" id="hbox10">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label11">
@@ -240,7 +248,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area3">
+          <object class="GtkButtonBox" id="dialog-action_area3">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">spread</property>
             <child>

--- a/rabbitvcs/ui/xml/dialogs/certificate.xml
+++ b/rabbitvcs/ui/xml/dialogs/certificate.xml
@@ -1,256 +1,29 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="Certificate">
     <property name="width_request">550</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Check Certificate</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
-    <property name="has_separator">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
-        <property name="orientation">vertical</property>
         <property name="width_request">400</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
-        <child>
-          <object class="GtkBox" id="vbox4">
-            <property name="orientation">vertical</property>
-            <property name="visible">True</property>
-            <property name="border_width">6</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkLabel" id="label12">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">&lt;b&gt;Certificate Details&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkAlignment" id="alignment1">
-                <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkBox" id="vbox5">
-                    <property name="orientation">vertical</property>
-                    <property name="visible">True</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkBox" id="hbox6">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label7">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Realm:</property>
-                            <property name="ellipsize">start</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="cert_realm">
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="wrap">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox7">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label8">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Host:</property>
-                            <property name="ellipsize">start</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="cert_host">
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="wrap">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox8">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label9">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Issuer:</property>
-                            <property name="ellipsize">start</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="cert_issuer">
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="wrap">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox9">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label10">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Valid:</property>
-                            <property name="ellipsize">start</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="cert_valid">
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="wrap">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox10">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label11">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Fingerprint:</property>
-                            <property name="ellipsize">start</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="cert_fingerprint">
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="wrap">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">4</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area3">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">spread</property>
             <child>
               <object class="GtkButton" id="cert_accept_once">
@@ -299,6 +72,253 @@
             <property name="position">0</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkBox" id="vbox4">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">6</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label12">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Certificate Details&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox5">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox" id="hbox6">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label7">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Realm:</property>
+                        <property name="ellipsize">start</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="cert_realm">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox7">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label8">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Host:</property>
+                        <property name="ellipsize">start</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="cert_host">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox8">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label9">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Issuer:</property>
+                        <property name="ellipsize">start</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="cert_issuer">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox9">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label10">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Valid:</property>
+                        <property name="ellipsize">start</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="cert_valid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox10">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label11">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Fingerprint:</property>
+                        <property name="ellipsize">start</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="cert_fingerprint">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
     </child>
     <action-widgets>
@@ -306,8 +326,4 @@
       <action-widget response="2">cert_accept_forever</action-widget>
     </action-widgets>
   </object>
-
-
-
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/confirmation.xml
+++ b/rabbitvcs/ui/xml/dialogs/confirmation.xml
@@ -13,11 +13,13 @@
     <property name="type_hint">dialog</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox7">
+      <object class="GtkBox" id="dialog-vbox7">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" orientation="horizontal" id="hbox15">
+          <object class="GtkBox" id="hbox15">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <child>
               <object class="GtkImage" id="image1">
@@ -54,7 +56,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area7">
+          <object class="GtkButtonBox" id="dialog-action_area7">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>

--- a/rabbitvcs/ui/xml/dialogs/confirmation.xml
+++ b/rabbitvcs/ui/xml/dialogs/confirmation.xml
@@ -1,32 +1,90 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-no">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-no</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-yes">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-yes</property>
+  </object>
   <object class="GtkDialog" id="Confirmation">
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Confirmation</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
-    <property name="has_separator">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox7">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area7">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="confirm_cancel">
+                <property name="label" translatable="yes">_No</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">rabbitvcs-no</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="confirm_ok">
+                <property name="label" translatable="yes">_Yes</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">rabbitvcs-yes</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkBox" id="hbox15">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkImage" id="image1">
                 <property name="width_request">75</property>
                 <property name="visible">True</property>
-                <property name="stock">gtk-dialog-warning</property>
-                <property name="icon-size">6</property>
+                <property name="can_focus">False</property>
+                <property name="pixel_size">48</property>
+                <property name="icon_name">dialog-warning</property>
+                <property name="icon_size">6</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -37,10 +95,11 @@
             <child>
               <object class="GtkLabel" id="confirm_message">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="xpad">6</property>
                 <property name="ypad">6</property>
                 <property name="label" translatable="yes">Are you sure you want to continue?</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -55,48 +114,6 @@
             <property name="position">1</property>
           </packing>
         </child>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area7">
-	    <property name="orientation">horizontal</property>
-            <property name="visible">True</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="confirm_cancel">
-                <property name="label">gtk-no</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="confirm_ok">
-                <property name="label">gtk-yes</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
       </object>
     </child>
     <action-widgets>
@@ -104,7 +121,4 @@
       <action-widget response="-5">confirm_ok</action-widget>
     </action-widgets>
   </object>
-
-
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/conflict_decision.xml
+++ b/rabbitvcs/ui/xml/dialogs/conflict_decision.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="ConflictDecision">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Edit Conflicts</property>
     <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox16">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area16">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">center</property>
@@ -81,23 +83,21 @@
         </child>
         <child>
           <object class="GtkBox" id="hbox1">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkBox" id="vbox1">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkImage" id="image1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xpad">25</property>
-                    <property name="ypad">25</property>
-                    <property name="stock">gtk-dialog-warning</property>
-                    <property name="icon-size">6</property>
+                    <property name="pixel_size">64</property>
+                    <property name="icon_name">dialog-warning</property>
+                    <property name="icon_size">6</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -114,19 +114,19 @@
             </child>
             <child>
               <object class="GtkBox" id="vbox2">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
                 <child>
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="yalign">0.10000000149011612</property>
                     <property name="label" translatable="yes">&lt;b&gt;A conflict was found in the following file:&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0.10000000149011612</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/dialogs/conflict_decision.xml
+++ b/rabbitvcs/ui/xml/dialogs/conflict_decision.xml
@@ -8,12 +8,14 @@
     <property name="title" translatable="yes">Edit Conflicts</property>
     <property name="type_hint">normal</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox16">
+      <object class="GtkBox" id="dialog-vbox16">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">12</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area16">
+          <object class="GtkButtonBox" id="dialog-action_area16">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">center</property>
@@ -78,12 +80,14 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="horizontal" id="hbox1">
+          <object class="GtkBox" id="hbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox1">
+              <object class="GtkBox" id="vbox1">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
@@ -109,7 +113,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox2">
+              <object class="GtkBox" id="vbox2">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>

--- a/rabbitvcs/ui/xml/dialogs/create_folder.xml
+++ b/rabbitvcs/ui/xml/dialogs/create_folder.xml
@@ -12,15 +12,18 @@
     <property name="type_hint">normal</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox12">
+      <object class="GtkBox" id="dialog-vbox12">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox1">
+          <object class="GtkBox" id="vbox1">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkBox" orientation="horizontal" id="vbox3">
+              <object class="GtkBox" id="vbox3">
+		<property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="spacing">6</property>
                 <child>
@@ -59,7 +62,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox2">
+              <object class="GtkBox" id="vbox2">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="spacing">6</property>
                 <child>
@@ -110,7 +114,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area12">
+          <object class="GtkButtonBox" id="dialog-action_area12">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>

--- a/rabbitvcs/ui/xml/dialogs/create_folder.xml
+++ b/rabbitvcs/ui/xml/dialogs/create_folder.xml
@@ -1,56 +1,115 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="CreateFolder">
     <property name="width_request">320</property>
     <property name="height_request">240</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Create Folder...</property>
     <property name="type_hint">normal</property>
-    <property name="has_separator">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox12">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area12">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="cancel">
+                <property name="label" translatable="yes">_Cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ok">
+                <property name="label" translatable="yes">_OK</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="has_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkBox" id="vbox1">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkBox" id="vbox3">
-		<property name="orientation">horizontal</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
-                    <property name="xalign">0</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Folder Name&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment2">
+                  <object class="GtkEntry" id="folder_name">
                     <property name="visible">True</property>
-                    <property name="left_padding">12</property>
-                    <child>
-                      <object class="GtkEntry" id="folder_name">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="invisible_char">&#x25CF;</property>
-                        <signal handler="on_folder_name_changed" name="changed"/>
-                      </object>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="margin_left">12</property>
+                    <property name="invisible_char">●</property>
+                    <signal name="changed" handler="on_folder_name_changed" swapped="no"/>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -63,15 +122,17 @@
             </child>
             <child>
               <object class="GtkBox" id="vbox2">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label2">
                     <property name="visible">True</property>
-                    <property name="xalign">0</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Add Message&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -80,80 +141,36 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment1">
+                  <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
-                    <property name="left_padding">12</property>
+                    <property name="can_focus">True</property>
+                    <property name="margin_left">12</property>
+                    <property name="shadow_type">etched-in</property>
                     <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow1">
+                      <object class="GtkTextView" id="log_message">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">automatic</property>
-                        <property name="vscrollbar_policy">automatic</property>
-                        <property name="shadow_type">etched-in</property>
-                        <child>
-                          <object class="GtkTextView" id="log_message">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                          </object>
-                        </child>
                       </object>
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
-          </packing>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area12">
-	    <property name="orientation">horizontal</property>
-            <property name="visible">True</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
           </packing>
         </child>
       </object>
@@ -163,8 +180,4 @@
       <action-widget response="-5">ok</action-widget>
     </action-widgets>
   </object>
-
-
-
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/delete_confirmation.xml
+++ b/rabbitvcs/ui/xml/dialogs/delete_confirmation.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="edit-delete">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">edit-delete</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
   <object class="GtkDialog" id="DeleteConfirmation">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -9,6 +19,9 @@
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox10">
         <property name="visible">True</property>
@@ -22,11 +35,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -36,13 +50,14 @@
             </child>
             <child>
               <object class="GtkButton" id="delete">
-                <property name="label">gtk-delete</property>
+                <property name="label" translatable="yes">_Delete</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">edit-delete</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -67,7 +82,8 @@
                 <property name="width_request">75</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="stock">gtk-dialog-warning</property>
+                <property name="pixel_size">64</property>
+                <property name="icon_name">dialog-warning</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>
@@ -130,8 +146,5 @@
       <action-widget response="-6">cancel</action-widget>
       <action-widget response="-5">delete</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/error_notification.xml
+++ b/rabbitvcs/ui/xml/dialogs/error_notification.xml
@@ -13,11 +13,13 @@
     <property name="type_hint">normal</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox15">
+      <object class="GtkBox" id="dialog-vbox15">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkBox" orientation="horizontal" id="hbox1">
+          <object class="GtkBox" id="hbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <child>
@@ -48,7 +50,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="horizontal" id="notice_box">
+          <object class="GtkBox" id="notice_box">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <child>
               <placeholder/>
@@ -80,7 +83,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area15">
+          <object class="GtkButtonBox" id="dialog-action_area15">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>

--- a/rabbitvcs/ui/xml/dialogs/error_notification.xml
+++ b/rabbitvcs/ui/xml/dialogs/error_notification.xml
@@ -1,64 +1,107 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="window-close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkDialog" id="ErrorNotification">
     <property name="width_request">500</property>
     <property name="height_request">300</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">RabbitVCS Error</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">normal</property>
-    <property name="has_separator">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox15">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">6</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area15">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label" translatable="yes">_Close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">window-close</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkBox" id="hbox1">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkImage" id="image1">
                 <property name="visible">True</property>
-                <property name="stock">gtk-dialog-warning</property>
-                <property name="icon-size">6</property>
+                <property name="can_focus">False</property>
+                <property name="pixel_size">64</property>
+                <property name="icon_name">dialog-warning</property>
+                <property name="icon_size">6</property>
               </object>
               <packing>
                 <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;span weight="bold" size="xx-large"&gt;RabbitVCS Error&lt;/span&gt;</property>
                 <property name="use_markup">True</property>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="notice_box">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
               <placeholder/>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">2</property>
           </packing>
         </child>
@@ -66,8 +109,6 @@
           <object class="GtkScrolledWindow" id="scrolledwindow1">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="hscrollbar_policy">automatic</property>
-            <property name="vscrollbar_policy">automatic</property>
             <property name="shadow_type">etched-in</property>
             <child>
               <object class="GtkTextView" id="error_text">
@@ -79,40 +120,12 @@
             </child>
           </object>
           <packing>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area15">
-	    <property name="orientation">horizontal</property>
-            <property name="visible">True</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="button1">
-                <property name="label">gtk-close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
             <property name="expand">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>
     </child>
   </object>
-
-
-
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/loading.xml
+++ b/rabbitvcs/ui/xml/dialogs/loading.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
   <object class="GtkDialog" id="Loading">
     <property name="width_request">300</property>
     <property name="visible">True</property>
@@ -14,6 +19,9 @@
     <property name="type_hint">dialog</property>
     <property name="gravity">center</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox13">
         <property name="visible">True</property>
@@ -29,12 +37,13 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="loading_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_loading_cancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -64,9 +73,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child>
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/mark_resolved_prompt.xml
+++ b/rabbitvcs/ui/xml/dialogs/mark_resolved_prompt.xml
@@ -10,12 +10,14 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox2">
+      <object class="GtkBox" id="dialog-vbox2">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area2">
+          <object class="GtkButtonBox" id="dialog-action_area2">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>

--- a/rabbitvcs/ui/xml/dialogs/message_box.xml
+++ b/rabbitvcs/ui/xml/dialogs/message_box.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="MessageBox">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -10,6 +15,9 @@
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox8">
         <property name="visible">True</property>
@@ -23,11 +31,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="messagebox_ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -63,8 +72,5 @@
     <action-widgets>
       <action-widget response="1">messagebox_ok</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/name_email_prompt.xml
+++ b/rabbitvcs/ui/xml/dialogs/name_email_prompt.xml
@@ -15,7 +15,8 @@
     <property name="has_separator">False</property>
     <signal handler="on_key_release_event" name="key_release_event"/>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox18">
+      <object class="GtkBox" id="dialog-vbox18">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="spacing">12</property>
         <child>
@@ -36,11 +37,13 @@
             <property name="visible">True</property>
             <property name="left_padding">12</property>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox1">
+              <object class="GtkBox" id="vbox1">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" orientation="horizontal" id="hbox1">
+                  <object class="GtkBox" id="hbox1">
+		    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <child>
                       <object class="GtkLabel" id="label2">
@@ -74,7 +77,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" orientation="horizontal" id="hbox2">
+                  <object class="GtkBox" id="hbox2">
+		    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <child>
                       <object class="GtkLabel" id="label3">
@@ -115,7 +119,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area18">
+          <object class="GtkButtonBox" id="dialog-action_area18">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>

--- a/rabbitvcs/ui/xml/dialogs/name_email_prompt.xml
+++ b/rabbitvcs/ui/xml/dialogs/name_email_prompt.xml
@@ -1,135 +1,47 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="NameEmailPrompt">
     <property name="width_request">400</property>
+    <property name="can_focus">False</property>
     <property name="border_width">12</property>
     <property name="title" translatable="yes">Name and Email</property>
     <property name="window_position">center-on-parent</property>
     <property name="type_hint">normal</property>
-    <property name="has_separator">False</property>
-    <signal handler="on_key_release_event" name="key_release_event"/>
+    <signal name="key-release-event" handler="on_key_release_event" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox18">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
-        <child>
-          <object class="GtkLabel" id="label1">
-            <property name="visible">True</property>
-            <property name="xalign">0</property>
-            <property name="label" translatable="yes">&lt;b&gt;Enter Name and Email Details&lt;/b&gt;</property>
-            <property name="use_markup">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkAlignment" id="alignment1">
-            <property name="visible">True</property>
-            <property name="left_padding">12</property>
-            <child>
-              <object class="GtkBox" id="vbox1">
-                <property name="orientation">vertical</property>
-                <property name="visible">True</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkBox" id="hbox1">
-		    <property name="orientation">horizontal</property>
-                    <property name="visible">True</property>
-                    <child>
-                      <object class="GtkLabel" id="label2">
-                        <property name="width_request">90</property>
-                        <property name="visible">True</property>
-                        <property name="xalign">0</property>
-                        <property name="label" translatable="yes">Name:</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="name">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="invisible_char">&#x25CF;</property>
-                        <property name="invisible_char_set">True</property>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="hbox2">
-		    <property name="orientation">horizontal</property>
-                    <property name="visible">True</property>
-                    <child>
-                      <object class="GtkLabel" id="label3">
-                        <property name="width_request">90</property>
-                        <property name="visible">True</property>
-                        <property name="xalign">0</property>
-                        <property name="label" translatable="yes">Email:</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="email">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="invisible_char">&#x25CF;</property>
-                        <property name="invisible_char_set">True</property>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="position">2</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area18">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -139,11 +51,12 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -154,8 +67,111 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">&lt;b&gt;Enter Name and Email Details&lt;/b&gt;</property>
+            <property name="use_markup">True</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">12</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkBox" id="hbox1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="label2">
+                    <property name="width_request">90</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Name:</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="name">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">●</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="hbox2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="label3">
+                    <property name="width_request">90</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Email:</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="email">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">●</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
@@ -165,5 +181,4 @@
       <action-widget response="-5">ok</action-widget>
     </action-widgets>
   </object>
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/one_line_text_change.xml
+++ b/rabbitvcs/ui/xml/dialogs/one_line_text_change.xml
@@ -1,70 +1,47 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="OneLineTextChange">
     <property name="width_request">500</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Text Change</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">normal</property>
-    <signal handler="on_key_release_event" name="key_release_event"/>
+    <signal name="key-release-event" handler="on_key_release_event" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox13">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">12</property>
-        <child>
-          <object class="GtkBox" id="hbox1">
-            <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
-            <child>
-              <object class="GtkLabel" id="label">
-                <property name="width_request">100</property>
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">New Name:</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="new_text">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="invisible_char">&#x25CF;</property>
-              </object>
-              <packing>
-                <property name="position">1</property>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area13">
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -74,7 +51,7 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="has_focus">True</property>
@@ -82,7 +59,8 @@
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -98,6 +76,43 @@
             <property name="position">0</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkBox" id="hbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel" id="label">
+                <property name="width_request">100</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">New Name:</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="new_text">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="invisible_char">●</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
     </child>
     <action-widgets>
@@ -105,7 +120,4 @@
       <action-widget response="-5">ok</action-widget>
     </action-widgets>
   </object>
-
-
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/previous_messages.xml
+++ b/rabbitvcs/ui/xml/dialogs/previous_messages.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="PreviousMessages">
     <property name="width_request">500</property>
     <property name="can_focus">False</property>
@@ -11,6 +21,9 @@
     <property name="default_width">450</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -24,11 +37,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="prevmes_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -38,11 +52,12 @@
             </child>
             <child>
               <object class="GtkButton" id="prevmes_ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -80,37 +95,31 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
+              <object class="GtkScrolledWindow" id="scrolledwindow4">
+                <property name="height_request">200</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">True</property>
+                <property name="margin_left">12</property>
+                <property name="shadow_type">etched-in</property>
                 <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow4">
-                    <property name="height_request">200</property>
+                  <object class="GtkTreeView" id="prevmes_table">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="shadow_type">etched-in</property>
-                    <child>
-                      <object class="GtkTreeView" id="prevmes_table">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <child internal-child="selection">
-                          <object class="GtkTreeSelection"/>
-                        </child>
-                      </object>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
                     </child>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
+                <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
@@ -137,35 +146,29 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment5">
+              <object class="GtkScrolledWindow" id="scrolledwindow5">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">True</property>
+                <property name="margin_left">12</property>
+                <property name="shadow_type">etched-in</property>
                 <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow5">
+                  <object class="GtkTextView" id="prevmes_message">
+                    <property name="height_request">100</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="shadow_type">etched-in</property>
-                    <child>
-                      <object class="GtkTextView" id="prevmes_message">
-                        <property name="height_request">100</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="wrap_mode">word</property>
-                      </object>
-                    </child>
+                    <property name="wrap_mode">word</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
+                <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">2</property>
           </packing>
@@ -176,8 +179,5 @@
       <action-widget response="-6">prevmes_cancel</action-widget>
       <action-widget response="-5">prevmes_ok</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/property.xml
+++ b/rabbitvcs/ui/xml/dialogs/property.xml
@@ -15,11 +15,13 @@
     <property name="type_hint">dialog</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox5">
+      <object class="GtkBox" id="dialog-vbox5">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox8">
+          <object class="GtkBox" id="vbox8">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="border_width">6</property>
             <property name="spacing">6</property>
@@ -41,11 +43,13 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox9">
+                  <object class="GtkBox" id="vbox9">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox11">
+                      <object class="GtkBox" id="hbox11">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label16">
@@ -61,8 +65,9 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxEntry" id="property_name">
+                          <object class="GtkComboBoxText" id="property_name">
                             <property name="visible">True</property>
+                            <property name="has-entry">True</property>
                             <property name="can_focus">True</property>
                           </object>
                           <packing>
@@ -77,7 +82,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox12">
+                      <object class="GtkBox" id="hbox12">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label17">
@@ -119,7 +125,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox17">
+                      <object class="GtkBox" id="hbox17">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label18">
@@ -167,7 +174,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area5">
+          <object class="GtkButtonBox" id="dialog-action_area5">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>

--- a/rabbitvcs/ui/xml/dialogs/property.xml
+++ b/rabbitvcs/ui/xml/dialogs/property.xml
@@ -1,190 +1,47 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="Property">
-    <property name="default_width">600</property>
-    <property name="default_height">400</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Property</property>
     <property name="window_position">center</property>
+    <property name="default_width">600</property>
+    <property name="default_height">400</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
-    <property name="has_separator">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox5">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
-        <child>
-          <object class="GtkBox" id="vbox8">
-            <property name="orientation">vertical</property>
-            <property name="visible">True</property>
-            <property name="border_width">6</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkLabel" id="label15">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">&lt;b&gt;Edit Property Details&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkAlignment" id="alignment12">
-                <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkBox" id="vbox9">
-                    <property name="orientation">vertical</property>
-                    <property name="visible">True</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkBox" id="hbox11">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label16">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Property:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBoxText" id="property_name">
-                            <property name="visible">True</property>
-                            <property name="has-entry">True</property>
-                            <property name="can_focus">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox12">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label17">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0.05000000074505806</property>
-                            <property name="label" translatable="yes">Value:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow1">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">automatic</property>
-                            <property name="vscrollbar_policy">automatic</property>
-                            <property name="shadow_type">etched-in</property>
-                            <child>
-                              <object class="GtkTextView" id="property_value">
-                                <property name="height_request">100</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="wrap_mode">word</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox17">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label18">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="property_recurse">
-                            <property name="label" translatable="yes">Apply property recursively</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area5">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="property_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -194,13 +51,14 @@
             </child>
             <child>
               <object class="GtkButton" id="property_ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -211,8 +69,178 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox8">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">6</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label15">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Edit Property Details&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox9">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox" id="hbox11">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label16">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Property:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="property_name">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="has_entry">True</property>
+                        <child internal-child="entry">
+                          <object class="GtkEntry">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox12">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label17">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Value:</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.05000000074505806</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">etched-in</property>
+                        <child>
+                          <object class="GtkTextView" id="property_value">
+                            <property name="height_request">100</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="wrap_mode">word</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox17">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label18">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="property_recurse">
+                        <property name="label" translatable="yes">Apply property recursively</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -222,7 +250,4 @@
       <action-widget response="-5">property_ok</action-widget>
     </action-widgets>
   </object>
-
-
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/ssl_client_cert_prompt.xml
+++ b/rabbitvcs/ui/xml/dialogs/ssl_client_cert_prompt.xml
@@ -14,11 +14,13 @@
     <property name="type_hint">dialog</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox9">
+      <object class="GtkBox" id="dialog-vbox9">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox1">
+          <object class="GtkBox" id="vbox1">
+          <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <child>
@@ -39,11 +41,13 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox2">
+                  <object class="GtkBox" id="vbox2">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox2">
+                      <object class="GtkBox" id="hbox2">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label2">
@@ -73,7 +77,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox1">
+                      <object class="GtkBox" id="hbox1">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="spacing">2</property>
                         <child>
@@ -151,7 +156,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area9">
+          <object class="GtkButtonBox" id="dialog-action_area9">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>

--- a/rabbitvcs/ui/xml/dialogs/ssl_client_cert_prompt.xml
+++ b/rabbitvcs/ui/xml/dialogs/ssl_client_cert_prompt.xml
@@ -1,173 +1,48 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="SSLClientCertPrompt">
     <property name="width_request">400</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">SSL Client Certification</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
-    <property name="has_separator">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox9">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
-        <child>
-          <object class="GtkBox" id="vbox1">
-          <property name="orientation">vertical</property>
-            <property name="visible">True</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">&lt;b&gt;Please provide your ssl certification file&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkAlignment" id="alignment1">
-                <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkBox" id="vbox2">
-                    <property name="orientation">vertical</property>
-                    <property name="visible">True</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkBox" id="hbox2">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label2">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Realm:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="sslclientcert_realm">
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox1">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <property name="spacing">2</property>
-                        <child>
-                          <object class="GtkLabel" id="label3">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Path:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="sslclientcert_path">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="invisible_char">&#x25CF;</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="sslclientcert_browse">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <signal handler="on_sslclientcert_browse_clicked" name="clicked"/>
-                            <child>
-                              <object class="GtkImage" id="image1">
-                                <property name="visible">True</property>
-                                <property name="stock">gtk-harddisk</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="sslclientcert_save">
-                        <property name="label" translatable="yes">Save Authentication</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="xalign">0.4699999988079071</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area9">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="sslclientcert_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_sslclientcert_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_sslclientcert_cancel_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -177,11 +52,12 @@
             </child>
             <child>
               <object class="GtkButton" id="sslclientcert_ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -192,8 +68,185 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Please provide your ssl certification file&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox" id="hbox2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label2">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Realm:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="sslclientcert_realm">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">2</property>
+                    <child>
+                      <object class="GtkLabel" id="label3">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Path:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="sslclientcert_path">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="invisible_char">●</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="sslclientcert_browse">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_sslclientcert_browse_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="image1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">drive-harddisk</property>
+                          </object>
+                        </child>
+                        <accelerator key="p" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="sslclientcert_save">
+                        <property name="label" translatable="yes">Save Authentication</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="xalign">0.4699999988079071</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -203,7 +256,4 @@
       <action-widget response="-5">sslclientcert_ok</action-widget>
     </action-widgets>
   </object>
-
-
-
 </interface>

--- a/rabbitvcs/ui/xml/dialogs/text_change.xml
+++ b/rabbitvcs/ui/xml/dialogs/text_change.xml
@@ -16,12 +16,14 @@
     <property name="type_hint">dialog</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <object class="GtkBox" orientation="vertical" id="dialog-vbox12">
+      <object class="GtkBox" id="dialog-vbox12">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox12">
+          <object class="GtkBox" id="vbox12">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="spacing">6</property>
@@ -73,7 +75,8 @@
           </packing>
         </child>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" orientation="horizontal" id="dialog-action_area12">
+          <object class="GtkButtonBox" id="dialog-action_area12">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="layout_style">end</property>

--- a/rabbitvcs/ui/xml/dialogs/text_change.xml
+++ b/rabbitvcs/ui/xml/dialogs/text_change.xml
@@ -1,93 +1,51 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
-
-
-
-
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkDialog" id="TextChange">
     <property name="width_request">350</property>
     <property name="height_request">200</property>
+    <property name="can_focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="border_width">5</property>
     <property name="window_position">center-on-parent</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="type_hint">dialog</property>
-    <property name="has_separator">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox12">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">12</property>
-        <child>
-          <object class="GtkBox" id="vbox12">
-            <property name="orientation">vertical</property>
-            <property name="visible">True</property>
-            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkLabel" id="label22">
-                <property name="visible">True</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">&lt;b&gt;Message&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkAlignment" id="alignment4">
-                <property name="visible">True</property>
-                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkScrolledWindow" id="textchange_scrollwin">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
-                    <property name="shadow_type">etched-in</property>
-                    <child>
-                      <object class="GtkTextView" id="textchange_message">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="wrap_mode">word</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area12">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="textchange_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -97,7 +55,7 @@
             </child>
             <child>
               <object class="GtkButton" id="textchange_ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="has_focus">True</property>
@@ -105,7 +63,8 @@
                 <property name="has_default">True</property>
                 <property name="receives_default">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -116,8 +75,60 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox12">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label22">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="label" translatable="yes">&lt;b&gt;Message&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow" id="textchange_scrollwin">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="margin_left">12</property>
+                <property name="shadow_type">etched-in</property>
+                <child>
+                  <object class="GtkTextView" id="textchange_message">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="wrap_mode">word</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -127,6 +138,4 @@
       <action-widget response="-5">textchange_ok</action-widget>
     </action-widgets>
   </object>
-
-
 </interface>

--- a/rabbitvcs/ui/xml/git-update.xml
+++ b/rabbitvcs/ui/xml/git-update.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvxs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Update">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -9,6 +19,9 @@
     <property name="window_position">center-always</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
@@ -37,17 +50,18 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="repository_container">
+              <object class="GtkBox" id="repository_container">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
+                <property name="fill">False</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -66,11 +80,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -81,11 +96,12 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
@@ -114,13 +130,14 @@
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="on_apply_changes_toggled" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -128,40 +145,19 @@
               <object class="GtkBox" id="vbox5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">5</property>
                 <child>
-                  <object class="GtkBox" id="hbox4">
+                  <object class="GtkRadioButton" id="merge">
+                    <property name="label" translatable="yes">merge into local branch</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkLabel" id="label5">
-                        <property name="width_request">30</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="merge">
-                        <property name="label" translatable="yes">merge into local branch</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="relief">none</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="relief">none</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -170,38 +166,15 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="hbox5">
+                  <object class="GtkRadioButton" id="rebase">
+                    <property name="label" translatable="yes">apply remote changes prior to local changes (rebase)</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkLabel" id="label6">
-                        <property name="width_request">30</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="rebase">
-                        <property name="label" translatable="yes">apply remote changes prior to local changes (rebase)</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="relief">none</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                        <property name="group">merge</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="relief">none</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -224,34 +197,21 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="hbox3">
+          <object class="GtkCheckButton" id="all">
+            <property name="label" translatable="yes">Fetch from all remotes</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <object class="GtkCheckButton" id="all">
-                <property name="label" translatable="yes">Fetch from all remotes</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="halign">start</property>
+            <property name="draw_indicator">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="position">3</property>
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/ignore.xml
+++ b/rabbitvcs/ui/xml/ignore.xml
@@ -1,34 +1,49 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.14 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Ignore">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Ignore</property>
     <property name="window_position">center-always</property>
     <property name="icon_name">rabbitvcs</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox2">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="yalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Ignore and exclude files from being tracked&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -37,36 +52,43 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="fileeditor_container">
+              <object class="GtkBox" id="fileeditor_container">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox1">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -76,12 +98,12 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-ok</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/ignore.xml
+++ b/rabbitvcs/ui/xml/ignore.xml
@@ -10,13 +10,15 @@
     <signal handler="on_destroy" name="destroy"/>
     <signal handler="on_key_pressed" name="key_press_event"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox2">
+          <object class="GtkBox" id="vbox2">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -52,7 +54,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>

--- a/rabbitvcs/ui/xml/import.xml
+++ b/rabbitvcs/ui/xml/import.xml
@@ -10,13 +10,13 @@
     <signal handler="on_destroy" name="destroy"/>
     <signal handler="on_key_pressed" name="key_press_event"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox16">
+      <object class="GtkBox" id="vbox16">
         <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox1">
+          <object class="GtkBox" id="vbox1">
             <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
@@ -37,13 +37,14 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox17">
+                  <object class="GtkBox" id="vbox17">
                     <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkComboBoxEntry" id="repositories">
+                      <object class="GtkComboBoxText" id="repositories">
                         <property name="visible">True</property>
+                        <property name="has-entry">True</property>
                         <child internal-child="entry">
                           <object class="GtkEntry" id="repository">
                             <property name="visible">True</property>
@@ -64,7 +65,7 @@
           </object>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox2">
+          <object class="GtkBox" id="vbox2">
             <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
@@ -85,12 +86,13 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox18">
+                  <object class="GtkBox" id="vbox18">
                     <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox12">
+                      <object class="GtkButtonBox" id="hbuttonbox12">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="layout_style">GTK_BUTTONBOX_START</property>
                         <child>
@@ -156,7 +158,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox11">
+          <object class="GtkButtonBox" id="hbuttonbox11">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <property name="layout_style">GTK_BUTTONBOX_END</property>

--- a/rabbitvcs/ui/xml/import.xml
+++ b/rabbitvcs/ui/xml/import.xml
@@ -1,188 +1,233 @@
-<?xml version="1.0"?>
-<!--Generated with glade3 3.4.5 on Thu Jan 29 16:44:40 2009 -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Import">
     <property name="width_request">550</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Import</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox16">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox1">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Repository&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkAlignment" id="alignment14">
-                <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkBox" id="vbox17">
-                    <property name="orientation">vertical</property>
-                    <property name="visible">True</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkComboBoxText" id="repositories">
-                        <property name="visible">True</property>
-                        <property name="has-entry">True</property>
-                        <child internal-child="entry">
-                          <object class="GtkEntry" id="repository">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox" id="vbox2">
-            <property name="orientation">vertical</property>
-            <property name="visible">True</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkLabel" id="label2">
-                <property name="visible">True</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">&lt;b&gt;Import Message&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment1">
+              <object class="GtkBox" id="vbox17">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox18">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkComboBoxText" id="repositories">
                     <property name="visible">True</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkButtonBox" id="hbuttonbox12">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <property name="layout_style">GTK_BUTTONBOX_START</property>
-                        <child>
-                          <object class="GtkButton" id="previous_messages">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="label" translatable="yes">Previous Messages</property>
-                            <signal handler="on_previous_messages_clicked" name="clicked"/>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow13">
-                        <property name="height_request">150</property>
+                    <property name="can_focus">False</property>
+                    <property name="has_entry">True</property>
+                    <child internal-child="entry">
+                      <object class="GtkEntry" id="repository">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="shadow_type">GTK_SHADOW_ETCHED_IN</property>
-                        <child>
-                          <object class="GtkTextView" id="message">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="wrap_mode">GTK_WRAP_WORD</property>
-                          </object>
-                        </child>
                       </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="include_ignored">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="label" translatable="yes">Include ignored files</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Import Message&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox18">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkButtonBox" id="hbuttonbox12">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="layout_style">start</property>
+                    <child>
+                      <object class="GtkButton" id="previous_messages">
+                        <property name="label" translatable="yes">Previous Messages</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_previous_messages_clicked" swapped="no"/>
+                        <accelerator key="p" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow13">
+                    <property name="height_request">150</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">etched-in</property>
+                    <child>
+                      <object class="GtkTextView" id="message">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="wrap_mode">word</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="include_ignored">
+                    <property name="label" translatable="yes">Include ignored files</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox11">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="label">gtk-cancel</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="ok">
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="label">gtk-ok</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -190,7 +235,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="pack_type">GTK_PACK_END</property>
+            <property name="pack_type">end</property>
             <property name="position">2</property>
           </packing>
         </child>

--- a/rabbitvcs/ui/xml/lock.xml
+++ b/rabbitvcs/ui/xml/lock.xml
@@ -1,32 +1,49 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.6 -->
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Lock">
     <property name="width_request">600</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Lock Files</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox3">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Please describe why you are locking these files&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -35,32 +52,25 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment1">
+              <object class="GtkBox" id="vbox4">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox4">
+                  <object class="GtkButtonBox" id="hbuttonbox2">
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
+                    <property name="can_focus">False</property>
+                    <property name="layout_style">start</property>
                     <child>
-                      <object class="GtkButtonBox" id="hbuttonbox2">
+                      <object class="GtkButton" id="previous_messages">
+                        <property name="label" translatable="yes">Previous Messages</property>
                         <property name="visible">True</property>
-                        <property name="layout_style">start</property>
-                        <child>
-                          <object class="GtkButton" id="previous_messages">
-                            <property name="label" translatable="yes">Previous Messages</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <signal handler="on_previous_messages_clicked" name="clicked"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_previous_messages_clicked" swapped="no"/>
+                        <accelerator key="p" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -68,34 +78,37 @@
                         <property name="position">0</property>
                       </packing>
                     </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow2">
+                    <property name="height_request">100</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">etched-in</property>
                     <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow2">
-                        <property name="height_request">100</property>
+                      <object class="GtkTextView" id="message">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">automatic</property>
-                        <property name="vscrollbar_policy">automatic</property>
-                        <property name="shadow_type">etched-in</property>
-                        <child>
-                          <object class="GtkTextView" id="message">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="wrap_mode">word</property>
-                          </object>
-                        </child>
+                        <property name="wrap_mode">word</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -109,14 +122,16 @@
         <child>
           <object class="GtkBox" id="vbox5">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Files to lock&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -125,117 +140,125 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
+              <object class="GtkBox" id="vbox2">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox2">
+                  <object class="GtkScrolledWindow" id="scrolledwindow1">
+                    <property name="height_request">250</property>
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">etched-in</property>
                     <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow1">
-                        <property name="height_request">250</property>
+                      <object class="GtkTreeView" id="files_table">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">automatic</property>
-                        <property name="vscrollbar_policy">automatic</property>
-                        <property name="shadow_type">etched-in</property>
-                        <child>
-                          <object class="GtkTreeView" id="files_table">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                          </object>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
                         </child>
                       </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="vbox6">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkCheckButton" id="select_all">
+                        <property name="label" translatable="yes">Select / Deselect all</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_select_all_toggled" swapped="no"/>
+                      </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="vbox6">
+                      <object class="GtkCheckButton" id="steal_locks">
+                        <property name="label" translatable="yes">Steal the locks</property>
                         <property name="visible">True</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkCheckButton" id="select_all">
-                            <property name="label" translatable="yes">Select / Deselect all</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <signal handler="on_select_all_toggled" name="toggled"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="steal_locks">
-                            <property name="label" translatable="yes">Steal the locks</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="draw_indicator">True</property>
-                            <!--<signal handler="on_steal_locks_toggled" name="toggled"/>-->
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="draw_indicator">True</property>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkLabel" id="status">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
+                <property name="margin_right">6</property>
                 <property name="width_chars">0</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkButtonBox" id="hbuttonbox1">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="spacing">6</property>
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="cancel">
-                    <property name="label">gtk-cancel</property>
+                    <property name="label" translatable="yes">_Cancel</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
-                    <signal handler="on_cancel_clicked" name="clicked"/>
+                    <property name="image">rabbitvcs-cancel</property>
+                    <property name="use_underline">True</property>
+                    <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -245,12 +268,13 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="ok">
-                    <property name="label">gtk-ok</property>
+                    <property name="label" translatable="yes">_OK</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
-                    <signal handler="on_ok_clicked" name="clicked"/>
+                    <property name="image">rabbitvcs-ok</property>
+                    <property name="use_underline">True</property>
+                    <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/log.xml
+++ b/rabbitvcs/ui/xml/log.xml
@@ -1,9 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="go-next">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-next</property>
+  </object>
+  <object class="GtkImage" id="go-previous">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-previous</property>
+  </object>
   <object class="GtkTextBuffer" id="search_buffer">
     <signal name="changed" handler="on_search" swapped="no"/>
+  </object>
+  <object class="GtkImage" id="window-close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
   </object>
   <object class="GtkWindow" id="Log">
     <property name="width_request">775</property>
@@ -15,189 +30,40 @@
     <property name="icon_name">rabbitvcs-small</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox11">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="hexpand">False</property>
         <property name="vexpand">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <placeholder/>
-        </child>
-        <child>
-          <object class="GtkBox" id="hbox3">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">12</property>
-            <child>
-              <object class="GtkBox" id="hbox8">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkButtonBox" id="hbuttonbox1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <property name="layout_style">start</property>
-                    <child>
-                      <object class="GtkButton" id="previous">
-                        <property name="label">gtk-go-back</property>
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="use_stock">True</property>
-                        <signal name="clicked" handler="on_previous_clicked" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="next">
-                        <property name="label">gtk-go-forward</property>
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="use_stock">True</property>
-                        <signal name="clicked" handler="on_next_clicked" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="hbox2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkLabel" id="label5">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Limit:</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="limit">
-                        <property name="width_request">75</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="text" translatable="yes">100</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="refresh">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Refresh</property>
-                        <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
-                        <child>
-                          <object class="GtkImage" id="image1">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="stock">gtk-refresh</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButtonBox" id="hbuttonbox7">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">6</property>
-                <property name="layout_style">end</property>
-                <child>
-                  <object class="GtkButton" id="ok">
-                    <property name="label">gtk-close</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
-                    <signal name="clicked" handler="on_close_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkPaned" id="vpaned1">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
             <property name="orientation">vertical</property>
+            <property name="position">274</property>
+            <property name="position_set">True</property>
             <child>
               <object class="GtkBox" id="vbox2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox" id="hbox5">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
                     <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label2">
@@ -329,39 +195,36 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment1">
+                  <object class="GtkBox" id="vbox4">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="vbox4">
+                      <object class="GtkScrolledWindow" id="scrolledwindow7">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="shadow_type">etched-in</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow7">
-                            <property name="height_request">180</property>
+                          <object class="GtkTreeView" id="revisions_table">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="shadow_type">etched-in</property>
-                            <child>
-                              <object class="GtkTreeView" id="revisions_table">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="rubber_banding">True</property>
-                                <child internal-child="selection">
-                                  <object class="GtkTreeSelection"/>
-                                </child>
-                              </object>
+                            <property name="rubber_banding">True</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -380,7 +243,11 @@
               <object class="GtkPaned" id="hpaned1">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="border_width">6</property>
+                <property name="margin_top">6</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="position">390</property>
+                <property name="position_set">True</property>
                 <child>
                   <object class="GtkBox" id="vbox3">
                     <property name="visible">True</property>
@@ -388,10 +255,12 @@
                     <property name="margin_right">6</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
+                    <property name="baseline_position">top</property>
                     <child>
                       <object class="GtkLabel" id="label3">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">&lt;b&gt;Affected File(s)&lt;/b&gt; (double-click to compare with base)</property>
                         <property name="use_markup">True</property>
                         <property name="xalign">0</property>
@@ -403,36 +272,34 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment2">
+                      <object class="GtkScrolledWindow" id="scrolledwindow8">
+                        <property name="height_request">80</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="shadow_type">etched-in</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow8">
-                            <property name="height_request">80</property>
+                          <object class="GtkTreeView" id="paths_table">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="shadow_type">etched-in</property>
-                            <child>
-                              <object class="GtkTreeView" id="paths_table">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <child internal-child="selection">
-                                  <object class="GtkTreeSelection"/>
-                                </child>
-                              </object>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
                             </child>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">True</property>
+                        <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="resize">False</property>
+                    <property name="resize">True</property>
                     <property name="shrink">True</property>
                   </packing>
                 </child>
@@ -443,10 +310,12 @@
                     <property name="margin_left">6</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
+                    <property name="baseline_position">top</property>
                     <child>
                       <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">&lt;b&gt;Message&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                         <property name="xalign">0</property>
@@ -458,28 +327,26 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment9">
+                      <object class="GtkScrolledWindow" id="scrolledwindow9">
+                        <property name="height_request">80</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="shadow_type">etched-in</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow9">
-                            <property name="height_request">80</property>
+                          <object class="GtkTextView" id="message">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="shadow_type">etched-in</property>
-                            <child>
-                              <object class="GtkTextView" id="message">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="editable">False</property>
-                                <property name="wrap_mode">word</property>
-                              </object>
-                            </child>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="editable">False</property>
+                            <property name="wrap_mode">word</property>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">True</property>
+                        <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
@@ -492,7 +359,7 @@
                 </child>
               </object>
               <packing>
-                <property name="resize">False</property>
+                <property name="resize">True</property>
                 <property name="shrink">True</property>
               </packing>
             </child>
@@ -500,13 +367,172 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="hbox3">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkBox" id="hbox8">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkButtonBox" id="hbuttonbox1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">6</property>
+                    <property name="layout_style">start</property>
+                    <child>
+                      <object class="GtkButton" id="previous">
+                        <property name="label" translatable="yes">_Back</property>
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">go-previous</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="on_previous_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="next">
+                        <property name="label" translatable="yes">_Forward</property>
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">go-next</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="on_next_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label5">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Limit:</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="limit">
+                        <property name="width_request">75</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="text" translatable="yes">100</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="refresh">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Refresh</property>
+                        <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="image1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">view-refresh</property>
+                          </object>
+                        </child>
+                        <accelerator key="r" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButtonBox" id="hbuttonbox7">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="spacing">6</property>
+                <property name="layout_style">end</property>
+                <child>
+                  <object class="GtkButton" id="close">
+                    <property name="label" translatable="yes">_Close</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="image">window-close</property>
+                    <property name="use_underline">True</property>
+                    <signal name="clicked" handler="on_close_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
             <property name="position">2</property>
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/manager.xml
+++ b/rabbitvcs/ui/xml/manager.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="window-close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkWindow" id="Manager">
     <property name="width_request">450</property>
     <property name="visible">True</property>
@@ -10,6 +15,9 @@
     <property name="icon_name">rabbitvcs-small</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
@@ -41,86 +49,76 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment1">
+                  <object class="GtkBox" id="hbox2">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="left_padding">12</property>
+                    <property name="margin_left">12</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="hbox2">
+                      <object class="GtkScrolledWindow" id="scrolledwindow1">
+                        <property name="width_request">200</property>
+                        <property name="height_request">150</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">6</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">etched-in</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow1">
-                            <property name="width_request">200</property>
-                            <property name="height_request">150</property>
+                          <object class="GtkTreeView" id="items_treeview">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="shadow_type">etched-in</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="vbox4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkButton" id="add">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <signal name="clicked" handler="on_add_clicked" swapped="no"/>
                             <child>
-                              <object class="GtkTreeView" id="items_treeview">
+                              <object class="GtkImage" id="image3">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <child internal-child="selection">
-                                  <object class="GtkTreeSelection"/>
-                                </child>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">list-add</property>
                               </object>
                             </child>
+                            <accelerator key="a" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
-                            <property name="fill">True</property>
+                            <property name="fill">False</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="vbox4">
+                          <object class="GtkButton" id="delete">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <property name="spacing">6</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <signal name="clicked" handler="on_delete_clicked" swapped="no"/>
                             <child>
-                              <object class="GtkButton" id="add">
+                              <object class="GtkImage" id="image4">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_add_clicked" swapped="no"/>
-                                <child>
-                                  <object class="GtkImage" id="image3">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="stock">gtk-add</property>
-                                  </object>
-                                </child>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">edit-delete</property>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
-                            <child>
-                              <object class="GtkButton" id="delete">
-                                <property name="visible">True</property>
-                                <property name="sensitive">False</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <signal name="clicked" handler="on_delete_clicked" swapped="no"/>
-                                <child>
-                                  <object class="GtkImage" id="image4">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="stock">gtk-delete</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <accelerator key="d" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -129,63 +127,62 @@
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
+                <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="right_side">
+              <object class="GtkBox" id="right_side">
                 <property name="can_focus">False</property>
-                <property name="left_padding">25</property>
+                <property name="margin_left">20</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="vbox3">
+                  <object class="GtkLabel" id="detail_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="detail_container">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkLabel" id="detail_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">label</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkAlignment" id="detail_container">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
+                      <placeholder/>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -204,11 +201,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">window-close</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_close_clicked" swapped="no"/>
               </object>
               <packing>
@@ -226,9 +224,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/merge.xml
+++ b/rabbitvcs/ui/xml/merge.xml
@@ -26,13 +26,13 @@
       <placeholder/>
     </child>
     <child>
-      <object class="GtkBox" orientation="vertical" id="page1">
+      <object class="GtkBox" id="page1">
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox3">
+          <object class="GtkBox" id="vbox3">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <child>
@@ -71,7 +71,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox5">
+          <object class="GtkBox" id="vbox5">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <child>
@@ -111,7 +111,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox6">
+          <object class="GtkBox" id="vbox6">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <child>
@@ -156,13 +156,13 @@
       </packing>
     </child>
     <child>
-      <object class="GtkBox" orientation="vertical" id="page2a">
+      <object class="GtkBox" id="page2a">
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox8">
+          <object class="GtkBox" id="vbox8">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -184,8 +184,9 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkComboBoxEntry" id="mergerange_from_urls">
+                  <object class="GtkComboBoxText" id="mergerange_from_urls">
                     <property name="visible">True</property>
+                    <property name="has-entry">True</property>
                     <signal handler="on_mergerange_from_urls_changed" name="changed"/>
                   </object>
                 </child>
@@ -204,7 +205,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox9">
+          <object class="GtkBox" id="vbox9">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -226,12 +227,13 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox34">
+                  <object class="GtkBox" id="vbox34">
                     <property name="visible">True</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox18">
+                      <object class="GtkBox" id="hbox18">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="spacing">6</property>
                         <child>
@@ -308,7 +310,7 @@ To merge all revisions, leave the box empty.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox10">
+          <object class="GtkBox" id="vbox10">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -330,7 +332,8 @@ To merge all revisions, leave the box empty.</property>
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="horizontal" id="hbox19">
+                  <object class="GtkBox" id="hbox19">
+		    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="spacing">12</property>
                     <child>
@@ -364,13 +367,13 @@ To merge all revisions, leave the box empty.</property>
       </packing>
     </child>
     <child>
-      <object class="GtkBox" orientation="vertical" id="page2b">
+      <object class="GtkBox" id="page2b">
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox11">
+          <object class="GtkBox" id="vbox11">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -392,20 +395,22 @@ To merge all revisions, leave the box empty.</property>
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox7">
+                  <object class="GtkBox" id="vbox7">
                     <property name="visible">True</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox1">
+                      <object class="GtkBox" id="hbox1">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkAlignment" id="alignment7">
                             <property name="visible">True</property>
                             <child>
-                              <object class="GtkComboBoxEntry" id="merge_reintegrate_repos">
+                              <object class="GtkComboBoxText" id="merge_reintegrate_repos">
                                 <property name="visible">True</property>
+                                <property name="has-entry">True</property>
                                 <signal handler="on_merge_reintegrate_from_urls_changed" name="changed"/>
                               </object>
                             </child>
@@ -470,7 +475,7 @@ To merge all revisions, leave the box empty.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox12">
+          <object class="GtkBox" id="vbox12">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <child>
@@ -491,7 +496,8 @@ To merge all revisions, leave the box empty.</property>
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="horizontal" id="hbox20">
+                  <object class="GtkBox" id="hbox20">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="spacing">12</property>
                     <child>
@@ -526,13 +532,13 @@ To merge all revisions, leave the box empty.</property>
       </packing>
     </child>
     <child>
-      <object class="GtkBox" orientation="vertical" id="page2c">
+      <object class="GtkBox" id="page2c">
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox13">
+          <object class="GtkBox" id="vbox13">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -554,13 +560,14 @@ To merge all revisions, leave the box empty.</property>
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox38">
+                  <object class="GtkBox" id="vbox38">
                     <property name="visible">True</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkComboBoxEntry" id="mergetree_from_urls">
+                      <object class="GtkComboBoxText" id="mergetree_from_urls">
                         <property name="visible">True</property>
+                        <property name="has-entry">True</property>
                         <signal handler="on_mergetree_from_urls_changed" name="changed"/>
                       </object>
                       <packing>
@@ -570,7 +577,7 @@ To merge all revisions, leave the box empty.</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="vertical" id="vbox2">
+                      <object class="GtkBox" id="vbox2">
                         <property name="visible">True</property>
                         <property name="orientation">vertical</property>
                         <child>
@@ -589,7 +596,8 @@ To merge all revisions, leave the box empty.</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox22">
+                          <object class="GtkBox" id="hbox22">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="spacing">6</property>
                             <child>
@@ -671,7 +679,7 @@ To merge all revisions, leave the box empty.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox14">
+          <object class="GtkBox" id="vbox14">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -693,13 +701,14 @@ To merge all revisions, leave the box empty.</property>
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox39">
+                  <object class="GtkBox" id="vbox39">
                     <property name="visible">True</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkComboBoxEntry" id="mergetree_to_urls">
+                      <object class="GtkComboBoxText" id="mergetree_to_urls">
                         <property name="visible">True</property>
+                        <property name="has-entry">True</property>
                         <signal handler="on_mergetree_to_urls_changed" name="changed"/>
                       </object>
                       <packing>
@@ -709,7 +718,7 @@ To merge all revisions, leave the box empty.</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="vertical" id="vbox4">
+                      <object class="GtkBox" id="vbox4">
                         <property name="visible">True</property>
                         <property name="orientation">vertical</property>
                         <child>
@@ -728,7 +737,8 @@ To merge all revisions, leave the box empty.</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox23">
+                          <object class="GtkBox" id="hbox23">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="spacing">6</property>
                             <child>
@@ -810,7 +820,7 @@ To merge all revisions, leave the box empty.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox15">
+          <object class="GtkBox" id="vbox15">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -832,7 +842,8 @@ To merge all revisions, leave the box empty.</property>
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="horizontal" id="hbox21">
+                  <object class="GtkBox" id="hbox21">
+		    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="spacing">12</property>
                     <child>
@@ -866,13 +877,13 @@ To merge all revisions, leave the box empty.</property>
       </packing>
     </child>
     <child>
-      <object class="GtkBox" orientation="vertical" id="page3">
+      <object class="GtkBox" id="page3">
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox1">
+          <object class="GtkBox" id="vbox1">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -894,7 +905,7 @@ To merge all revisions, leave the box empty.</property>
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox41">
+                  <object class="GtkBox" id="vbox41">
                     <property name="visible">True</property>
                     <property name="orientation">vertical</property>
                     <child>
@@ -953,7 +964,8 @@ To merge all revisions, leave the box empty.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox24">
+          <object class="GtkButtonBox" id="hbuttonbox24">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>
@@ -963,7 +975,8 @@ To merge all revisions, leave the box empty.</property>
                 <property name="receives_default">True</property>
                 <signal handler="on_test_clicked" name="clicked"/>
                 <child>
-                  <object class="GtkBox" orientation="horizontal" id="hbox2">
+                  <object class="GtkBox" id="hbox2">
+		    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <child>
                       <object class="GtkImage" id="image5">

--- a/rabbitvcs/ui/xml/merge.xml
+++ b/rabbitvcs/ui/xml/merge.xml
@@ -1,21 +1,34 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.10 -->
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkAssistant" id="Merge">
     <property name="width_request">600</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="border_width">12</property>
     <property name="title" translatable="yes">Merge Assistant</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="gravity">center</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_apply_clicked" name="apply"/>
-    <signal handler="on_cancel_clicked" name="cancel"/>
-    <signal handler="on_close_clicked" name="close"/>
-    <signal handler="on_prepare" name="prepare"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="apply" handler="on_apply_clicked" swapped="no"/>
+    <signal name="cancel" handler="on_cancel_clicked" swapped="no"/>
+    <signal name="close" handler="on_close_clicked" swapped="no"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <signal name="prepare" handler="on_prepare" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <placeholder/>
     </child>
@@ -28,21 +41,34 @@
     <child>
       <object class="GtkBox" id="page1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox3">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkRadioButton" id="mergetype_range_opt">
-                <property name="label" translatable="yes">Merge a range of revisions</property>
+              <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkRadioButton" id="mergetype_range_opt">
+                    <property name="label" translatable="yes">Merge a range of revisions</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -54,12 +80,15 @@
               <object class="GtkLabel" id="label47">
                 <property name="width_request">475</property>
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="xpad">30</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">30</property>
                 <property name="label" translatable="yes">Choose this method if you have made some changes to a branch and wish to merge your changes with another branch.</property>
                 <property name="wrap">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -73,16 +102,27 @@
         <child>
           <object class="GtkBox" id="vbox5">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkRadioButton" id="mergetype_tree_opt">
-                <property name="label" translatable="yes">Merge two different trees</property>
+              <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
-                <property name="group">mergetype_range_opt</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkRadioButton" id="mergetype_tree_opt">
+                    <property name="label" translatable="yes">Merge two different trees</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -94,12 +134,15 @@
               <object class="GtkLabel" id="label51">
                 <property name="width_request">475</property>
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="xpad">30</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">30</property>
                 <property name="label" translatable="yes">Choose this method if you wish to merge two different branches into your working copy.</property>
                 <property name="wrap">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -113,15 +156,26 @@
         <child>
           <object class="GtkBox" id="vbox6">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkRadioButton" id="mergetype_reintegrate_opt">
-                <property name="label" translatable="yes">Reintegrate a branch</property>
+              <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="draw_indicator">True</property>
-                <property name="group">mergetype_range_opt</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkRadioButton" id="mergetype_reintegrate_opt">
+                    <property name="label" translatable="yes">Reintegrate a branch</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -133,12 +187,15 @@
               <object class="GtkLabel" id="label2">
                 <property name="width_request">475</property>
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="xpad">30</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">30</property>
                 <property name="label" translatable="yes">Choose this method if you wish to reintegrate a branch into the trunk.</property>
                 <property name="wrap">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -153,25 +210,29 @@
       <packing>
         <property name="page_type">intro</property>
         <property name="title">Step 1: Merge Type</property>
+        <property name="has_padding">False</property>
       </packing>
     </child>
     <child>
       <object class="GtkBox" id="page2a">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox8">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;URL to merge from&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -180,20 +241,22 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
+              <object class="GtkComboBoxText" id="mergerange_from_urls">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkComboBoxText" id="mergerange_from_urls">
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="has_entry">True</property>
+                <signal name="changed" handler="on_mergerange_from_urls_changed" swapped="no"/>
+                <child internal-child="entry">
+                  <object class="GtkEntry">
                     <property name="visible">True</property>
-                    <property name="has-entry">True</property>
-                    <signal handler="on_mergerange_from_urls_changed" name="changed"/>
+                    <property name="can_focus">True</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -207,14 +270,16 @@
         <child>
           <object class="GtkBox" id="vbox9">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label4">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Revision Range&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -223,69 +288,45 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment5">
+              <object class="GtkBox" id="vbox34">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox34">
+                  <object class="GtkBox" id="hbox18">
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="hbox18">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkEntry" id="mergerange_revisions">
                         <property name="visible">True</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkEntry" id="mergerange_revisions">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <signal handler="on_mergerange_revisions_changed" name="changed"/>
-                          </object>
-                          <packing>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="mergerange_show_log1">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="tooltip-text" translatable="yes">Show log</property>
-                            <signal handler="on_mergerange_show_log1_clicked" name="clicked"/>
-                            <child>
-                              <object class="GtkImage" id="image1">
-                                <property name="visible">True</property>
-                                <property name="pixel_size">24</property>
-                                <property name="icon_name">rabbitvcs-show_log</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <signal name="changed" handler="on_mergerange_revisions_changed" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="label56">
-                        <property name="width_request">500</property>
+                      <object class="GtkButton" id="mergerange_show_log1">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
-                        <property name="xpad">30</property>
-                        <property name="label" translatable="yes">Use the log dialog to select the revisions that you wish to merge.  Or write out the revisions manually, each separated by a comma.  You can specify a revision range by a dash. 
-
-Example: 4-7,9,11,15-HEAD
-
-To merge all revisions, leave the box empty.</property>
-                        <property name="wrap">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Show log</property>
+                        <signal name="clicked" handler="on_mergerange_show_log1_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="image1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="pixel_size">24</property>
+                            <property name="icon_name">rabbitvcs-show_log</property>
+                          </object>
+                        </child>
+                        <accelerator key="r" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -294,11 +335,36 @@ To merge all revisions, leave the box empty.</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label56">
+                    <property name="width_request">500</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">8</property>
+                    <property name="label" translatable="yes">Use the log dialog to select the revisions that you wish to merge.  Or write out the revisions manually, each separated by a comma.  You can specify a revision range by a dash. 
+
+Example: 4-7,9,11,15-HEAD
+
+To merge all revisions, leave the box empty.</property>
+                    <property name="wrap">True</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -312,14 +378,16 @@ To merge all revisions, leave the box empty.</property>
         <child>
           <object class="GtkBox" id="vbox10">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label5">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Working Copy&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -328,29 +396,27 @@ To merge all revisions, leave the box empty.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment6">
+              <object class="GtkBox" id="hbox19">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="spacing">12</property>
                 <child>
-                  <object class="GtkBox" id="hbox19">
-		    <property name="orientation">horizontal</property>
+                  <object class="GtkLabel" id="mergerange_working_copy">
                     <property name="visible">True</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="mergerange_working_copy">
-                        <property name="visible">True</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -364,25 +430,29 @@ To merge all revisions, leave the box empty.</property>
       </object>
       <packing>
         <property name="title">Step 2: Merge a Range of Revisions</property>
+        <property name="has_padding">False</property>
       </packing>
     </child>
     <child>
       <object class="GtkBox" id="page2b">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox11">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label6">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;From URL&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -391,79 +461,87 @@ To merge all revisions, leave the box empty.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment1">
+              <object class="GtkBox" id="vbox7">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox7">
+                  <object class="GtkBox" id="hbox1">
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="hbox1">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkComboBoxText" id="merge_reintegrate_repos">
                         <property name="visible">True</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkAlignment" id="alignment7">
-                            <property name="visible">True</property>
-                            <child>
-                              <object class="GtkComboBoxText" id="merge_reintegrate_repos">
-                                <property name="visible">True</property>
-                                <property name="has-entry">True</property>
-                                <signal handler="on_merge_reintegrate_from_urls_changed" name="changed"/>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="merge_reintegrate_browse">
+                        <property name="can_focus">False</property>
+                        <property name="has_entry">True</property>
+                        <signal name="changed" handler="on_merge_reintegrate_from_urls_changed" swapped="no"/>
+                        <child internal-child="entry">
+                          <object class="GtkEntry">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="has_tooltip">True</property>
-                            <property name="tooltip-text" translatable="yes">Show log</property>
-                            <signal handler="on_merge_reintegrate_browse_clicked" name="clicked"/>
-                            <child>
-                              <object class="GtkImage" id="image2">
-                                <property name="visible">True</property>
-                                <property name="stock">gtk-harddisk</property>
-                                <property name="pixel_size">24</property>
-                              </object>
-                            </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
                       <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="revision_container">
+                      <object class="GtkButton" id="merge_reintegrate_browse">
                         <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="has_tooltip">True</property>
+                        <property name="tooltip_text" translatable="yes">Show log</property>
+                        <signal name="clicked" handler="on_merge_reintegrate_browse_clicked" swapped="no"/>
                         <child>
-                          <placeholder/>
+                          <object class="GtkImage" id="image2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="pixel_size">24</property>
+                            <property name="icon_name">drive-harddisk</property>
+                          </object>
                         </child>
+                        <accelerator key="u" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="pack_type">end</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="revision_container">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -477,13 +555,15 @@ To merge all revisions, leave the box empty.</property>
         <child>
           <object class="GtkBox" id="vbox12">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="label7">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Working Copy&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -492,30 +572,16 @@ To merge all revisions, leave the box empty.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment8">
+              <object class="GtkLabel" id="merge_reintegrate_working_copy">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkBox" id="hbox20">
-                    <property name="orientation">horizontal</property>
-                    <property name="visible">True</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="merge_reintegrate_working_copy">
-                        <property name="visible">True</property>
-                        <property name="xalign">0</property>
-                        <property name="wrap">True</property>
-                      </object>
-                      <packing>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -529,25 +595,29 @@ To merge all revisions, leave the box empty.</property>
       </object>
       <packing>
         <property name="title">Step 2: Reintegrate a Branch</property>
+        <property name="has_padding">False</property>
       </packing>
     </child>
     <child>
       <object class="GtkBox" id="page2c">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox13">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label8">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;From: (URL and revision to merge)&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -556,30 +626,40 @@ To merge all revisions, leave the box empty.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment9">
+              <object class="GtkBox" id="vbox38">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox38">
+                  <object class="GtkComboBoxText" id="mergetree_from_urls">
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkComboBoxText" id="mergetree_from_urls">
+                    <property name="can_focus">False</property>
+                    <property name="has_entry">True</property>
+                    <signal name="changed" handler="on_mergetree_from_urls_changed" swapped="no"/>
+                    <child internal-child="entry">
+                      <object class="GtkEntry">
                         <property name="visible">True</property>
-                        <property name="has-entry">True</property>
-                        <signal handler="on_mergetree_from_urls_changed" name="changed"/>
+                        <property name="can_focus">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="vbox2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkBox" id="vbox2">
+                      <object class="GtkBox">
                         <property name="visible">True</property>
-                        <property name="orientation">vertical</property>
+                        <property name="can_focus">False</property>
                         <child>
                           <object class="GtkRadioButton" id="mergetree_from_revision_head_opt">
                             <property name="label" translatable="yes">HEAD</property>
@@ -591,68 +671,82 @@ To merge all revisions, leave the box empty.</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
-                            <property name="fill">False</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="hbox22">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="hbox22">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkBox">
+                            <property name="width_request">140</property>
                             <property name="visible">True</property>
-                            <property name="spacing">6</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkRadioButton" id="mergetree_from_revision_number_opt">
                                 <property name="label" translatable="yes">Revision</property>
-                                <property name="width_request">140</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
                                 <property name="draw_indicator">True</property>
-                                <property name="group">mergetree_from_revision_head_opt</property>
                               </object>
                               <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEntry" id="mergetree_from_revision_number">
-                                <property name="width_request">75</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <signal handler="on_mergetree_from_revision_number_focused" name="focus_in_event"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="mergetree_from_show_log">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip-text" translatable="yes">Show log</property>
-                                <signal handler="on_mergetree_from_show_log_clicked" name="clicked"/>
-                                <child>
-                                  <object class="GtkImage" id="image3">
-                                    <property name="visible">True</property>
-                                    <property name="pixel_size">24</property>
-                                    <property name="icon_name">rabbitvcs-show_log</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
-                            <property name="fill">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="mergetree_from_revision_number">
+                            <property name="width_request">75</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <signal name="focus-in-event" handler="on_mergetree_from_revision_number_focused" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="mergetree_from_show_log">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="tooltip_text" translatable="yes">Show log</property>
+                            <signal name="clicked" handler="on_mergetree_from_show_log_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkImage" id="image3">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="pixel_size">24</property>
+                                <property name="icon_name">rabbitvcs-show_log</property>
+                              </object>
+                            </child>
+                            <accelerator key="f" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                       </object>
@@ -663,11 +757,16 @@ To merge all revisions, leave the box empty.</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -681,14 +780,16 @@ To merge all revisions, leave the box empty.</property>
         <child>
           <object class="GtkBox" id="vbox14">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label9">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;To: (URL and revision to merge)&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -697,30 +798,40 @@ To merge all revisions, leave the box empty.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment10">
+              <object class="GtkBox" id="vbox39">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox39">
+                  <object class="GtkComboBoxText" id="mergetree_to_urls">
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkComboBoxText" id="mergetree_to_urls">
+                    <property name="can_focus">False</property>
+                    <property name="has_entry">True</property>
+                    <signal name="changed" handler="on_mergetree_to_urls_changed" swapped="no"/>
+                    <child internal-child="entry">
+                      <object class="GtkEntry">
                         <property name="visible">True</property>
-                        <property name="has-entry">True</property>
-                        <signal handler="on_mergetree_to_urls_changed" name="changed"/>
+                        <property name="can_focus">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="vbox4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkBox" id="vbox4">
+                      <object class="GtkBox">
                         <property name="visible">True</property>
-                        <property name="orientation">vertical</property>
+                        <property name="can_focus">False</property>
                         <child>
                           <object class="GtkRadioButton" id="mergetree_to_revision_head_opt">
                             <property name="label" translatable="yes">HEAD</property>
@@ -732,68 +843,83 @@ To merge all revisions, leave the box empty.</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
-                            <property name="fill">False</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="hbox23">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="hbox23">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkBox">
+                            <property name="width_request">140</property>
                             <property name="visible">True</property>
-                            <property name="spacing">6</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkRadioButton" id="mergetree_to_revision_number_opt">
                                 <property name="label" translatable="yes">Revision</property>
-                                <property name="width_request">140</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="halign">start</property>
                                 <property name="draw_indicator">True</property>
-                                <property name="group">mergetree_to_revision_head_opt</property>
                               </object>
                               <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEntry" id="mergetree_to_revision_number">
-                                <property name="width_request">75</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <signal handler="on_mergetree_to_revision_number_focused" name="focus_in_event"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="mergetree_to_show_log">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip-text" translatable="yes">Show log</property>
-                                <signal handler="on_mergetree_to_show_log_clicked" name="clicked"/>
-                                <child>
-                                  <object class="GtkImage" id="image4">
-                                    <property name="visible">True</property>
-                                    <property name="pixel_size">24</property>
-                                    <property name="icon_name">rabbitvcs-show_log</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
-                            <property name="fill">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="mergetree_to_revision_number">
+                            <property name="width_request">75</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <signal name="focus-in-event" handler="on_mergetree_to_revision_number_focused" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="mergetree_to_show_log">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="tooltip_text" translatable="yes">Show log</property>
+                            <signal name="clicked" handler="on_mergetree_to_show_log_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkImage" id="image4">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="pixel_size">24</property>
+                                <property name="icon_name">rabbitvcs-show_log</property>
+                              </object>
+                            </child>
+                            <accelerator key="t" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                       </object>
@@ -804,11 +930,16 @@ To merge all revisions, leave the box empty.</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -822,14 +953,16 @@ To merge all revisions, leave the box empty.</property>
         <child>
           <object class="GtkBox" id="vbox15">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label10">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Working Copy&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -838,29 +971,15 @@ To merge all revisions, leave the box empty.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment11">
+              <object class="GtkLabel" id="mergetree_working_copy">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkBox" id="hbox21">
-		    <property name="orientation">horizontal</property>
-                    <property name="visible">True</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="mergetree_working_copy">
-                        <property name="visible">True</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -874,25 +993,29 @@ To merge all revisions, leave the box empty.</property>
       </object>
       <packing>
         <property name="title">Step 2: Merge two different trees</property>
+        <property name="has_padding">False</property>
       </packing>
     </child>
     <child>
       <object class="GtkBox" id="page3">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox1">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Options&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -901,58 +1024,61 @@ To merge all revisions, leave the box empty.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment3">
+              <object class="GtkBox" id="vbox41">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="vbox41">
+                  <object class="GtkCheckButton" id="mergeoptions_recursive">
+                    <property name="label" translatable="yes">Recursive</property>
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkCheckButton" id="mergeoptions_recursive">
-                        <property name="label" translatable="yes">Recursive</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="mergeoptions_ignore_ancestry">
-                        <property name="label" translatable="yes">Ignore ancestry</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="mergeoptions_only_record">
-                        <property name="label" translatable="yes">Only record the merge</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="mergeoptions_ignore_ancestry">
+                    <property name="label" translatable="yes">Ignore ancestry</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="mergeoptions_only_record">
+                    <property name="label" translatable="yes">Only record the merge</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -965,39 +1091,46 @@ To merge all revisions, leave the box empty.</property>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox24">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="mergeoptions_test_merge">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <signal handler="on_test_clicked" name="clicked"/>
+                <signal name="clicked" handler="on_test_clicked" swapped="no"/>
                 <child>
                   <object class="GtkBox" id="hbox2">
-		    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkImage" id="image5">
                         <property name="visible">True</property>
-                        <property name="stock">gtk-execute</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">system-run</property>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label11">
                         <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Test Merge</property>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                 </child>
+                <accelerator key="t" signal="clicked" modifiers="GDK_MOD1_MASK"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -1016,7 +1149,20 @@ To merge all revisions, leave the box empty.</property>
       <packing>
         <property name="page_type">confirm</property>
         <property name="title">Step 3: Final Options</property>
+        <property name="has_padding">False</property>
       </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/notification.xml
+++ b/rabbitvcs/ui/xml/notification.xml
@@ -1,7 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="document-save-as">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">document-save-as</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Notification">
     <property name="width_request">740</property>
     <property name="can_focus">True</property>
@@ -10,6 +25,9 @@
     <property name="icon_name">rabbitvcs-small</property>
     <property name="gravity">center</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox14">
         <property name="visible">True</property>
@@ -114,12 +132,13 @@
                 <property name="layout_style">start</property>
                 <child>
                   <object class="GtkButton" id="saveas">
-                    <property name="label">gtk-save-as</property>
+                    <property name="label" translatable="yes">Save _As</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
+                    <property name="image">document-save-as</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_saveas_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -143,11 +162,12 @@
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="cancel">
-                    <property name="label">gtk-cancel</property>
+                    <property name="label" translatable="yes">_Cancel</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
+                    <property name="image">rabbitvcs-cancel</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -158,14 +178,15 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="ok">
-                    <property name="label">gtk-ok</property>
+                    <property name="label" translatable="yes">_OK</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
                     <property name="can_default">True</property>
                     <property name="has_default">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
+                    <property name="image">rabbitvcs-ok</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -191,9 +212,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/properties.xml
+++ b/rabbitvcs/ui/xml/properties.xml
@@ -10,13 +10,13 @@
     <signal handler="on_destroy" name="destroy"/>
     <signal handler="on_key_pressed" name="key_press_event"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox12">
+      <object class="GtkBox" id="vbox12">
         <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox1">
+          <object class="GtkBox" id="vbox1">
             <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
@@ -37,12 +37,13 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox13">
+                  <object class="GtkBox" id="vbox13">
                     <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox1">
+                      <object class="GtkBox" id="hbox1">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="spacing">6</property>
                         <child>
@@ -129,7 +130,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox9">
+                      <object class="GtkButtonBox" id="hbuttonbox9">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="spacing">3</property>
                         <property name="layout_style">GTK_BUTTONBOX_START</property>
@@ -193,7 +195,8 @@
           </object>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox8">
+          <object class="GtkButtonBox" id="hbuttonbox8">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <property name="layout_style">GTK_BUTTONBOX_END</property>

--- a/rabbitvcs/ui/xml/properties.xml
+++ b/rabbitvcs/ui/xml/properties.xml
@@ -1,114 +1,110 @@
-<?xml version="1.0"?>
-<!--Generated with glade3 3.4.1 on Thu Oct 15 09:51:29 2009 -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="document-new">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">document-new</property>
+  </object>
+  <object class="GtkImage" id="document-save">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">document-save</property>
+  </object>
+  <object class="GtkImage" id="edit-delete">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">edit-delete</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-editprops">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-editprops</property>
+  </object>
   <object class="GtkWindow" id="Properties">
     <property name="width_request">600</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Properties</property>
-    <property name="window_position">GTK_WIN_POS_CENTER</property>
+    <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox12">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox1">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Properties for:&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment13">
+              <object class="GtkBox" id="vbox13">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox13">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkBox" id="hbox1">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="hbox1">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkEntry" id="path">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="tooltip-text">URL/Path</property>
-                            <signal handler="on_refresh_activate" name="activate"/>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="refresh">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <signal handler="on_refresh_activate" name="clicked"/>
-                            <child>
-                              <object class="GtkImage" id="image1">
-                                <property name="visible">True</property>
-                                <property name="stock">gtk-refresh</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        </object> 
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                      </packing>
-                    </child>                    
-                    <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow12">
-                        <property name="height_request">150</property>
+                      <object class="GtkEntry" id="path">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="shadow_type">GTK_SHADOW_ETCHED_IN</property>
-                        <child>
-                          <object class="GtkTreeView" id="table">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="rubber_banding">True</property>
-                            <signal handler="on_table_button_released" name="button_release_event"/>
-                            <signal handler="on_table_cursor_changed" name="cursor_changed"/>
-                          </object>
-                        </child>
+                        <property name="tooltip_text">URL/Path</property>
+                        <signal name="activate" handler="on_refresh_activate" swapped="no"/>
                       </object>
                       <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="recursive_label">
+                      <object class="GtkButton" id="refresh">
                         <property name="visible">True</property>
-                        <property name="label" translatable="yes">&lt;i&gt;Selected properties will be applied recursively.&lt;/i&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="on_refresh_activate" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="image1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">view-refresh</property>
+                          </object>
+                        </child>
+                        <accelerator key="r" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -116,112 +112,176 @@
                         <property name="position">2</property>
                       </packing>
                     </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow12">
+                    <property name="height_request">150</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">etched-in</property>
                     <child>
-                      <object class="GtkCheckButton" id="delete_recurse">
+                      <object class="GtkTreeView" id="table">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="label" translatable="yes">Delete properties recursively</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="rubber_banding">True</property>
+                        <signal name="button-release-event" handler="on_table_button_released" swapped="no"/>
+                        <signal name="cursor-changed" handler="on_table_cursor_changed" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="recursive_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">&lt;i&gt;Selected properties will be applied recursively.&lt;/i&gt;</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="delete_recurse">
+                    <property name="label" translatable="yes">Delete properties recursively</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButtonBox" id="hbuttonbox9">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_top">8</property>
+                    <property name="spacing">3</property>
+                    <property name="layout_style">start</property>
+                    <child>
+                      <object class="GtkButton" id="new">
+                        <property name="label" translatable="yes">_New...</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">document-new</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="on_new_clicked" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
-                        <property name="position">3</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkButtonBox" id="hbuttonbox9">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkButton" id="edit">
+                        <property name="label" translatable="yes">_Edit...</property>
                         <property name="visible">True</property>
-                        <property name="spacing">3</property>
-                        <property name="layout_style">GTK_BUTTONBOX_START</property>
-                        <child>
-                          <object class="GtkButton" id="new">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="label" translatable="yes">New...</property>
-                            <signal handler="on_new_clicked" name="clicked"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="edit">
-                            <property name="visible">True</property>
-                            <property name="sensitive">False</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="label" translatable="yes">Edit...</property>
-                            <signal handler="on_edit_clicked" name="clicked"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="delete">
-                            <property name="visible">True</property>
-                            <property name="sensitive">False</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="label" translatable="yes">Delete</property>
-                            <signal handler="on_delete_clicked" name="clicked"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">rabbitvcs-editprops</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="on_edit_clicked" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
-                        <property name="position">4</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="delete">
+                        <property name="label" translatable="yes">_Delete</property>
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">edit-delete</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="on_delete_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">4</property>
+                  </packing>
                 </child>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox8">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="label">gtk-cancel</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="ok">
+                <property name="label" translatable="yes">_Save</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="label">gtk-save</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
+                <property name="image">document-save</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -233,7 +293,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="pack_type">GTK_PACK_END</property>
+            <property name="pack_type">end</property>
             <property name="position">1</property>
           </packing>
         </child>

--- a/rabbitvcs/ui/xml/property_editor.xml
+++ b/rabbitvcs/ui/xml/property_editor.xml
@@ -1,23 +1,44 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.16 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="document-new">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">document-new</property>
+  </object>
+  <object class="GtkImage" id="view-refresh">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">view-refresh</property>
+  </object>
+  <object class="GtkImage" id="window-close">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">window-close</property>
+  </object>
   <object class="GtkWindow" id="PropertyEditor">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Property Editor</property>
     <property name="default_width">600</property>
     <property name="default_height">400</property>
-    <property name="visible">True</property>
-    <property name="title" translatable="yes">Property Editor</property>
     <property name="icon_name">rabbitvcs-small</property>
-    <signal handler="on_destroy" name="destroy"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkTable" id="table2">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="n_rows">2</property>
             <property name="n_columns">2</property>
             <property name="column_spacing">20</property>
@@ -25,10 +46,11 @@
             <child>
               <object class="GtkBox" id="hbox1">
                 <property name="visible">True</property>
-                <property name="orientation">horizontal</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkLabel" id="wc_lbl">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Working Copy:&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
                     <property name="single_line_mode">True</property>
@@ -48,10 +70,11 @@
             <child>
               <object class="GtkBox" id="hbox2">
                 <property name="visible">True</property>
-                <property name="orientation">horizontal</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkLabel" id="remote_lbl">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Remote URI:&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
                     <property name="single_line_mode">True</property>
@@ -73,14 +96,17 @@
             <child>
               <object class="GtkBox" id="hbox3">
                 <property name="visible">True</property>
-                <property name="orientation">horizontal</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkLabel" id="remote_uri_text">
                     <property name="visible">True</property>
-                    <property name="xalign">0</property>
+                    <property name="can_focus">False</property>
                     <property name="ellipsize">middle</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
@@ -95,14 +121,17 @@
             <child>
               <object class="GtkBox" id="hbox4">
                 <property name="visible">True</property>
-                <property name="orientation">horizontal</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkLabel" id="wc_text">
                     <property name="visible">True</property>
-                    <property name="xalign">0</property>
+                    <property name="can_focus">False</property>
                     <property name="ellipsize">middle</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
@@ -115,6 +144,7 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -122,36 +152,40 @@
           <object class="GtkScrolledWindow" id="scrolledwindow1">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="hscrollbar_policy">automatic</property>
-            <property name="vscrollbar_policy">automatic</property>
             <property name="shadow_type">etched-in</property>
             <child>
               <object class="GtkTreeView" id="table">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection"/>
+                </child>
               </object>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox2">
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="homogeneous">True</property>
             <property name="layout_style">center</property>
             <child>
               <object class="GtkButton" id="refresh">
-                <property name="label">gtk-refresh</property>
+                <property name="label" translatable="yes">_Refresh</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="tooltip-text" translatable="yes">Refresh the list of properties.</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_refresh_clicked" name="clicked"/>
+                <property name="tooltip_text" translatable="yes">Refresh the list of properties.</property>
+                <property name="image">view-refresh</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -161,13 +195,14 @@
             </child>
             <child>
               <object class="GtkButton" id="new">
-                <property name="label">gtk-new</property>
+                <property name="label" translatable="yes">_New</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="tooltip-text" translatable="yes">Add a new property.</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_new_clicked" name="clicked"/>
+                <property name="tooltip_text" translatable="yes">Add a new property.</property>
+                <property name="image">document-new</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_new_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -185,32 +220,35 @@
         <child>
           <object class="GtkBox" id="note_box">
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can_focus">False</property>
             <property name="homogeneous">True</property>
             <child>
               <placeholder/>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">3</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox1">
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="homogeneous">True</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="tooltip-text" translatable="yes">Close this dialog.</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_close_clicked" name="clicked"/>
+                <property name="tooltip_text" translatable="yes">Close this dialog.</property>
+                <property name="image">window-close</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_close_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/property_page.xml
+++ b/rabbitvcs/ui/xml/property_page.xml
@@ -1,31 +1,7 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.16 -->
-  <!-- interface-naming-policy project-wide -->
-  <object class="GtkBox" id="property_page_label">
-    <property name="orientation">vertical</property>
-    <property name="visible">True</property>
-    <child>
-      <object class="GtkImage" id="rabbitvcs-icon">
-        <property name="visible">True</property>
-        <property name="icon_name">rabbitvcs</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="position">0</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="rabbitvcs-title">
-        <property name="visible">True</property>
-        <property name="label" translatable="yes">RabbitVCS</property>
-      </object>
-      <packing>
-        <property name="position">1</property>
-      </packing>
-    </child>
-  </object>
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkExpander" id="file_info_expander">
     <property name="visible">True</property>
     <property name="can_focus">True</property>
@@ -35,12 +11,14 @@
     <child type="label">
       <object class="GtkLabel" id="file_expander_path">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="xalign">0</property>
       </object>
     </child>
   </object>
   <object class="GtkBox" id="file_info_table">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="border_width">12</property>
     <property name="orientation">vertical</property>
     <property name="spacing">12</property>
@@ -48,22 +26,26 @@
       <object class="GtkFixed" id="fixed1">
         <property name="height_request">12</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
       </object>
       <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
         <property name="position">0</property>
       </packing>
     </child>
     <child>
       <object class="GtkBox" id="icon_plus_table">
-	<property name="orientation">horizontal</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <child>
           <object class="GtkImage" id="vcs_icon">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="yalign">0</property>
             <property name="xpad">8</property>
-            <property name="stock">gtk-file</property>
-            <property name="icon-size">6</property>
+            <property name="icon_name">text-x-generic</property>
+            <property name="icon_size">6</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -74,6 +56,7 @@
         <child>
           <object class="GtkTable" id="file_info">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="n_rows">4</property>
             <property name="n_columns">2</property>
             <property name="column_spacing">16</property>
@@ -81,8 +64,9 @@
             <child>
               <object class="GtkLabel" id="filename_label">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Name:</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="x_options">GTK_FILL</property>
@@ -92,8 +76,9 @@
             <child>
               <object class="GtkLabel" id="content_status_label">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Content status:</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="top_attach">2</property>
@@ -105,8 +90,9 @@
             <child>
               <object class="GtkLabel" id="prop_status_label">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Property status:</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="top_attach">3</property>
@@ -118,8 +104,9 @@
             <child>
               <object class="GtkLabel" id="vcs_label">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">VCS:</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="top_attach">1</property>
@@ -131,8 +118,9 @@
             <child>
               <object class="GtkLabel" id="file_name">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="selectable">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -142,8 +130,9 @@
             <child>
               <object class="GtkLabel" id="vcs_type">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="selectable">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -154,24 +143,29 @@
             </child>
             <child>
               <object class="GtkBox" id="prop_status_box">
-		<property name="orientation">horizontal</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkImage" id="prop_status_icon">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="prop_status">
                     <property name="visible">True</property>
-                    <property name="xalign">0</property>
+                    <property name="can_focus">False</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -185,24 +179,29 @@
             </child>
             <child>
               <object class="GtkBox" id="content_status_box">
-		<property name="orientation">horizontal</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkImage" id="content_status_icon">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="content_status">
                     <property name="visible">True</property>
-                    <property name="xalign">0</property>
+                    <property name="can_focus">False</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -216,11 +215,15 @@
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
       </object>
       <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
         <property name="position">1</property>
       </packing>
     </child>
@@ -228,8 +231,11 @@
       <object class="GtkFixed" id="fixed2">
         <property name="height_request">12</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
       </object>
       <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
         <property name="position">2</property>
       </packing>
     </child>
@@ -238,14 +244,15 @@
     <property name="visible">True</property>
     <property name="can_focus">True</property>
     <property name="hscrollbar_policy">never</property>
-    <property name="vscrollbar_policy">automatic</property>
     <child>
       <object class="GtkViewport" id="prop_page_viewport">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="resize_mode">queue</property>
         <child>
           <object class="GtkBox" id="property_page">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <placeholder/>
@@ -253,6 +260,35 @@
           </object>
         </child>
       </object>
+    </child>
+  </object>
+  <object class="GtkBox" id="property_page_label">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkImage" id="rabbitvcs-icon">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="icon_name">rabbitvcs</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="rabbitvcs-title">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">RabbitVCS</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/ui/xml/property_page.xml
+++ b/rabbitvcs/ui/xml/property_page.xml
@@ -2,7 +2,8 @@
 <interface>
   <!-- interface-requires gtk+ 2.16 -->
   <!-- interface-naming-policy project-wide -->
-  <object class="GtkBox" orientation="horizontal" id="property_page_label">
+  <object class="GtkBox" id="property_page_label">
+    <property name="orientation">vertical</property>
     <property name="visible">True</property>
     <child>
       <object class="GtkImage" id="rabbitvcs-icon">
@@ -38,7 +39,7 @@
       </object>
     </child>
   </object>
-  <object class="GtkBox" orientation="vertical" id="file_info_table">
+  <object class="GtkBox" id="file_info_table">
     <property name="visible">True</property>
     <property name="border_width">12</property>
     <property name="orientation">vertical</property>
@@ -53,7 +54,8 @@
       </packing>
     </child>
     <child>
-      <object class="GtkBox" orientation="horizontal" id="icon_plus_table">
+      <object class="GtkBox" id="icon_plus_table">
+	<property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <child>
           <object class="GtkImage" id="vcs_icon">
@@ -151,7 +153,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="horizontal" id="prop_status_box">
+              <object class="GtkBox" id="prop_status_box">
+		<property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <child>
                   <object class="GtkImage" id="prop_status_icon">
@@ -181,7 +184,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="horizontal" id="content_status_box">
+              <object class="GtkBox" id="content_status_box">
+		<property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <child>
                   <object class="GtkImage" id="content_status_icon">
@@ -240,7 +244,7 @@
         <property name="visible">True</property>
         <property name="resize_mode">queue</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="property_page">
+          <object class="GtkBox" id="property_page">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <child>

--- a/rabbitvcs/ui/xml/pull.xml
+++ b/rabbitvcs/ui/xml/pull.xml
@@ -8,12 +8,14 @@
     <property name="window_position">center-always</property>
     <signal handler="on_destroy" name="destroy"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox3">
+          <object class="GtkBox" id="vbox3">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <child>
@@ -50,7 +52,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="horizontal" id="hbox1">
+          <object class="GtkBox" id="hbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <child>
               <object class="GtkLabel" id="label2">
@@ -86,7 +89,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>

--- a/rabbitvcs/ui/xml/pull.xml
+++ b/rabbitvcs/ui/xml/pull.xml
@@ -1,29 +1,46 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.12 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Pull">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Pull</property>
     <property name="window_position">center-always</property>
-    <signal handler="on_destroy" name="destroy"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox3">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Pull Information&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -32,15 +49,18 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="repository_container">
+              <object class="GtkBox" id="repository_container">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -52,13 +72,60 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="hbox1">
-	    <property name="orientation">horizontal</property>
+          <object class="GtkButtonBox" id="hbuttonbox1">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">6</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="cancel">
+                <property name="label" translatable="yes">_Cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ok">
+                <property name="label" translatable="yes">_OK</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="hbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkLabel" id="label2">
                 <property name="width_request">90</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -86,50 +153,6 @@
             <property name="expand">False</property>
             <property name="fill">False</property>
             <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButtonBox" id="hbuttonbox1">
-	    <property name="orientation">horizontal</property>
-            <property name="visible">True</property>
-            <property name="spacing">6</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
           </packing>
         </child>
       </object>

--- a/rabbitvcs/ui/xml/push.xml
+++ b/rabbitvcs/ui/xml/push.xml
@@ -10,13 +10,14 @@
     <signal handler="on_destroy" name="destroy"/>
     <signal handler="on_key_pressed" name="key_press_event"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox1">
+      <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox3">
+          <object class="GtkBox" id="vbox3">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <child>
@@ -53,7 +54,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox2">
+          <object class="GtkBox" id="vbox2">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <child>
@@ -105,7 +107,8 @@
           <property name="visible">True</property>
           <property name="left_padding">10</property>
           <child>
-            <object class="GtkBox" orientation="horizontal" id="pushTagsBox">
+            <object class="GtkBox" id="pushTagsBox">
+	      <property name="orientation">horizontal</property>
               <property name="visible">True</property>
               <child>
                 <object class="GtkCheckButton" id="tags">
@@ -124,7 +127,8 @@
         </object>
         </child>
         <child>
-          <object class="GtkBox" orientation="horizontal" id="hbox1">
+          <object class="GtkBox" id="hbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <child>
               <object class="GtkLabel" id="status">
@@ -138,7 +142,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox1">
+              <object class="GtkButtonBox" id="hbuttonbox1">
+		<property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="spacing">6</property>
                 <property name="layout_style">end</property>

--- a/rabbitvcs/ui/xml/push.xml
+++ b/rabbitvcs/ui/xml/push.xml
@@ -1,31 +1,48 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.12 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Push">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Push</property>
     <property name="window_position">center-always</property>
     <property name="icon_name">rabbitvcs</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox3">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Push Information&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -34,15 +51,18 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="repository_container">
+              <object class="GtkBox" id="repository_container">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -54,107 +74,36 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="vbox2">
-            <property name="orientation">vertical</property>
+          <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
-            <property name="spacing">6</property>
+            <property name="can_focus">False</property>
             <child>
-              <object class="GtkLabel" id="label4">
+              <object class="GtkLabel" id="status">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">&lt;b&gt;Commits to Push&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
-                <property name="visible">True</property>
-                <property name="left_padding">12</property>
-                <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
-                    <property name="shadow_type">etched-in</property>
-                    <child>
-                      <object class="GtkTreeView" id="log">
-                        <property name="width_request">450</property>
-                        <property name="height_request">200</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-        <object class="GtkAlignment" id="tagsContainer">
-          <property name="visible">True</property>
-          <property name="left_padding">10</property>
-          <child>
-            <object class="GtkBox" id="pushTagsBox">
-	      <property name="orientation">horizontal</property>
-              <property name="visible">True</property>
-              <child>
-                <object class="GtkCheckButton" id="tags">
-                  <property name="visible">True</property>
-                  <property name="xalign">0</property>
-                  <property name="label">Include tags</property>
-                </object>
-                <packing>
-                  <property name="expand">False</property>
-                  <property name="fill">False</property>
-                  <property name="position">1</property>
-                </packing>
-              </child>
-            </object>
-          </child>
-        </object>
-        </child>
-        <child>
-          <object class="GtkBox" id="hbox1">
-	    <property name="orientation">horizontal</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkLabel" id="status">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkButtonBox" id="hbuttonbox1">
-		<property name="orientation">horizontal</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="spacing">6</property>
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="cancel">
-                    <property name="label">gtk-cancel</property>
+                    <property name="label" translatable="yes">_Cancel</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
-                    <signal handler="on_cancel_clicked" name="clicked"/>
+                    <property name="image">rabbitvcs-cancel</property>
+                    <property name="use_underline">True</property>
+                    <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -164,12 +113,13 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="ok">
-                    <property name="label">gtk-ok</property>
+                    <property name="label" translatable="yes">_OK</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
-                    <signal handler="on_ok_clicked" name="clicked"/>
+                    <property name="image">rabbitvcs-ok</property>
+                    <property name="use_underline">True</property>
+                    <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -182,15 +132,93 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="pack_type">end</property>
-                <property name="position">0</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="pack_type">end</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Commits to Push&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolledwindow1">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="margin_left">12</property>
+                <property name="shadow_type">etched-in</property>
+                <child>
+                  <object class="GtkTreeView" id="log">
+                    <property name="width_request">450</property>
+                    <property name="height_request">200</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="pushTagsBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">10</property>
+            <child>
+              <object class="GtkCheckButton" id="tags">
+                <property name="label">Include tags</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/rabbitvcs/ui/xml/relocate.xml
+++ b/rabbitvcs/ui/xml/relocate.xml
@@ -93,6 +93,7 @@
                         <child>
                           <object class="GtkComboBoxText" id="to_urls">
                             <property name="visible">True</property>
+                            <property name="has-entry">True</property>
                             <child internal-child="entry">
                               <object class="GtkEntry" id="to_url">
                                 <property name="visible">True</property>

--- a/rabbitvcs/ui/xml/relocate.xml
+++ b/rabbitvcs/ui/xml/relocate.xml
@@ -1,123 +1,148 @@
-<?xml version="1.0"?>
-<!--Generated with glade3 3.4.5 on Thu Feb 12 09:48:19 2009 -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Relocate">
     <property name="width_request">640</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Relocate</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox28">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox1">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Change the repository of your working copy&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment1">
+              <object class="GtkBox" id="vbox29">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox29">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkBox" id="hbox15">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="hbox15">
+                      <object class="GtkLabel" id="label44">
+                        <property name="width_request">100</property>
                         <property name="visible">True</property>
-                        <property name="orientation">horizontal</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="label44">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">From:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="from_url">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">From:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox16">
+                      <object class="GtkEntry" id="from_url">
                         <property name="visible">True</property>
-                        <property name="orientation">horizontal</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="label46">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">To:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBoxText" id="to_urls">
-                            <property name="visible">True</property>
-                            <property name="has-entry">True</property>
-                            <child internal-child="entry">
-                              <object class="GtkEntry" id="to_url">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">True</property>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox16">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label46">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">To:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="to_urls">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="has_entry">True</property>
+                        <child internal-child="entry">
+                          <object class="GtkEntry" id="to_url">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -125,34 +150,44 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox17">
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="label">gtk-cancel</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="ok">
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="label">gtk-ok</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -160,7 +195,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="pack_type">GTK_PACK_END</property>
+            <property name="pack_type">end</property>
             <property name="position">1</property>
           </packing>
         </child>

--- a/rabbitvcs/ui/xml/reset.xml
+++ b/rabbitvcs/ui/xml/reset.xml
@@ -1,29 +1,47 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.12 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Reset">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Reset</property>
+    <property name="resizable">False</property>
     <property name="window_position">center-always</property>
-    <signal handler="on_destroy" name="destroy"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox6">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Reset your Repository&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -34,8 +52,9 @@
             <child>
               <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Reset current HEAD to specified state.</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -45,68 +64,75 @@
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="vbox7">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label9">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Path&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
+              <object class="GtkBox" id="hbox1">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="hbox1">
-		    <property name="orientation">horizontal</property>
+                  <object class="GtkEntry" id="path">
                     <property name="visible">True</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkEntry" id="path">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="invisible_char">&#x25CF;</property>
-                        <signal handler="on_path_changed" name="changed"/>
-                      </object>
-                      <packing>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="browse">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <signal handler="on_browse_clicked" name="clicked"/>
-                        <child>
-                          <object class="GtkImage" id="image1">
-                            <property name="visible">True</property>
-                            <property name="stock">gtk-harddisk</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">●</property>
+                    <signal name="changed" handler="on_path_changed" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="browse">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <signal name="clicked" handler="on_browse_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkImage" id="image1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">drive-harddisk</property>
+                      </object>
+                    </child>
+                    <accelerator key="p" signal="clicked" modifiers="GDK_MOD1_MASK"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -120,190 +146,220 @@
         <child>
           <object class="GtkBox" id="vboxa">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label8">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Revision&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="revision_container">
+              <object class="GtkBox" id="revision_container">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="position">2</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="vbox2">
+          <object class="GtkBox" id="vbox3">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkBox" id="vbox3">
+              <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Options&lt;/b&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkLabel" id="label2">
+                  <object class="GtkRadioButton" id="mixed_opt">
                     <property name="visible">True</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Options&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
-                  </object>
-                  <packing>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAlignment" id="alignment1">
-                    <property name="visible">True</property>
-                    <property name="left_padding">12</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
                     <child>
-                      <object class="GtkBox" id="vbox4">
+                      <object class="GtkLabel" id="label4">
                         <property name="visible">True</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkRadioButton" id="mixed_opt">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="draw_indicator">True</property>
-                            <child>
-                              <object class="GtkLabel" id="label4">
-                                <property name="visible">True</property>
-                                <property name="label" translatable="yes">&lt;i&gt;Mixed&lt;/i&gt; - Reset the index but not the working tree</property>
-                                <property name="use_markup">True</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="soft_opt">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">mixed_opt</property>
-                            <child>
-                              <object class="GtkLabel" id="label5">
-                                <property name="visible">True</property>
-                                <property name="label" translatable="yes">&lt;i&gt;Soft&lt;/i&gt; - Does not touch the index file or working tree at all, 
-but requires them to be in good working order</property>
-                                <property name="use_markup">True</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="hard_opt">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">mixed_opt</property>
-                            <child>
-                              <object class="GtkLabel" id="label6">
-                                <property name="visible">True</property>
-                                <property name="label" translatable="yes">&lt;i&gt;Hard&lt;/i&gt; - Matches the working tree and index to that of the 
-tree being switched to</property>
-                                <property name="use_markup">True</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="merge_opt">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">mixed_opt</property>
-                            <child>
-                              <object class="GtkLabel" id="label7">
-                                <property name="visible">True</property>
-                                <property name="label" translatable="yes">&lt;i&gt;Merge&lt;/i&gt; - Resets the index to match the tree recorded by the named commit,
-and updates the files that are different between the named commit
-and the current commit in the working tree</property>
-                                <property name="use_markup">True</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkRadioButton" id="none_opt">
-                            <property name="label" translatable="yes">None</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
-                            <property name="group">mixed_opt</property>
-                          </object>
-                          <packing>
-                            <property name="position">4</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;i&gt;Mixed&lt;/i&gt; - Reset the index but not the working tree</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="soft_opt">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">mixed_opt</property>
+                    <child>
+                      <object class="GtkLabel" id="label5">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;i&gt;Soft&lt;/i&gt; - Does not touch the index file or working tree at all, 
+but requires them to be in good working order</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="hard_opt">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">mixed_opt</property>
+                    <child>
+                      <object class="GtkLabel" id="label6">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;i&gt;Hard&lt;/i&gt; - Matches the working tree and index to that of the 
+tree being switched to</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="merge_opt">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">mixed_opt</property>
+                    <child>
+                      <object class="GtkLabel" id="label7">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;i&gt;Merge&lt;/i&gt; - Resets the index to match the tree recorded by the named commit,
+and updates the files that are different between the named commit
+and the current commit in the working tree</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="none_opt">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">mixed_opt</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">None</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="position">0</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">3</property>
           </packing>
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox1">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -313,12 +369,13 @@ and the current commit in the working tree</property>
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/reset.xml
+++ b/rabbitvcs/ui/xml/reset.xml
@@ -8,13 +8,13 @@
     <property name="window_position">center-always</property>
     <signal handler="on_destroy" name="destroy"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox1">
+      <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox6">
+          <object class="GtkBox" id="vbox6">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -49,7 +49,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox7">
+          <object class="GtkBox" id="vbox7">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -69,7 +69,8 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="horizontal" id="hbox1">
+                  <object class="GtkBox" id="hbox1">
+		    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="spacing">6</property>
                     <child>
@@ -117,7 +118,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vboxa">
+          <object class="GtkBox" id="vboxa">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -150,12 +151,12 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox2">
+          <object class="GtkBox" id="vbox2">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox3">
+              <object class="GtkBox" id="vbox3">
                 <property name="visible">True</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
@@ -175,7 +176,7 @@
                     <property name="visible">True</property>
                     <property name="left_padding">12</property>
                     <child>
-                      <object class="GtkBox" orientation="vertical" id="vbox4">
+                      <object class="GtkBox" id="vbox4">
                         <property name="visible">True</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
@@ -290,7 +291,8 @@ and the current commit in the working tree</property>
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>

--- a/rabbitvcs/ui/xml/revert.xml
+++ b/rabbitvcs/ui/xml/revert.xml
@@ -1,21 +1,36 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.6 -->
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Revert">
     <property name="width_request">450</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Revert</property>
     <property name="window_position">center</property>
     <property name="default_width">400</property>
     <property name="default_height">300</property>
     <property name="icon_name">rabbitvcs-small</property>
     <property name="gravity">center</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
@@ -24,17 +39,20 @@
             <property name="height_request">200</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="hscrollbar_policy">automatic</property>
-            <property name="vscrollbar_policy">automatic</property>
             <property name="shadow_type">etched-in</property>
             <child>
               <object class="GtkTreeView" id="files_table">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection"/>
+                </child>
               </object>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -44,9 +62,10 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="xalign">0</property>
             <property name="active">True</property>
             <property name="draw_indicator">True</property>
-            <signal handler="on_select_all_toggled" name="toggled"/>
+            <signal name="toggled" handler="on_select_all_toggled" swapped="no"/>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -57,10 +76,11 @@
         <child>
           <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkLabel" id="status">
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -72,17 +92,18 @@
             <child>
               <object class="GtkButtonBox" id="hbuttonbox2">
                 <property name="visible">True</property>
-                <property name="orientation">horizontal</property>
+                <property name="can_focus">False</property>
                 <property name="spacing">6</property>
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="cancel">
-                    <property name="label">gtk-cancel</property>
+                    <property name="label" translatable="yes">_Cancel</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
-                    <signal handler="on_cancel_clicked" name="clicked"/>
+                    <property name="image">rabbitvcs-cancel</property>
+                    <property name="use_underline">True</property>
+                    <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -92,12 +113,13 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="ok">
-                    <property name="label">gtk-ok</property>
+                    <property name="label" translatable="yes">_OK</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
-                    <signal handler="on_ok_clicked" name="clicked"/>
+                    <property name="image">rabbitvcs-ok</property>
+                    <property name="use_underline">True</property>
+                    <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/settings.xml
+++ b/rabbitvcs/ui/xml/settings.xml
@@ -1,7 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="2.18"/>
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="edit-clear-1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">edit-clear</property>
+  </object>
+  <object class="GtkImage" id="edit-clear-2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">edit-clear</property>
+  </object>
+  <object class="GtkImage" id="edit-clear-3">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">edit-clear</property>
+  </object>
+  <object class="GtkImage" id="process-stop">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">process-stop</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
+  <object class="GtkImage" id="system-run">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">system-run</property>
+  </object>
+  <object class="GtkImage" id="view-refresh">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">view-refresh</property>
+  </object>
   <object class="GtkWindow" id="Settings">
     <property name="width_request">550</property>
     <property name="height_request">425</property>
@@ -13,11 +53,14 @@
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
     <child>
+      <placeholder/>
+    </child>
+    <child>
       <object class="GtkBox" id="vbox1">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">12</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkNotebook" id="pages">
@@ -25,23 +68,23 @@
             <property name="can_focus">True</property>
             <child>
               <object class="GtkBox" id="vbox3">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox" id="vbox4">
-                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="border_width">12</property>
+                    <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label8">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;RabbitVCS&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -50,93 +93,78 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment2">
+                      <object class="GtkBox" id="vbox13">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="margin_left">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkBox" id="vbox5">
-                            <property name="orientation">vertical</property>
+                          <object class="GtkCheckButton" id="enable_attributes">
+                            <property name="label" translatable="yes">Enable file attributes</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkBox" id="vbox13">
-                                <property name="orientation">vertical</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkCheckButton" id="enable_attributes">
-                                    <property name="label" translatable="yes">Enable file attributes</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="active">True</property>
-                                    <property name="draw_indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="enable_recursive">
-                                    <property name="label" translatable="yes">Enable recursive status checks</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="active">True</property>
-                                    <property name="draw_indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="enable_emblems">
-                                    <property name="label" translatable="yes">Enable emblems</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="active">True</property>
-                                    <property name="draw_indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="show_debug">
-                                    <property name="label" translatable="yes">Show RabbitVCS debugging tools</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">The debug menu is used to diagnose problems with RabbitVCS itself</property>
-                                    <property name="draw_indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
                           </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="enable_recursive">
+                            <property name="label" translatable="yes">Enable recursive status checks</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="enable_emblems">
+                            <property name="label" translatable="yes">Enable emblems</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="show_debug">
+                            <property name="label" translatable="yes">Show RabbitVCS debugging tools</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="tooltip_text" translatable="yes">The debug menu is used to diagnose problems with RabbitVCS itself</property>
+                            <property name="halign">start</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">3</property>
+                          </packing>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -149,18 +177,18 @@
                 </child>
                 <child>
                   <object class="GtkBox" id="vbox20">
-                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="border_width">12</property>
+                    <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label10">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;Version Control Systems&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -169,51 +197,47 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment7">
+                      <object class="GtkBox" id="vbox21">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="margin_left">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkBox" id="vbox21">
-                            <property name="orientation">vertical</property>
+                          <object class="GtkCheckButton" id="enable_subversion">
+                            <property name="label" translatable="yes">Enable Subversion</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkCheckButton" id="enable_subversion">
-                                <property name="label" translatable="yes">Enable Subversion</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="active">True</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="enable_git">
-                                <property name="label" translatable="yes">Enable Git</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="active">True</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
                           </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="enable_git">
+                            <property name="label" translatable="yes">Enable Git</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -226,18 +250,18 @@
                 </child>
                 <child>
                   <object class="GtkBox" id="vbox17">
-                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="border_width">12</property>
+                    <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label19">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;Language&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -246,34 +270,14 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment4">
+                      <object class="GtkComboBox" id="language">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
-                        <child>
-                          <object class="GtkBox" id="vbox18">
-                            <property name="orientation">vertical</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkComboBox" id="language">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
+                        <property name="margin_left">12</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -297,24 +301,24 @@
             </child>
             <child>
               <object class="GtkBox" id="vbox2">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
                 <child>
                   <object class="GtkBox" id="vbox7">
-                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label4">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;Program used to compare files&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -323,121 +327,23 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment1">
+                      <object class="GtkBox" id="vbox8">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="margin_left">12</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="vbox8">
-                            <property name="orientation">vertical</property>
+                          <object class="GtkBox" id="hbox1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkBox" id="hbox1">
-                                <property name="orientation">horizontal</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkEntry" id="diff_tool">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="diff_tool_browse">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="tooltip_text" translatable="yes">Browse...</property>
-                                    <signal name="clicked" handler="on_external_diff_tool_browse_clicked" swapped="no"/>
-                                    <child>
-                                      <object class="GtkImage" id="image1">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="stock">gtk-harddisk</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="diff_tool_swap">
-                                <property name="label" translatable="yes">Show new version on the left side</property>
+                              <object class="GtkEntry" id="diff_tool">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="merge_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
-                        <property name="label" translatable="yes">&lt;b&gt;Configure the program to resolve conflicted files.&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkAlignment" id="alignment6">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
-                        <child>
-                          <object class="GtkBox" id="vbox19">
-                            <property name="orientation">vertical</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkEntry" id="merge_tool">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="invisible_char">•</property>
                                 <property name="primary_icon_activatable">False</property>
                                 <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
                               </object>
                               <packing>
                                 <property name="expand">True</property>
@@ -446,16 +352,20 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="merge_arg_hints">
+                              <object class="GtkButton" id="diff_tool_browse">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Use the following macros to configure the merge tool:
-%base       - The common ancestor of the two files to be merged.
-%mine      - The file you modified in your working copy.
-%theirs    - The file being merged into your working copy.
-%merged - The file to store the merged result.</property>
-                                <property name="track_visited_links">False</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="tooltip_text" translatable="yes">Browse...</property>
+                                <signal name="clicked" handler="on_external_diff_tool_browse_clicked" swapped="no"/>
+                                <child>
+                                  <object class="GtkImage" id="image1">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="icon_name">drive-harddisk</property>
+                                  </object>
+                                </child>
+                                <accelerator key="p" signal="clicked" modifiers="GDK_MOD1_MASK"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -464,10 +374,89 @@
                               </packing>
                             </child>
                           </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="diff_tool_swap">
+                            <property name="label" translatable="yes">Show new version on the left side</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">True</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="merge_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Configure the program to resolve conflicted files.&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="vbox19">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">12</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkEntry" id="merge_tool">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="invisible_char">•</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="secondary_icon_activatable">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="merge_arg_hints">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Use the following macros to configure the merge tool:
+%base       - The common ancestor of the two files to be merged.
+%mine      - The file you modified in your working copy.
+%theirs    - The file being merged into your working copy.
+%merged - The file to store the merged result.</property>
+                            <property name="track_visited_links">False</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">3</property>
                       </packing>
@@ -497,24 +486,24 @@
             </child>
             <child>
               <object class="GtkBox" id="vbox6">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
                 <child>
                   <object class="GtkBox" id="vbox10">
-                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;URL History&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -523,66 +512,57 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment8">
+                      <object class="GtkBox" id="hbox2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="margin_left">12</property>
+                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="hbox2">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkLabel" id="label2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkLabel" id="label2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Number of URLs to remember</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEntry" id="cache_number_repositories">
-                                <property name="width_request">60</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="primary_icon_activatable">False</property>
-                                <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="cache_clear_repositories">
-                                <property name="label">gtk-clear</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_stock">True</property>
-                                <signal name="clicked" handler="on_cache_clear_repositories_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
+                            <property name="label" translatable="yes">Number of URLs to remember</property>
+                            <property name="xalign">0</property>
                           </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="cache_number_repositories">
+                            <property name="width_request">60</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="secondary_icon_activatable">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="cache_clear_repositories">
+                            <property name="label" translatable="yes">Clear</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="image">edit-clear-1</property>
+                            <signal name="clicked" handler="on_cache_clear_repositories_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
+                          </packing>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -595,17 +575,17 @@
                 </child>
                 <child>
                   <object class="GtkBox" id="vbox11">
-                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label3">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;Log Messages&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -614,68 +594,59 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment9">
+                      <object class="GtkBox" id="hbox9">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="margin_left">12</property>
+                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="hbox9">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkLabel" id="label14">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkLabel" id="label14">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Number of messages to remember</property>
-                                <property name="wrap_mode">word-char</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="cache_clear_messages">
-                                <property name="label">gtk-clear</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_stock">True</property>
-                                <signal name="clicked" handler="on_cache_clear_messages_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEntry" id="cache_number_messages">
-                                <property name="width_request">60</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="primary_icon_activatable">False</property>
-                                <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
+                            <property name="label" translatable="yes">Number of messages to remember</property>
+                            <property name="wrap_mode">word-char</property>
+                            <property name="xalign">0</property>
                           </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="cache_clear_messages">
+                            <property name="label" translatable="yes">Clear</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="image">edit-clear-2</property>
+                            <signal name="clicked" handler="on_cache_clear_messages_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="pack_type">end</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="cache_number_messages">
+                            <property name="width_request">60</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="secondary_icon_activatable">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -688,17 +659,17 @@
                 </child>
                 <child>
                   <object class="GtkBox" id="vbox12">
-                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label5">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;Authentication&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -707,51 +678,44 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment10">
+                      <object class="GtkBox" id="hbox10">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="margin_left">12</property>
+                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="hbox10">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkLabel" id="label6">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkLabel" id="label6">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0.0099999997764825821</property>
-                                <property name="label" translatable="yes">Clear your authentication information</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="cache_clear_authentication">
-                                <property name="label">gtk-clear</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="use_stock">True</property>
-                                <signal name="clicked" handler="on_cache_clear_authentication_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="label" translatable="yes">Clear your authentication information</property>
+                            <property name="xalign">0.0099999997764825821</property>
                           </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="cache_clear_authentication">
+                            <property name="label" translatable="yes">Clear</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="image">edit-clear-3</property>
+                            <signal name="clicked" handler="on_cache_clear_authentication_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="pack_type">end</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -780,19 +744,19 @@
             </child>
             <child>
               <object class="GtkBox" id="vbox14">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label9">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="yalign">0</property>
                     <property name="label" translatable="yes">&lt;b&gt;Logging Options&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -801,46 +765,22 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment3">
+                  <object class="GtkBox" id="vbox16">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
+                    <property name="margin_left">12</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="vbox16">
-                        <property name="orientation">vertical</property>
+                      <object class="GtkBox" id="hbox5">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="hbox5">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkLabel" id="label11">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="label11">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Type:</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBox" id="logging_type">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="label" translatable="yes">Type:</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -849,47 +789,63 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="hbox7">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkComboBox" id="logging_type">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="label12">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Minimum level to log</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBox" id="logging_level">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="pack_type">end</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
+                            <property name="pack_type">end</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="hbox7">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkLabel" id="label12">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Minimum level to log</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBox" id="logging_level">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="pack_type">end</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
@@ -912,121 +868,102 @@
             </child>
             <child>
               <object class="GtkBox" id="vbox9">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkAlignment" id="alignment5">
+                  <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="yscale">0</property>
-                    <property name="left_padding">6</property>
-                    <property name="right_padding">6</property>
+                    <property name="margin_left">6</property>
+                    <property name="row_spacing">6</property>
+                    <property name="column_spacing">12</property>
                     <child>
-                      <object class="GtkTable" id="table1">
+                      <object class="GtkLabel" id="label13">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="n_rows">3</property>
-                        <property name="n_columns">2</property>
-                        <property name="column_spacing">12</property>
-                        <property name="row_spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="label13">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Checker type:&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
-                          </object>
-                          <packing>
-                            <property name="x_options">GTK_FILL</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label15">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Memory usage:&lt;/b&gt; </property>
-                            <property name="use_markup">True</property>
-                          </object>
-                          <packing>
-                            <property name="top_attach">2</property>
-                            <property name="bottom_attach">3</property>
-                            <property name="x_options">GTK_FILL</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="checker_type">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Unknown</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="x_options">GTK_FILL</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="memory_usage">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Unknown</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">2</property>
-                            <property name="bottom_attach">3</property>
-                            <property name="x_options">GTK_FILL</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label16">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Process ID:&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
-                          </object>
-                          <packing>
-                            <property name="top_attach">1</property>
-                            <property name="bottom_attach">2</property>
-                            <property name="x_options">GTK_FILL</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="pid">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">Unknown</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">1</property>
-                            <property name="bottom_attach">2</property>
-                            <property name="x_options">GTK_FILL</property>
-                          </packing>
-                        </child>
+                        <property name="label" translatable="yes">&lt;b&gt;Checker type:&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label16">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Process ID:&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label15">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Memory usage:&lt;/b&gt; </property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="checker_type">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Unknown</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="pid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Unknown</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="memory_usage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Unknown</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="padding">6</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHSeparator" id="hseparator1">
+                  <object class="GtkSeparator">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                   </object>
@@ -1043,15 +980,14 @@
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <object class="GtkAlignment" id="info_table_area">
+                      <object class="GtkBox" id="info_table_area">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="yalign">0</property>
-                        <property name="yscale">0</property>
-                        <property name="top_padding">12</property>
-                        <property name="bottom_padding">12</property>
-                        <property name="left_padding">12</property>
-                        <property name="right_padding">12</property>
+                        <property name="margin_left">12</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="orientation">vertical</property>
                         <child>
                           <placeholder/>
                         </child>
@@ -1074,7 +1010,6 @@
                 </child>
                 <child>
                   <object class="GtkButtonBox" id="hbuttonbox2">
-		    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="layout_style">center</property>
@@ -1084,6 +1019,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="image">view-refresh</property>
                         <signal name="clicked" handler="on_refresh_info_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -1098,6 +1034,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="image">system-run</property>
                         <signal name="clicked" handler="on_restart_checker_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -1112,6 +1049,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="image">process-stop</property>
                         <property name="yalign">0.54000002145767212</property>
                         <signal name="clicked" handler="on_stop_checker_clicked" swapped="no"/>
                       </object>
@@ -1146,18 +1084,18 @@
             </child>
             <child>
               <object class="GtkBox" id="vbox15">
-                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
+                <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label18">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">&lt;b&gt;Configuration Editor&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -1166,10 +1104,11 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="git_config_container">
+                  <object class="GtkBox" id="git_config_container">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
+                    <property name="margin_left">12</property>
+                    <property name="orientation">vertical</property>
                     <child>
                       <placeholder/>
                     </child>
@@ -1205,18 +1144,18 @@
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox1">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -1227,11 +1166,12 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>

--- a/rabbitvcs/ui/xml/settings.xml
+++ b/rabbitvcs/ui/xml/settings.xml
@@ -13,7 +13,8 @@
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">12</property>
@@ -23,11 +24,13 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox3">
+              <object class="GtkBox" id="vbox3">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox4">
+                  <object class="GtkBox" id="vbox4">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="border_width">12</property>
@@ -52,12 +55,14 @@
                         <property name="can_focus">False</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <object class="GtkBox" orientation="vertical" id="vbox5">
+                          <object class="GtkBox" id="vbox5">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkBox" orientation="vertical" id="vbox13">
+                              <object class="GtkBox" id="vbox13">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -143,7 +148,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox20">
+                  <object class="GtkBox" id="vbox20">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="border_width">12</property>
@@ -168,7 +174,8 @@
                         <property name="can_focus">False</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <object class="GtkBox" orientation="vertical" id="vbox21">
+                          <object class="GtkBox" id="vbox21">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -218,7 +225,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox17">
+                  <object class="GtkBox" id="vbox17">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="border_width">12</property>
@@ -243,7 +251,8 @@
                         <property name="can_focus">False</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <object class="GtkBox" orientation="vertical" id="vbox18">
+                          <object class="GtkBox" id="vbox18">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -287,13 +296,15 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox2">
+              <object class="GtkBox" id="vbox2">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
                 <property name="spacing">18</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox7">
+                  <object class="GtkBox" id="vbox7">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -317,12 +328,14 @@
                         <property name="can_focus">False</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <object class="GtkBox" orientation="vertical" id="vbox8">
+                          <object class="GtkBox" id="vbox8">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkBox" orientation="horizontal" id="hbox1">
+                              <object class="GtkBox" id="hbox1">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -412,7 +425,8 @@
                         <property name="can_focus">False</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <object class="GtkBox" orientation="vertical" id="vbox19">
+                          <object class="GtkBox" id="vbox19">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -482,13 +496,15 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox6">
+              <object class="GtkBox" id="vbox6">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
                 <property name="spacing">18</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox10">
+                  <object class="GtkBox" id="vbox10">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -512,7 +528,8 @@
                         <property name="can_focus">False</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox2">
+                          <object class="GtkBox" id="hbox2">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -577,7 +594,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox11">
+                  <object class="GtkBox" id="vbox11">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -601,7 +619,8 @@
                         <property name="can_focus">False</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox9">
+                          <object class="GtkBox" id="hbox9">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -668,7 +687,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox12">
+                  <object class="GtkBox" id="vbox12">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -692,7 +712,8 @@
                         <property name="can_focus">False</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox10">
+                          <object class="GtkBox" id="hbox10">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -758,7 +779,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox14">
+              <object class="GtkBox" id="vbox14">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
@@ -784,12 +806,14 @@
                     <property name="can_focus">False</property>
                     <property name="left_padding">12</property>
                     <child>
-                      <object class="GtkBox" orientation="vertical" id="vbox16">
+                      <object class="GtkBox" id="vbox16">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox5">
+                          <object class="GtkBox" id="hbox5">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -825,7 +849,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" orientation="horizontal" id="hbox7">
+                          <object class="GtkBox" id="hbox7">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -886,7 +911,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox9">
+              <object class="GtkBox" id="vbox9">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
@@ -1047,7 +1073,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox2">
+                  <object class="GtkButtonBox" id="hbuttonbox2">
+		    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="layout_style">center</property>
@@ -1118,7 +1145,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" orientation="vertical" id="vbox15">
+              <object class="GtkBox" id="vbox15">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
@@ -1176,7 +1204,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">6</property>

--- a/rabbitvcs/ui/xml/switch.xml
+++ b/rabbitvcs/ui/xml/switch.xml
@@ -11,13 +11,15 @@
     <signal handler="on_destroy" name="destroy"/>
     <signal handler="on_key_pressed" name="key_press_event"/>
     <child>
-      <object class="GtkBox" orientation="vertical" id="vbox19">
+      <object class="GtkBox" id="vbox19">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox1">
+          <object class="GtkBox" id="vbox1">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -37,12 +39,13 @@
                 <property name="visible">True</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkBox" orientation="vertical" id="vbox20">
+                  <object class="GtkBox" id="vbox20">
                     <property name="visible">True</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox1">
+                      <object class="GtkBox" id="hbox1">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label23">
@@ -73,7 +76,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" orientation="horizontal" id="hbox5">
+                      <object class="GtkBox" id="hbox5">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="label11">
@@ -90,8 +94,9 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxEntry" id="repositories">
+                          <object class="GtkComboBoxText" id="repositories">
                             <property name="visible">True</property>
+                            <property name="has-entry">True</property>
                           </object>
                           <packing>
                             <property name="position">1</property>
@@ -121,7 +126,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" orientation="vertical" id="vbox2">
+          <object class="GtkBox" id="vbox2">
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
@@ -158,7 +163,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" orientation="horizontal" id="hbuttonbox13">
+          <object class="GtkButtonBox" id="hbuttonbox13">
+	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>

--- a/rabbitvcs/ui/xml/switch.xml
+++ b/rabbitvcs/ui/xml/switch.xml
@@ -1,120 +1,148 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 2.6 -->
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Switch">
     <property name="width_request">550</property>
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Switch</property>
     <property name="window_position">center</property>
     <property name="icon_name">rabbitvcs-small</property>
-    <signal handler="on_destroy" name="destroy"/>
-    <signal handler="on_key_pressed" name="key_press_event"/>
+    <signal name="destroy" handler="on_destroy" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox19">
-        <property name="orientation">vertical</property>
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
           <object class="GtkBox" id="vbox1">
-            <property name="orientation">vertical</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Switch Details&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment1">
+              <object class="GtkBox" id="vbox20">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
-                  <object class="GtkBox" id="vbox20">
+                  <object class="GtkBox" id="hbox1">
                     <property name="visible">True</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">6</property>
+                    <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkBox" id="hbox1">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkLabel" id="label23">
+                        <property name="width_request">100</property>
                         <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label23">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="xpad">5</property>
-                            <property name="label" translatable="yes">From:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="path">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="hbox5">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label11">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="xalign">0</property>
-                            <property name="xpad">5</property>
-                            <property name="label" translatable="yes">To:</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBoxText" id="repositories">
-                            <property name="visible">True</property>
-                            <property name="has-entry">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="can_focus">False</property>
+                        <property name="xpad">5</property>
+                        <property name="label" translatable="yes">From:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="path">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="hbox5">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="label11">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xpad">5</property>
+                        <property name="label" translatable="yes">To:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="repositories">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="has_entry">True</property>
+                        <child internal-child="entry">
+                          <object class="GtkEntry">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -128,30 +156,36 @@
         <child>
           <object class="GtkBox" id="vbox2">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
-                <property name="xalign">0</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Revision&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="revision_container">
+              <object class="GtkBox" id="revision_container">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -164,18 +198,19 @@
         </child>
         <child>
           <object class="GtkButtonBox" id="hbuttonbox13">
-	    <property name="orientation">horizontal</property>
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="spacing">6</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_cancel_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -185,12 +220,13 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_ok_clicked" name="clicked"/>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/rabbitvcs/ui/xml/update.xml
+++ b/rabbitvcs/ui/xml/update.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="rabbitvcs-cancel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-cancel</property>
+  </object>
+  <object class="GtkImage" id="rabbitvcs-ok">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">rabbitvcs-ok</property>
+  </object>
   <object class="GtkWindow" id="Update">
     <property name="width_request">400</property>
     <property name="visible">True</property>
@@ -11,6 +21,9 @@
     <property name="icon_name">rabbitvcs-small</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_key_pressed" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="vbox25">
         <property name="visible">True</property>
@@ -26,11 +39,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-cancel</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -41,11 +55,12 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="image">rabbitvcs-ok</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>
@@ -71,6 +86,7 @@
               <object class="GtkLabel" id="revision_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="valign">start</property>
                 <property name="label" translatable="yes">&lt;b&gt;Revision&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
                 <property name="xalign">0</property>
@@ -82,17 +98,18 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="revision_container">
+              <object class="GtkBox" id="revision_container">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="valign">start</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -114,6 +131,7 @@
                 <property name="label" translatable="yes">&lt;b&gt;Options&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
                 <property name="xalign">0</property>
+                <property name="yalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -122,64 +140,62 @@
               </packing>
             </child>
             <child>
-              <object class="GtkAlignment" id="alignment2">
+              <object class="GtkBox" id="vbox26">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="margin_left">12</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="vbox26">
+                  <object class="GtkCheckButton" id="recursive">
+                    <property name="label" translatable="yes">Recursive</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkCheckButton" id="recursive">
-                        <property name="label" translatable="yes">Recursive</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="omit_externals">
-                        <property name="label" translatable="yes">Omit Externals</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="rollback">
-                        <property name="label" translatable="yes">Rollback to specified revision number</property>
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="omit_externals">
+                    <property name="label" translatable="yes">Omit Externals</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="rollback">
+                    <property name="label" translatable="yes">Rollback to specified revision number</property>
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -191,9 +207,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/rabbitvcs/util/configspec/configspec.ini
+++ b/rabbitvcs/util/configspec/configspec.ini
@@ -9,6 +9,7 @@ show_unversioned_files = boolean(default=True)
 [external]
 diff_tool = string(default="/usr/bin/meld")
 diff_tool_swap = boolean(default=False)
+merge_tool = string(default="")
 
 [cache]
 number_repositories = integer(default=30)

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -32,7 +32,7 @@ from six.moves import range
 from .contextmenuitems import *
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk as gtk
 from gi.repository import GLib as glib
 
@@ -291,7 +291,7 @@ class ContextMenuCallbacks:
         window.set_resizable(True)
         window.set_position(gtk.WIN_POS_CENTER)
         scrolled_window = gtk.ScrolledWindow()
-        scrolled_window.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        scrolled_window.set_policy(gtk.PolicyType.AUTOMATIC, gtk.PolicyType.AUTOMATIC)
         ipython_view = IPythonView()
         ipython_view.updateNamespace(locals())
         ipython_view.set_wrap_mode(gtk.WRAP_CHAR)

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -31,8 +31,10 @@ from six.moves import range
 # Yes, * imports are bad. You write it out then.
 from .contextmenuitems import *
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk as gtk
-from gi.repository import GObject as gobject
+from gi.repository import GLib as glib
 
 from rabbitvcs.vcs import create_vcs_instance, VCS_SVN, VCS_GIT, VCS_DUMMY, VCS_MERCURIAL
 from rabbitvcs.util.log import Log
@@ -246,7 +248,7 @@ class GtkContextMenuCaller:
             return still_going
 
         # Add our callback function on a 1 second timeout
-        gobject.timeout_add_seconds(1, is_process_still_alive)
+        glib.timeout_add_seconds(1, is_process_still_alive)
         
 class ContextMenuCallbacks:
     """
@@ -332,7 +334,7 @@ class ContextMenuCallbacks:
                     nautilusVFSFile_table[path].add_emblem(emblem)
             return False
             
-        gobject.idle_add(add_emblem_dialog)
+        glib.idle_add(add_emblem_dialog)
     
     # End debugging callbacks
 

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -754,6 +754,7 @@ class ContextMenuConditions:
     def rename(self, data=None):
         return (self.path_dict["length"] == 1 and
                 self.path_dict["is_in_a_or_a_working_copy"] and
+                not self.path_dict["is_working_copy"] and
                 self.path_dict["is_versioned"])
         
     def delete(self, data=None):

--- a/rabbitvcs/util/contextmenuitems.py
+++ b/rabbitvcs/util/contextmenuitems.py
@@ -50,7 +50,7 @@ class MenuItem(object):
         identifier = "RabbitVCS::Perform_Magic"
         label = _("Perform Magic")
         tooltip = _("Put on your robe and wizard hat")
-        icon = "rabbitvcs-wand" # or, say, Gtk.STOCK_OPEN
+        icon = "rabbitvcs-wand"
     
     There is some introspection magic that goes on to associate the items
     themselves with certain methods of a ContextMenuCondition object or a
@@ -94,7 +94,7 @@ class MenuItem(object):
     tooltip = ""
     
     # The icon that will appear on the menu item. This can be, say,
-    # "rabbitvcs-something" or Gtk.STOCK_SOMETHING
+    # "rabbitvcs-something"
     icon = None
 
     # This is a string that holds the name of the function that is called when
@@ -213,7 +213,7 @@ class MenuItem(object):
             # that method is not available until pyGtk 2.16
             action.set_menu_item_type(Gtk.ImageMenuItem)
             menuitem = action.create_menu_item()
-            menuitem.set_image(Gtk.image_new_from_icon_name(self.icon, Gtk.ICON_SIZE_MENU))
+            menuitem.set_image(Gtk.image_new_from_icon_name(self.icon, Gtk.IconSize.MENU))
         else:
             menuitem = action.create_menu_item()
             
@@ -397,7 +397,7 @@ class MenuRepoBrowser(MenuItem):
     identifier = "RabbitVCS::Repo_Browser"
     label = _("Repository Browser")
     tooltip = _("Browse a repository tree")
-    icon = Gtk.STOCK_FIND
+    icon = "edit-find"
 
 class MenuCheckForModifications(MenuItem):
     identifier = "RabbitVCS::Check_For_Modifications"
@@ -623,7 +623,7 @@ class MenuOpen(MenuItem):
     identifier = "RabbitVCS::Open"
     label = _("Open")
     tooltip = _("Open a file")
-    icon = Gtk.STOCK_OPEN
+    icon = "document-open"
     # Not sure why, but it was like this before...
     condition_name = "_open"
     callback_name = "_open"
@@ -632,7 +632,7 @@ class MenuBrowseTo(MenuItem):
     identifier = "RabbitVCS::Browse_To"
     label = _("Browse to")
     tooltip = _("Browse to a file or folder")
-    icon = Gtk.STOCK_HARDDISK
+    icon = "drive-harddisk"
 
 class PropMenuRevert(MenuItem):
     identifier = "RabbitVCS::Property_Revert"
@@ -663,7 +663,7 @@ class PropMenuDeleteRecursive(MenuItem):
 class PropMenuEdit(MenuItem):
     identifier = "RabbitVCS::Property_Edit"
     label = _("Edit details")
-    icon = Gtk.STOCK_EDIT
+    icon = "rabbitvcs-editprops"
     tooltip = _("Show and edit property details")
 
 class MenuInitializeRepository(MenuItem):
@@ -802,7 +802,7 @@ class RabbitVCSAction(Gtk.Action):
             try:
                 self.set_icon_name(self.stock_id)
             except AttributeError as e:
-                menu_item.set_image(Gtk.image_new_from_icon_name(self.stock_id, Gtk.ICON_SIZE_MENU))
+                menu_item.set_image(Gtk.image_new_from_icon_name(self.stock_id, Gtk.IconSize.MENU))
 
         if self.sub_actions is not None:
             menu = Gtk.Menu()

--- a/rabbitvcs/util/contextmenuitems.py
+++ b/rabbitvcs/util/contextmenuitems.py
@@ -23,6 +23,8 @@ from __future__ import absolute_import
 import os.path
 
 import os
+import gi
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
     
 import rabbitvcs.util.helper

--- a/rabbitvcs/util/decorators.py
+++ b/rabbitvcs/util/decorators.py
@@ -36,13 +36,13 @@ from __future__ import absolute_import
 
 import os
 
-import gi
-gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk as Gtk
+from gi.repository import GLib
 
 import time
 import warnings
 import threading
+
+from rabbitvcs.util import helper
 
 from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.util.decorators")
@@ -121,18 +121,12 @@ def disable(func):
 def gtk_unsafe(func):
     """
     Used to wrap a function that makes calls to GTK from a thread in
-    Gdk.threads_enter() and Gdk.threads_leave().
-    
+    the main thread's idle loop.
     """
 
-    from gi.repository import Gdk
-    
     def newfunc(*args, **kwargs):
-        Gdk.threads_enter()
-        result = func(*args, **kwargs)
-        Gdk.threads_leave()
-        return result
-        
+        return helper.run_in_main_thread(func, *args, **kwargs)
+
     return update_func_meta(newfunc, func)
 
 def debug_calls(caller_log, show_caller=False):

--- a/rabbitvcs/util/decorators.py
+++ b/rabbitvcs/util/decorators.py
@@ -121,7 +121,7 @@ def disable(func):
 def gtk_unsafe(func):
     """
     Used to wrap a function that makes calls to GTK from a thread in
-    Gtk.gdk.threads_enter() and Gtk.gdk.threads_leave().
+    Gdk.threads_enter() and Gdk.threads_leave().
     
     """
 

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -72,6 +72,22 @@ LINE_BREAK_CHAR = u'\u23CE'
 from rabbitvcs import gettext
 _ = gettext.gettext
 
+def compare_version(version1, version2, length = None):
+    if not length:
+        length = max(len(version1), len(version2))
+    for i in range(length):
+        x = int(version1[i]) if i in version1 else 0
+        y = int(version2[i]) if i in version2 else 0
+        r = x - y
+        if r:
+            return r
+    return 0
+
+def gobject_threads_init():
+    # Wrap to avoid deprecated call.
+    if compare_version(GObject.pygobject_version, [3, 10, 2]) < 0:
+        GObject.threads_init()
+
 def get_tmp_path(filename):
     day = datetime.datetime.now().day
     day_string = (str(day) + str(os.geteuid())).encode("utf-8")

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -88,6 +88,18 @@ def gobject_threads_init():
     if compare_version(GObject.pygobject_version, [3, 10, 2]) < 0:
         GObject.threads_init()
 
+def to_text(s):
+    # We cannot use a six.text_type() constructor alone as a bytes to text
+    # converter because it uses the str() function that stores the bytes type
+    # mark in the result under Python 3.
+    # Instead, decode it as UTF-8.
+    if isinstance(s, bytearray):
+        s = bytes(s)
+    if not isinstance(s, six.text_type):
+        if isinstance(s, bytes):
+            s = s.decode("utf-8")
+    return six.text_type(s)
+
 def get_tmp_path(filename):
     day = datetime.datetime.now().day
     day_string = (str(day) + str(os.geteuid())).encode("utf-8")
@@ -666,7 +678,7 @@ def save_repository_path(path):
         paths.pop()
     
     f = open(get_repository_paths_path(), "w")
-    f.write(six.text_type("\n".join(paths).encode("utf-8")))
+    f.write(to_text("\n".join(paths).encode("utf-8")))
     f.close()
     
 def launch_ui_window(filename, args=[], block=False):

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -39,18 +39,10 @@ import time
 import shutil
 import hashlib
 
-# A hacky way to get this working with python2 or 3
-try:
-    from urlparse import urlparse, urlunparse
-    from urllib import quote, quote_plus, unquote, unquote_plus
-except ImportError:
-    from urllib.parse import urlparse, urlunparse, quote, quote_plus, unquote, unquote_plus
-
-    
+import six
 from six.moves import filter
 from six.moves import range
-
-from gi.repository import GObject as gobject
+from six.moves.urllib.parse import urlparse, urlunparse, quote, quote_plus, unquote, unquote_plus
 
 import rabbitvcs.util.settings
 
@@ -59,6 +51,14 @@ log = Log("rabbitvcs.util.helper")
 
 from rabbitvcs import gettext
 ngettext = gettext.ngettext
+
+try:
+    from html import escape as html_escape
+except ImportError:
+    from cgi import escape as html_escape
+
+import gi
+from gi.repository import GObject
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M" # for log files
 LOCAL_DATETIME_FORMAT = locale.nl_langinfo(locale.D_T_FMT) # for UIs
@@ -650,7 +650,7 @@ def save_repository_path(path):
         paths.pop()
     
     f = open(get_repository_paths_path(), "w")
-    f.write("\n".join(paths).encode("utf-8"))
+    f.write(six.text_type("\n".join(paths).encode("utf-8")))
     f.close()
     
 def launch_ui_window(filename, args=[], block=False):
@@ -863,11 +863,11 @@ def unquote_url(url_text):
 
 def pretty_filesize(bytes):
     if bytes >= 1073741824:
-        return str(bytes / 1073741824) + ' GB'
+        return str(int(bytes / 1073741824)) + ' GB'
     elif bytes >= 1048576:
-        return str(bytes / 1048576) + ' MB'
+        return str(int(bytes / 1048576)) + ' MB'
     elif bytes >= 1024:
-        return str(bytes / 1024) + ' KB'
+        return str(int(bytes / 1024)) + ' KB'
     elif bytes < 1024:
         return str(bytes) + ' bytes'
 

--- a/rabbitvcs/vcs/git/__init__.py
+++ b/rabbitvcs/vcs/git/__init__.py
@@ -31,14 +31,13 @@ from datetime import datetime
 from .gittyup.client import GittyupClient
 from .gittyup import objects
 
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 
 import rabbitvcs.vcs
 import rabbitvcs.vcs.status
 import rabbitvcs.vcs.log
 from rabbitvcs.vcs.branch import BranchEntry
 from rabbitvcs.util.log import Log
-import six
 
 log = Log("rabbitvcs.vcs.git")
 
@@ -62,13 +61,13 @@ class Revision:
 
     def __unicode__(self):
         if self.value:
-            return six.text_type(self.value)
+            return helper.to_text(self.value)
         else:
             return self.kind
             
     def short(self):
         if self.value:
-            return six.text_type(self.value)[0:7]
+            return helper.to_text(self.value)[0:7]
         else:
             return self.kind
 
@@ -912,7 +911,7 @@ class Git:
 
         any_failures = False
 
-        for file, success, rej_file in rabbitvcs.util.helper.parse_patch_output(patch_file, base_dir, 1):
+        for file, success, rej_file in helper.parse_patch_output(patch_file, base_dir, 1):
 
             fullpath = os.path.join(base_dir, file)
 

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -882,17 +882,16 @@ class GittyupClient:
     def move(self, source, dest):
         """
         Move a file within the repository
-        
+
         @type   source: string
         @param  source: The source file
-        
+
         @type   dest: string
         @param  dest: The destination.  If dest exists as a directory, source
             will be added as a child.  Otherwise, source will be renamed to
             dest.
-            
         """
-        
+
         index = self._get_index()
         relative_source = self.get_relative_path(source)
         relative_dest = self.get_relative_path(dest)
@@ -901,22 +900,24 @@ class GittyupClient:
         source_files = []
         if os.path.isdir(source):
             for name in index:
+                name = name.decode(self.UTF8)
                 if name.startswith(relative_source):
                     source_files.append(name)
         else:
-            source_files.append(self.get_relative_path(source))
+            source_files.append(relative_source)
 
         # Rename the affected index entries
         for source_file in source_files:
-            new_path = source_file.replace(relative_source, relative_dest)            
+            new_path = source_file.replace(relative_source, relative_dest)
             if os.path.isdir(dest):
                 new_path = os.path.join(new_path, os.path.basename(source_file))
 
-            index[new_path] = index[source_file]
+            source_file = source_file.encode(self.UTF8)
+            index[new_path.encode(self.UTF8)] = index[source_file]
             del index[source_file]
 
         index.write()
-        
+
         # Actually move the file/folder
         shutil.move(source, dest)
 
@@ -1832,13 +1833,13 @@ class GittyupClient:
         for line in results.split("\n"):
             if not line:
                 continue
-                
-            (action, path) = line.split("\t")
+
+            (action, path) = (line + "\t").split("\t")[:2]
             summary.append({
                 "action": action,
                 "path": path
             })
-        
+
         return summary
 
     def export(self, path, dest_path, revision):

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -29,6 +29,8 @@ from . import util
 from .objects import *
 from .command import GittyupCommand
 
+from rabbitvcs.util import helper
+
 import six.moves.tkinter
 import six.moves.tkinter_messagebox
 import six
@@ -357,8 +359,8 @@ class GittyupClient:
 
     def _get_config_user(self):
         try:
-            config_user_name = six.text_type(self._config_get(("user", ), "name"))
-            config_user_email = six.text_type(self._config_get(("user", ), "email"))
+            config_user_name = helper.to_text(self._config_get(("user", ), "name"))
+            config_user_email = helper.to_text(self._config_get(("user", ), "email"))
             if config_user_name == "" or config_user_email == "":
                 raise KeyError()
         except KeyError:
@@ -1080,7 +1082,7 @@ class GittyupClient:
 
         if remoteKey.find("://") == -1:
             # Get existing url from config, otherwise just use what was provided (the url from cloning, etc).
-            originalRemoteUrl = six.text_type(self._config_get(remoteKey, "url"))
+            originalRemoteUrl = helper.to_text(self._config_get(remoteKey, "url"))
 
         if originalRemoteUrl.find('@') == -1:
             # No username or password. Prompt for both. Create dialog.
@@ -1137,7 +1139,7 @@ class GittyupClient:
 
         if remoteKey.find("://") == -1:
             # Get existing url from config, otherwise just use what was provided (the url from cloning, etc).
-            originalRemoteUrl = six.text_type(self._config_get(remoteKey, "url"))
+            originalRemoteUrl = helper.to_text(self._config_get(remoteKey, "url"))
 
         # If the url contains a username (@) without a password (:), then prompt for a password.
         if originalRemoteUrl.find('@') > -1 and originalRemoteUrl.rfind(':') <= 5:
@@ -1365,7 +1367,7 @@ class GittyupClient:
 
         tags = []
         for ref,tag_sha in list(refs.items()):
-            if six.text_type(ref).startswith("refs/tags"):
+            if helper.to_text(ref).startswith("refs/tags"):
                 if type(self.repo[tag_sha]) == dulwich.objects.Commit:
                     tag = CommitTag(ref[10:], tag_sha, self.repo[tag_sha])
                 else:

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -685,6 +685,8 @@ class GittyupClient:
             tracking = components.pop(0) == "*" and True or False
             if components[0] == "(no":
                 name = components.pop(0) + " " + components.pop(0)
+            elif components[0] == "(HEAD":
+                continue            # Detached head is not a branch.
             else:
                name = components.pop(0)
             revision = components.pop(0)

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -607,7 +607,7 @@ class GittyupClient:
         cmd += [name, commit_sha]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -670,7 +670,7 @@ class GittyupClient:
             cmd += ["--contains", commit_sha]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -719,7 +719,7 @@ class GittyupClient:
         cmd = ["git", "checkout", "-m", revision] + paths
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
         
@@ -757,7 +757,7 @@ class GittyupClient:
         self.modifiedHost = host
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=base_dir, notify=self.notify_and_parse_progress, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=base_dir, notify=self.notify_and_parse_progress, cancel=self.get_cancel()).execute()
 
             if stdout[1].find('could not read Username') > -1:
                 # Prompt for username if it does not exist in the url.
@@ -774,7 +774,7 @@ class GittyupClient:
                 cmd = ["git", "clone", self.modifiedHost, path] + more
 
                 # Try again.
-                (status, stdout, stderr) = GittyupCommand(cmd, cwd=base_dir, notify=self.notify_and_parse_progress, cancel=self.get_cancel).execute()
+                (status, stdout, stderr) = GittyupCommand(cmd, cwd=base_dir, notify=self.notify_and_parse_progress, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -961,7 +961,7 @@ class GittyupClient:
         isPassword = False
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel()).execute()
             if stdout[0].find('could not read Username') > -1:
                 # Prompt for username if it does not exist in the url.
                 isUsername, originalRemoteUrl = self.promptUsername(remoteKey)
@@ -974,7 +974,7 @@ class GittyupClient:
 
             if isUsername == True or isPassword == True:
                 # Try again.
-                (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel).execute()
+                (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1013,7 +1013,7 @@ class GittyupClient:
         isPassword = False
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel()).execute()
             if stdout[0].find('could not read Username') > -1:
                 # Prompt for username if it does not exist in the url.
                 isUsername, originalRemoteUrl = self.promptUsername(remoteKey)
@@ -1026,7 +1026,7 @@ class GittyupClient:
 
             if isUsername == True or isPassword == True:
                 # Try again.
-                (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel).execute()
+                (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1209,21 +1209,21 @@ class GittyupClient:
             cmd.append(branch)
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
     
     def fetch_all(self):
         cmd = ["git", "fetch", "--all"]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             
     def merge(self, branch):
         cmd = ["git", "merge", branch]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
     
@@ -1241,7 +1241,7 @@ class GittyupClient:
         
         cmd = ["git", "remote", "add", name, host]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
     
@@ -1259,7 +1259,7 @@ class GittyupClient:
         
         cmd = ["git", "remote", "rename", current_name, new_name]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
     
@@ -1277,7 +1277,7 @@ class GittyupClient:
         
         cmd = ["git", "remote", "set-url", name, url]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
     
@@ -1292,7 +1292,7 @@ class GittyupClient:
         
         cmd = ["git", "remote", "rm", name]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
     
@@ -1308,7 +1308,7 @@ class GittyupClient:
         cmd = ["git", "remote", "-v"]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
@@ -1736,7 +1736,7 @@ class GittyupClient:
         cmd = ["git", "annotate", "-l", revision_obj, relative_path]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
@@ -1782,7 +1782,7 @@ class GittyupClient:
 
         cmd = ["git", "show", "%s:%s" % (revision_obj, relative_path)]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
@@ -1828,7 +1828,7 @@ class GittyupClient:
             cmd += [relative_path2]
             
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
@@ -1872,8 +1872,8 @@ class GittyupClient:
         mkdir_p(dest_path)
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd1, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
-            (status, stdout, stderr) = GittyupCommand(cmd2, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd1, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd2, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
@@ -1904,7 +1904,7 @@ class GittyupClient:
         cmd.append(relative_path)
         
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             return
@@ -1921,7 +1921,7 @@ class GittyupClient:
             cmd.append(relative_path)
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel).execute()
+            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             return

--- a/rabbitvcs/vcs/git/gittyup/command.py
+++ b/rabbitvcs/vcs/git/gittyup/command.py
@@ -25,9 +25,9 @@ class GittyupCommand:
         if notify:
             self.notify = notify
 
-        self.get_cancel = cancel_func
+        self.cancel = cancel_func
         if cancel:
-            self.get_cancel = cancel
+            self.cancel = cancel
 
         self.cwd = cwd
         if not self.cwd:
@@ -66,7 +66,7 @@ class GittyupCommand:
             self.notify(line)
             stdout.append(line)
 
-            if self.get_cancel():
+            if self.cancel():
                 proc.kill()
 
         return (0, stdout, None)

--- a/rabbitvcs/vcs/git/gittyup/command.py
+++ b/rabbitvcs/vcs/git/gittyup/command.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import subprocess
 import fcntl
 import select
+import encodings
 import os
 
 from .exceptions import GittyupCommandError
@@ -51,18 +52,17 @@ class GittyupCommand:
                                 stdout=subprocess.PIPE,
                                 env=env,
                                 close_fds=True,
-                                preexec_fn=os.setsid,
-                                encoding="utf-8",
-                                universal_newlines=True)
+                                preexec_fn=os.setsid)
 
+        out = encodings.utf_8.StreamReader(proc.stdout)
         stdout = []
 
         while True:
-            line = proc.stdout.readline()
+            line = out.readline()
 
             if line == '':
                 break
-            line = line.rstrip('\n') # Strip trailing newline.
+            line = line.rstrip("\r\n") # Strip trailing newline.
             self.notify(line)
             stdout.append(line)
 

--- a/rabbitvcs/vcs/git/gittyup/objects.py
+++ b/rabbitvcs/vcs/git/gittyup/objects.py
@@ -129,7 +129,7 @@ class Tag(GittyupObject):
 
 class CommitTag(Commit):
     def __init__(self, name, sha, obj):
-        self.name = name
+        self._name = name
         self.sha = sha
         self.obj = obj
 
@@ -138,8 +138,8 @@ class CommitTag(Commit):
 
     @property
     def name(self):
-        return self.name
-    
+        return self._name
+
     def __eq__(self, other):
         return (self.name == other)
 
@@ -150,7 +150,7 @@ class CommitTag(Commit):
     @property
     def message(self):
         return self.obj.message
-    
+
     @property
     def tagger(self):
         return self.obj.committer
@@ -158,7 +158,7 @@ class CommitTag(Commit):
     @property
     def tag_time(self):
         return self.obj.commit_time
-    
+
     @property
     def tag_timezone(self):
         return self.obj.commit_timezone
@@ -169,7 +169,7 @@ class Tree(GittyupObject):
 
 class Branch(Commit):
     def __init__(self, name, sha, obj):
-        self.name = name
+        self._name = name
         self.sha = sha
         self.obj = obj
 
@@ -178,7 +178,7 @@ class Branch(Commit):
 
     @property
     def name(self):
-        return self.obj.name
-    
+        return self._name
+
     def __eq__(self, other):
         return (self.name == other)

--- a/rabbitvcs/vcs/mercurial/__init__.py
+++ b/rabbitvcs/vcs/mercurial/__init__.py
@@ -30,7 +30,7 @@ from datetime import datetime
 
 from mercurial import commands, ui, hg
 
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 
 import rabbitvcs.vcs
 import rabbitvcs.vcs.status
@@ -38,7 +38,6 @@ import rabbitvcs.vcs.log
 import rabbitvcs.vcs.mercurial.util
 from rabbitvcs.vcs.branch import BranchEntry
 from rabbitvcs.util.log import Log
-import six
 
 log = Log("rabbitvcs.vcs.mercurial")
 
@@ -62,13 +61,13 @@ class Revision:
 
     def __unicode__(self):
         if self.value:
-            return six.text_type(self.value)
+            return helper.to_text(self.value)
         else:
             return self.kind
             
     def short(self):
         if self.value:
-            return six.text_type(self.value)[0:7]
+            return helper.to_text(self.value)[0:7]
         else:
             return self.kind
 

--- a/rabbitvcs/vcs/status.py
+++ b/rabbitvcs/vcs/status.py
@@ -401,13 +401,14 @@ STATUS_TYPES = [
 ]
 
 class TestStatusObjects(unittest.TestCase):
-    def setUp(self):
+    
+    @classmethod
+    def __initclass__(self):
         self.base = "/path/to/test"
-        
         self.children = [
             os.path.join(self.base, chr(x)) for x in range(97,123) 
-                ]
-    
+        ]
+
     def testsingle_clean(self):
         status = Status(self.base, status_normal)
         self.assertEqual(status.single, status_normal)
@@ -487,6 +488,9 @@ class TestStatusObjects(unittest.TestCase):
         
         top_status.make_summary(child_sts)
         self.assertEqual(top_status.summary, status_added)
+
+TestStatusObjects.__initclass__()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -36,10 +36,9 @@ import pysvn
 import rabbitvcs.vcs
 import rabbitvcs.vcs.status
 import rabbitvcs.vcs.log
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from six.moves import map
-import six
 from six.moves import range
 
 log = Log("rabbitvcs.vcs.svn")
@@ -68,7 +67,7 @@ class Revision:
     }
 
     def __init__(self, kind, value=None):
-        self.kind = six.text_type(kind).lower()
+        self.kind = helper.to_text(kind).lower()
         self.value = value
         self.is_revision_object = True
 
@@ -95,7 +94,7 @@ class Revision:
 
     def __unicode__(self):
         if self.value:
-            return six.text_type(self.value)
+            return helper.to_text(self.value)
         else:
             return self.kind
 
@@ -1041,8 +1040,8 @@ class SVN:
         @param  revision: A pysvn.Revision object.
 
         """
-        src = rabbitvcs.util.helper.urlize(src)
-        dest = rabbitvcs.util.helper.urlize(dest)
+        src = helper.urlize(src)
+        dest = helper.urlize(dest)
         return self.client.copy(src, dest, revision.primitive())
 
     def copy_all(self, sources, dest_url_or_path, copy_as_child=False,
@@ -1094,7 +1093,7 @@ class SVN:
 
         """
 
-        url = rabbitvcs.util.helper.urlize(url)
+        url = helper.urlize(url)
 
         return self.client.checkout(url, path, recurse=recurse,
             revision=revision.primitive(), ignore_externals=ignore_externals)
@@ -1269,7 +1268,7 @@ class SVN:
 
         """
 
-        url = rabbitvcs.util.helper.urlize(url)
+        url = helper.urlize(url)
         return self.client.import_(path, url, log_message, ignore)
 
     def lock(self, url_or_path, lock_comment, force=False):
@@ -1306,8 +1305,8 @@ class SVN:
 
         """
         
-        from_url = rabbitvcs.util.helper.urlize(from_url)
-        to_url = rabbitvcs.util.helper.urlize(to_url)
+        from_url = helper.urlize(from_url)
+        to_url = helper.urlize(to_url)
         return self.client.relocate(from_url, to_url, path, recurse)
 
     def move(self, src_url_or_path, dest_url_or_path):
@@ -1413,7 +1412,7 @@ class SVN:
 
         """
 
-        url = rabbitvcs.util.helper.urlize(url)
+        url = helper.urlize(url)
         return self.client.switch(path, url, revision.primitive())
 
     def unlock(self, path, force=False):
@@ -1553,8 +1552,8 @@ class SVN:
 
         """
 
-        url_or_path1 = rabbitvcs.util.helper.urlize(url_or_path1)
-        url_or_path2 = rabbitvcs.util.helper.urlize(url_or_path2)
+        url_or_path1 = helper.urlize(url_or_path1)
+        url_or_path2 = helper.urlize(url_or_path2)
         return self.client.merge(url_or_path1, revision1.primitive(),
             url_or_path2, revision2.primitive(), local_path, force, recurse,
             record_only)
@@ -1659,7 +1658,7 @@ class SVN:
             url_or_path2, revision2.primitive(), recurse, ignore_ancestry)
 
     def list(self, url_or_path, revision=Revision("HEAD"), recurse=True):
-        url_or_path = rabbitvcs.util.helper.urlize(url_or_path)
+        url_or_path = helper.urlize(url_or_path)
         return self.client.list(url_or_path, revision=revision.primitive(),
             recurse=recurse)
 
@@ -1691,7 +1690,7 @@ class SVN:
 
         any_failures = False
 
-        for file, success, rej_file in rabbitvcs.util.helper.parse_patch_output(patch_file, base_dir):
+        for file, success, rej_file in helper.parse_patch_output(patch_file, base_dir):
 
             fullpath = os.path.join(base_dir, file)
 


### PR DESCRIPTION
These commits are a follow-up to the work that has already been done on the gtk3 branch.
They improve the gtk3 compatibility, dropping gtk2 support.
They also tend towards Python 3, retaining Python 2 compatibility.
- Glade files reworked.
- Gi-compatible Gtk constants used.
- Deprecated Gtk3 features replaced.
- Gtk thread-safety via GLib idle callbacks.
- Additional icons to replace deprecated stock items.
- Some bugs fixed.
- Mostly usable, although there are still many bugs that already existed with gtk2+python2.

Outdated client files have been retained, although not anymore functioning. Non-Caja clients are not tested.

I would be interested in knowing this project status and what are the plans for the future. Thanks.

My development/test environment is Fedora 29 64bit, Gtk3, Python 3.7 and Caja.

Thanks for considering this PR.