### PR TITLE
Encoding

### DIFF
--- a/clients/caja/RabbitVCS.py
+++ b/clients/caja/RabbitVCS.py
@@ -76,11 +76,12 @@ import rabbitvcs.vcs.status
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
-from rabbitvcs.util.helper import to_text
 
 from rabbitvcs.util.decorators import timeit, disable
 
 from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
+
+from rabbitvcs.util.strings import S
 
 import rabbitvcs.ui
 import rabbitvcs.ui.property_page
@@ -438,8 +439,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
         import cProfile
         import rabbitvcs.util.helper
 
-        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()),
-                       "utf-8").replace("/", ":")
+        path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
                                rabbitvcs.util.helper.get_home_folder(),

--- a/clients/caja/RabbitVCS.py
+++ b/clients/caja/RabbitVCS.py
@@ -65,8 +65,11 @@ import os.path
 from os.path import isdir, isfile, realpath, basename, dirname
 import datetime
 
-#import matevfs
+from rabbitvcs.util import helper
+
+sa = helper.SanitizeArgv()
 from gi.repository import Caja, GObject, Gtk, GdkPixbuf
+sa.restore()
 
 import pysvn
 
@@ -76,6 +79,7 @@ import rabbitvcs.vcs.status
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import unquote_url
 
 from rabbitvcs.util.decorators import timeit, disable
 
@@ -270,7 +274,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
 
         if not self.valid_uri(item.get_uri()): return Caja.OperationResult.FAILED
 
-        path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+        path = unquote_url(self.get_local_path(item.get_uri()))
 
         # log.debug("update_file_info() called for %s" % path)
 
@@ -387,7 +391,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+                path = unquote_url(self.get_local_path(item.get_uri()))
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 
@@ -416,7 +420,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+                path = unquote_url(self.get_local_path(item.get_uri()))
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 
@@ -437,12 +441,11 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
     # rename the real function "get_background_items_real".
     def get_background_items_profile(self, window, item):
         import cProfile
-        import rabbitvcs.util.helper
 
         path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
-                               rabbitvcs.util.helper.get_home_folder(),
+                               helper.get_home_folder(),
                                "checkerservice_%s.stats" % path)
 
         prof = cProfile.Profile()
@@ -468,7 +471,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
         """
 
         if not self.valid_uri(item.get_uri()): return
-        path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+        path = unquote_url(self.get_local_path(item.get_uri()))
         self.nautilusVFSFile_table[path] = item
 
         # log.debug("get_background_items_full() called")
@@ -489,7 +492,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
 
     def get_background_items(self, window, item):
         if not self.valid_uri(item.get_uri()): return
-        path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+        path = unquote_url(self.get_local_path(item.get_uri()))
         self.nautilusVFSFile_table[path] = item
 
         # log.debug("get_background_items() called")
@@ -623,7 +626,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
 
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+                path = unquote_url(self.get_local_path(item.get_uri()))
 
                 if self.vcs_client.is_in_a_or_a_working_copy(path):
                     paths.append(path)

--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -72,11 +72,12 @@ import rabbitvcs.vcs.status
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
-from rabbitvcs.util.helper import to_text
 
 from rabbitvcs.util.decorators import timeit, disable
 
 from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
+
+from rabbitvcs.util.strings import S
 
 import rabbitvcs.ui
 import rabbitvcs.ui.property_page
@@ -419,8 +420,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         import cProfile
         import rabbitvcs.util.helper
 
-        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()),
-                       "utf-8").replace("/", ":")
+        path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
                                rabbitvcs.util.helper.get_home_folder(),

--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -62,7 +62,11 @@ import os.path
 from os.path import isdir, isfile, realpath, basename, dirname
 import datetime
 
+from rabbitvcs.util import helper
+
+sa = helper.SanitizeArgv()
 from gi.repository import Nautilus, GObject, Gtk, GdkPixbuf
+sa.restore()
 
 import pysvn
 
@@ -72,6 +76,7 @@ import rabbitvcs.vcs.status
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import unquote_url
 
 from rabbitvcs.util.decorators import timeit, disable
 
@@ -266,7 +271,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
 
         if not self.valid_uri(item.get_uri()): return Nautilus.OperationResult.FAILED
 
-        path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+        path = unquote_url(self.get_local_path(item.get_uri()))
 
         # log.debug("update_file_info() called for %s" % path)
 
@@ -383,7 +388,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+                path = unquote_url(self.get_local_path(item.get_uri()))
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 
@@ -418,12 +423,11 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
     # rename the real function "get_background_items_real".
     def get_background_items_profile(self, window, item):
         import cProfile
-        import rabbitvcs.util.helper
 
         path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
-                               rabbitvcs.util.helper.get_home_folder(),
+                               helper.get_home_folder(),
                                "checkerservice_%s.stats" % path)
 
         prof = cProfile.Profile()
@@ -449,7 +453,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         """
 
         if not self.valid_uri(item.get_uri()): return
-        path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+        path = unquote_url(self.get_local_path(item.get_uri()))
         self.nautilusVFSFile_table[path] = item
 
         # log.debug("get_background_items_full() called")
@@ -602,7 +606,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
 
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = rabbitvcs.util.helper.unquote_url(self.get_local_path(item.get_uri()))
+                path = unquote_url(self.get_local_path(item.get_uri()))
 
                 if self.vcs_client.is_in_a_or_a_working_copy(path):
                     paths.append(path)

--- a/clients/nemo/RabbitVCS.py
+++ b/clients/nemo/RabbitVCS.py
@@ -82,7 +82,9 @@ from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import get_home_folder
 from rabbitvcs.util.helper import pretty_timedelta
-from rabbitvcs.util.helper import to_text, unquote_url
+from rabbitvcs.util.helper import unquote_url
+
+from rabbitvcs.util.strings import S
 
 from rabbitvcs.util.decorators import timeit, disable
 
@@ -441,8 +443,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
     def get_background_items_profile(self, window, item):
         import cProfile
 
-        path = to_text(gnomevfs.get_local_path_from_uri(item.get_uri()),
-                       "utf-8").replace("/", ":")
+        path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
             get_home_folder(),

--- a/clients/nemo/RabbitVCS.py
+++ b/clients/nemo/RabbitVCS.py
@@ -69,9 +69,13 @@ import os.path
 from os.path import isdir, isfile, realpath, basename
 import datetime
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version('Nemo', '3.0')
+sa = helper.SanitizeArgv()
 from gi.repository import Nemo, GObject, Gtk, GdkPixbuf
+sa.restore()
 
 import pysvn
 

--- a/clients/pluma/rabbitvcs-plugin.py
+++ b/clients/pluma/rabbitvcs-plugin.py
@@ -24,12 +24,15 @@ from gettext import gettext as _
 import os
 import gi
 
+from rabbitvcs.util import helper
+
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk
+sa.restore()
 from gi.repository import Pluma, GObject, Peas
 
 
-import rabbitvcs.util.helper
 from rabbitvcs.vcs import create_vcs_instance
 from rabbitvcs.util.contextmenu import GtkFilesContextMenuConditions, \
     GtkFilesContextMenuCallbacks, MainContextMenu, MainContextMenuCallbacks, \

--- a/clients/thunar/RabbitVCS.py
+++ b/clients/thunar/RabbitVCS.py
@@ -32,7 +32,6 @@ from os.path import isdir, isfile, realpath, basename
 import datetime
 import time
 import threading
-import urllib
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -48,7 +47,8 @@ import rabbitvcs.ui.property_page
 from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
-from rabbitvcs.util.helper import to_text, unquote
+from rabbitvcs.util.helper import unquote
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.decorators import timeit, disable
 from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR
 
@@ -181,7 +181,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = realpath(to_text(self.get_local_path(item)))
+                path = realpath(S(self.get_local_path(item)))
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 
@@ -208,7 +208,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         """
 
         if not self.valid_uri(item.get_uri()): return
-        path = realpath(to_text(self.get_local_path(item)))
+        path = realpath(S(self.get_local_path(item)))
         self.nautilusVFSFile_table[path] = item
 
         # log.debug("get_background_items() called")
@@ -312,7 +312,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         paths = []
         for item in items:
             if self.valid_uri(item.get_uri()):
-                path = realpath(to_text(self.get_local_path(item)))
+                path = realpath(S(self.get_local_path(item)))
                 paths.append(path)
                 self.nautilusVFSFile_table[path] = item
 

--- a/clients/thunar/RabbitVCS.py
+++ b/clients/thunar/RabbitVCS.py
@@ -33,9 +33,13 @@ import datetime
 import time
 import threading
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import GObject, Gtk, Thunarx
+sa.restore()
 
 from rabbitvcs.vcs.svn import SVN
 

--- a/rabbitvcs/services/checkerservice.py
+++ b/rabbitvcs/services/checkerservice.py
@@ -59,6 +59,7 @@ import dbus.service
 import rabbitvcs.util.decorators
 import rabbitvcs.util._locale
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 import rabbitvcs.services.service
 from rabbitvcs.services.statuschecker import StatusChecker
 
@@ -171,7 +172,7 @@ class StatusCheckerService(dbus.service.Object):
                       summary=False):
         """ Requests a status check from the underlying status checker.
         """
-        status = self.status_checker.check_status(helper.to_text(path),
+        status = self.status_checker.check_status(S(path),
                                                   recurse=recurse,
                                                   summary=summary,
                                                   invalidate=invalidate)
@@ -182,7 +183,7 @@ class StatusCheckerService(dbus.service.Object):
     def GenerateMenuConditions(self, paths):
         upaths = []
         for path in paths:
-            upaths.append(helper.to_text(path))
+            upaths.append(S(path))
 
         path_dict = self.status_checker.generate_menu_conditions(upaths)
         return json.dumps(path_dict)

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -30,15 +30,18 @@ from __future__ import absolute_import
 import os
 from six.moves import range
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, Gdk, GLib
+sa.restore()
 
 from rabbitvcs import APP_NAME, LOCALE_DIR, gettext
 _ = gettext.gettext
 
 import rabbitvcs.vcs.status
-from rabbitvcs.util import helper
 
 REVISION_OPT = (["-r", "--revision"], {"help":"specify the revision number"})
 BASEDIR_OPT = (["-b", "--base-dir"], {})

--- a/rabbitvcs/ui/about.py
+++ b/rabbitvcs/ui/about.py
@@ -26,9 +26,13 @@ import os.path
 import string
 import re
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, GdkPixbuf
+sa.restore()
 
 import rabbitvcs
 from rabbitvcs.ui import InterfaceView
@@ -94,6 +98,7 @@ class About:
         self.about.show_all()
         self.about.run()
         self.about.destroy()
+
 
 if __name__ == "__main__":
     window = About()

--- a/rabbitvcs/ui/action.py
+++ b/rabbitvcs/ui/action.py
@@ -37,6 +37,7 @@ import rabbitvcs.ui.dialog
 import rabbitvcs.util
 import rabbitvcs.vcs
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 from rabbitvcs.ui.dialog import MessageBox
 from rabbitvcs.util.decorators import gtk_unsafe
 
@@ -538,7 +539,7 @@ class VCSAction(threading.Thread):
         """
 
         if message is not None:
-            self.notification.get_widget("status").set_text(message)
+            self.notification.get_widget("status").set_text(S(message).display())
 
     def append(self, func, *args, **kwargs):
         """

--- a/rabbitvcs/ui/add.py
+++ b/rabbitvcs/ui/add.py
@@ -24,10 +24,13 @@ from __future__ import absolute_import
 import os
 import six.moves._thread
 from time import sleep
+from rabbitvcs.util import helper
 
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
@@ -263,6 +266,7 @@ class AddQuiet:
 
         self.action.append(self.svn.add, paths)
         self.action.schedule()
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT

--- a/rabbitvcs/ui/add.py
+++ b/rabbitvcs/ui/add.py
@@ -38,6 +38,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 from rabbitvcs.util.log import Log
 from rabbitvcs.vcs.status import Status
@@ -75,9 +76,11 @@ class Add(InterfaceView, GtkContextMenuCaller):
             if rabbitvcs.vcs.guess(path)['vcs'] == rabbitvcs.vcs.VCS_SVN:
                 self.get_widget("show_ignored").set_sensitive(False)
 
-        columns = [[GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH,
+        columns = [[GObject.TYPE_BOOLEAN,
+                    rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                    rabbitvcs.ui.widget.TYPE_PATH,
                     GObject.TYPE_STRING],
-                   [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"),
+                   [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"),
                     _("Extension")]]
 
         self.setup(self.get_widget("Add"), columns)
@@ -90,7 +93,7 @@ class Add(InterfaceView, GtkContextMenuCaller):
                 "callback": rabbitvcs.ui.widget.path_filter,
                 "user_data": {
                     "base_dir": base_dir,
-                    "column": 1
+                    "column": 2
                 }
             }],
             callbacks={
@@ -140,6 +143,7 @@ class Add(InterfaceView, GtkContextMenuCaller):
         for item in self.items:
             self.files_table.append([
                 True,
+                S(item.path),
                 item.path,
                 helper.get_file_extension(item.path)
             ])

--- a/rabbitvcs/ui/annotate.py
+++ b/rabbitvcs/ui/annotate.py
@@ -22,20 +22,22 @@ from __future__ import absolute_import
 #
 
 import os
+from datetime import datetime
+import time
+
+from rabbitvcs.util import helper
 
 from gi import require_version
 require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk, GLib
-
-from datetime import datetime
-import time
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.log import log_dialog_factory
 from rabbitvcs.ui.action import SVNAction, GitAction
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.dialog import MessageBox, Loading
-import rabbitvcs.util.helper
 from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 from rabbitvcs.util.decorators import gtk_unsafe
@@ -43,7 +45,7 @@ from rabbitvcs.util.decorators import gtk_unsafe
 from rabbitvcs import gettext
 _ = gettext.gettext
 
-DATETIME_FORMAT = rabbitvcs.util.helper.LOCAL_DATETIME_FORMAT
+DATETIME_FORMAT = helper.LOCAL_DATETIME_FORMAT
 
 class Annotate(InterfaceView):
     """
@@ -195,7 +197,7 @@ class SVNAnnotate(Annotate):
                 str(int(item["number"]) + 1),
                 str(item["revision"].number),
                 item["author"],
-                rabbitvcs.util.helper.format_datetime(date),
+                helper.format_datetime(date),
                 item["line"]
             ])
 
@@ -211,7 +213,7 @@ class SVNAnnotate(Annotate):
                 str(int(item["number"]) + 1),
                 str(item["revision"].number),
                 item["author"],
-                rabbitvcs.util.helper.format_datetime(date),
+                helper.format_datetime(date),
                 item["line"]
             )
 
@@ -281,7 +283,7 @@ class GitAnnotate(Annotate):
                 str(item["number"]),
                 item["revision"][:7],
                 item["author"],
-                rabbitvcs.util.helper.format_datetime(item["date"]),
+                helper.format_datetime(item["date"]),
                 item["line"]
             ])
 
@@ -294,7 +296,7 @@ class GitAnnotate(Annotate):
                 str(item["number"]),
                 item["revision"][:7],
                 item["author"],
-                rabbitvcs.util.helper.format_datetime(item["date"]),
+                helper.format_datetime(item["date"]),
                 item["line"]
             )
 
@@ -311,6 +313,7 @@ def annotate_factory(vcs, path, revision=None):
         vcs = guess["vcs"]
 
     return classes_map[vcs](path, revision)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT

--- a/rabbitvcs/ui/annotate.py
+++ b/rabbitvcs/ui/annotate.py
@@ -36,6 +36,7 @@ from rabbitvcs.ui.action import SVNAction, GitAction
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.dialog import MessageBox, Loading
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 from rabbitvcs.util.decorators import gtk_unsafe
 
@@ -78,14 +79,14 @@ class Annotate(InterfaceView):
 
     def on_from_log_closed(self, data):
         if data is not None:
-            self.get_widget("from").set_text(data)
+            self.get_widget("from").set_text(S(data).display())
 
     def on_to_show_log_clicked(self, widget, data=None):
         log_dialog_factory(self.path, ok_callback=self.on_to_log_closed)
 
     def on_to_log_closed(self, data):
         if data is not None:
-            self.get_widget("to").set_text(data)
+            self.get_widget("to").set_text(S(data).display())
 
     def enable_saveas(self):
         self.get_widget("save").set_sensitive(True)
@@ -121,8 +122,8 @@ class SVNAnnotate(Annotate):
             revision = "HEAD"
 
         self.path = path
-        self.get_widget("from").set_text(str(1))
-        self.get_widget("to").set_text(str(revision))
+        self.get_widget("from").set_text("1")
+        self.get_widget("to").set_text(S(revision).display())
 
         self.table = rabbitvcs.ui.widget.Table(
             self.get_widget("table"),
@@ -226,7 +227,7 @@ class GitAnnotate(Annotate):
             revision = "HEAD"
 
         self.path = path
-        self.get_widget("to").set_text(str(revision))
+        self.get_widget("to").set_text(S(revision).display())
 
         self.table = rabbitvcs.ui.widget.Table(
             self.get_widget("table"),

--- a/rabbitvcs/ui/applypatch.py
+++ b/rabbitvcs/ui/applypatch.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import os.path
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceNonView
 from rabbitvcs.ui.action import SVNAction
@@ -47,7 +51,7 @@ class ApplyPatch(InterfaceNonView):
         InterfaceNonView.__init__(self)
         self.paths = paths
         self.vcs = rabbitvcs.vcs.VCS()
-        self.common = rabbitvcs.util.helper.get_common_directory(paths)
+        self.common = helper.get_common_directory(paths)
 
     def choose_patch_path(self):
         path = None
@@ -158,6 +162,7 @@ classes_map = {
 def applypatch_factory(paths):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/branch.py
+++ b/rabbitvcs/ui/branch.py
@@ -21,15 +21,18 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
 from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 import rabbitvcs.vcs.status
@@ -57,14 +60,14 @@ class SVNBranch(InterfaceView):
 
         status = self.vcs.status(self.path)
 
-        repo_paths = rabbitvcs.util.helper.get_repository_paths()
+        repo_paths = helper.get_repository_paths()
         self.from_urls = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("from_urls"),
             repo_paths
         )
         self.to_urls = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("to_urls"),
-            rabbitvcs.util.helper.get_repository_paths()
+            helper.get_repository_paths()
         )
 
         repository_url = self.svn.get_repo_url(path)
@@ -103,7 +106,7 @@ class SVNBranch(InterfaceView):
         self.action.set_log_message(self.message.get_text())
 
         self.action.append(
-            rabbitvcs.util.helper.save_log_message,
+            helper.save_log_message,
             self.message.get_text()
         )
 
@@ -138,6 +141,7 @@ def branch_factory(vcs, path, revision=None):
         vcs = guess["vcs"]
 
     return classes_map[vcs](path, revision)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT

--- a/rabbitvcs/ui/branch.py
+++ b/rabbitvcs/ui/branch.py
@@ -30,6 +30,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 import rabbitvcs.vcs.status
 
@@ -117,7 +118,7 @@ class SVNBranch(InterfaceView):
         dialog = rabbitvcs.ui.dialog.PreviousMessages()
         message = dialog.run()
         if message is not None:
-            self.message.set_text(message)
+            self.message.set_text(S(message).display())
 
     def on_repo_browser_clicked(self, widget, data=None):
         from rabbitvcs.ui.browser import SVNBrowserDialog

--- a/rabbitvcs/ui/branches.py
+++ b/rabbitvcs/ui/branches.py
@@ -36,6 +36,7 @@ from rabbitvcs.ui.log import log_dialog_factory
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.dialog import DeleteConfirmation
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 
 from xml.sax import saxutils
@@ -265,12 +266,12 @@ class GitBranchManager(InterfaceView):
         if self.revision:
             active_branch = self.git.get_active_branch()
             if active_branch:
-                revision = helper.to_text(active_branch.name)
+                revision = S(active_branch.name)
 
         self.items_treeview.unselect_all()
         self.branch_entry.set_text("")
         self.save_button.set_label(_("Add"))
-        self.start_point_entry.set_text(revision)
+        self.start_point_entry.set_text(S(revision).display())
         self.track_checkbox.set_active(True)
         self.checkout_checkbox.set_sensitive(True)
         self.checkout_checkbox.set_active(False)
@@ -289,9 +290,9 @@ class GitBranchManager(InterfaceView):
         self.save_button.set_label(_("Save"))
 
         if self.selected_branch:
-            self.branch_entry.set_text(self.selected_branch.name)
-            self.revision_label.set_text(helper.to_text(self.selected_branch.revision))
-            self.message_label.set_text(self.selected_branch.message.rstrip("\n"))
+            self.branch_entry.set_text(S(self.selected_branch.name).display())
+            self.revision_label.set_text(S(self.selected_branch.revision).display())
+            self.message_label.set_text(S(self.selected_branch.message.rstrip("\n")).display())
             if self.selected_branch.tracking:
                 self.checkout_checkbox.set_active(True)
                 self.checkout_checkbox.set_sensitive(False)
@@ -310,7 +311,8 @@ class GitBranchManager(InterfaceView):
 
     def on_log_dialog_closed(self, data):
         if data:
-            self.start_point_entry.set_text(data)
+            self.start_point_entry.set_text(S(data).display())
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT

--- a/rabbitvcs/ui/branches.py
+++ b/rabbitvcs/ui/branches.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import os
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk, Pango
+sa.restore()
 
 from datetime import datetime
 import time
@@ -35,7 +39,6 @@ from rabbitvcs.ui.action import GitAction
 from rabbitvcs.ui.log import log_dialog_factory
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.dialog import DeleteConfirmation
-from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 

--- a/rabbitvcs/ui/browser.py
+++ b/rabbitvcs/ui/browser.py
@@ -90,32 +90,34 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         self.items = []
         self.list_table = rabbitvcs.ui.widget.Table(
             self.get_widget("list"),
-            [rabbitvcs.ui.widget.TYPE_PATH, GObject.TYPE_INT,
+            [rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH, GObject.TYPE_INT,
                 GObject.TYPE_INT, GObject.TYPE_STRING, GObject.TYPE_FLOAT],
-            [_("Path"), _("Revision"), _("Size"), _("Author"), _("Date")],
+            ["", _("Path"), _("Revision"), _("Size"), _("Author"), _("Date")],
             filters=[{
                 "callback": self.file_filter,
-                "user_data": {
-                    "column": 0
-                }
-            },{
-                "callback": self.revision_filter,
                 "user_data": {
                     "column": 1
                 }
             },{
-                "callback": self.size_filter,
+                "callback": self.revision_filter,
                 "user_data": {
                     "column": 2
                 }
             },{
+                "callback": self.size_filter,
+                "user_data": {
+                    "column": 3
+                }
+            },{
                 "callback": self.date_filter,
                 "user_data": {
-                    "column": 4
+                    "column": 5
                 }
             }],
             filter_types=[GObject.TYPE_STRING, GObject.TYPE_STRING,
-                GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
+                GObject.TYPE_STRING, GObject.TYPE_STRING,
+                GObject.TYPE_STRING, GObject.TYPE_STRING],
             callbacks={
                 "file-column-callback": self.file_column_callback,
                 "row-activated": self.on_row_activated,
@@ -154,9 +156,10 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         self.items = self.action.get_result(item_index)
         self.items.sort(key = self.sort_files_key)
 
-        self.list_table.append(["..", 0, 0, "", 0])
+        self.list_table.append([S(".."), "..", 0, 0, "", 0])
         for item,locked in self.items[1:]:
             self.list_table.append([
+                S(item.path),
                 item.path,
                 item.created_rev.number,
                 item.size,

--- a/rabbitvcs/ui/browser.py
+++ b/rabbitvcs/ui/browser.py
@@ -38,6 +38,7 @@ import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
 import rabbitvcs.vcs
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.decorators import gtk_unsafe
 
@@ -58,9 +59,9 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         self.url = ""
         if self.svn.is_in_a_or_a_working_copy(url):
             action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False, run_in_thread=False)
-            self.url = action.run_single(self.svn.get_repo_url, url)
+            self.url = S(action.run_single(self.svn.get_repo_url, url))
         elif self.svn.is_path_repository_url(url):
-            self.url = url
+            self.url = S(url)
 
         self.urls = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("urls"),
@@ -287,7 +288,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         BrowserContextMenu(self, data, None, self.vcs, paths).show()
 
     def set_url_clipboard(self, url):
-        self.url_clipboard.set_text(url, -1)
+        self.url_clipboard.set_text(S(url).display(), -1)
 
     def get_repo_root_url(self):
         return self.repo_root_url

--- a/rabbitvcs/ui/browser.py
+++ b/rabbitvcs/ui/browser.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 #
 
 import os.path
+import six
 import six.moves._thread
 from datetime import datetime
 
@@ -222,11 +223,12 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         Determine the node kind (dir or file) from our retrieved items list
         """
 
-        if filename == "..":
+        filename = S(filename).unicode()
+        if filename == six.u(".."):
             return "dir"
 
         for item,locked in self.items:
-            if item.path == filename:
+            if S(item.path).unicode() == filename:
                 return self.svn.NODE_KINDS_REVERSE[item.kind]
         return None
 

--- a/rabbitvcs/ui/browser.py
+++ b/rabbitvcs/ui/browser.py
@@ -23,11 +23,15 @@ from __future__ import absolute_import
 
 import os.path
 import six.moves._thread
+from datetime import datetime
+
+from rabbitvcs.util import helper
 
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
-from datetime import datetime
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.util.contextmenu import GtkContextMenu, GtkContextMenuCaller, \
@@ -37,7 +41,6 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
 import rabbitvcs.vcs
-from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.decorators import gtk_unsafe
@@ -626,6 +629,7 @@ classes_map = {
 def browser_factory(path):
     guess = rabbitvcs.vcs.guess(path)
     return classes_map[guess["vcs"]](path)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/changes.py
+++ b/rabbitvcs/ui/changes.py
@@ -31,6 +31,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.util import helper
 from rabbitvcs.util.contextmenu import GtkContextMenu
 from rabbitvcs.util.contextmenuitems import *
+from rabbitvcs.util.strings import S
 import rabbitvcs.ui.action
 from rabbitvcs.ui.dialog import MessageBox
 
@@ -213,8 +214,8 @@ class Changes(InterfaceView):
             rev2 = self.get_second_revision()
 
             helper.launch_ui_window("diff", [
-                "%s@%s" % (url1, helper.to_text(rev1)),
-                "%s@%s" % (url2, helper.to_text(rev2)),
+                "%s@%s" % (url1, S(rev1)),
+                "%s@%s" % (url2, S(rev2)),
                 "%s" % (sidebyside and "-s" or ""),
                 "--vcs=%s" % self.get_vcs_name()
             ])
@@ -231,8 +232,8 @@ class Changes(InterfaceView):
         url2 = self.second_urls.get_active_text()
 
         helper.launch_ui_window("diff", [
-            "%s@%s" % (url1, helper.to_text(rev1)),
-            "%s@%s" % (url2, helper.to_text(rev2)),
+            "%s@%s" % (url1, S(rev1)),
+            "%s@%s" % (url2, S(rev2)),
             "--vcs=%s" % self.get_vcs_name()
         ])
 
@@ -491,7 +492,7 @@ class ChangesContextMenuCallbacks:
         helper.launch_ui_window("open", [
             "--vcs=%s" % self.caller.get_vcs_name(),
             url,
-            "-r%s" % helper.to_text(rev)
+            "-r%s" % S(rev)
         ])
 
     def open_second(self, widget, data=None):
@@ -504,7 +505,7 @@ class ChangesContextMenuCallbacks:
         helper.launch_ui_window("open", [
             "--vcs=%s" % self.caller.get_vcs_name(),
             url,
-            "-r%s" % helper.to_text(rev)
+            "-r%s" % S(rev)
         ])
 
     def view_diff(self, widget, data=None):
@@ -524,8 +525,8 @@ class ChangesContextMenuCallbacks:
             rev2 = self.caller.get_second_revision()
 
             helper.launch_ui_window("diff", [
-                "%s@%s" % (url1, helper.to_text(rev1)),
-                "%s@%s" % (url2, helper.to_text(rev2)),
+                "%s@%s" % (url1, S(rev1)),
+                "%s@%s" % (url2, S(rev2)),
                 "-s",
                 "--vcs=%s" % self.caller.get_vcs_name()
             ])

--- a/rabbitvcs/ui/changes.py
+++ b/rabbitvcs/ui/changes.py
@@ -22,13 +22,17 @@ from __future__ import absolute_import
 #
 
 import os.path
+
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
-from rabbitvcs.util import helper
 from rabbitvcs.util.contextmenu import GtkContextMenu
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.util.strings import S
@@ -585,6 +589,7 @@ def changes_factory(vcs, path1=None, revision1=None, path2=None, revision2=None)
         vcs = guess["vcs"]
 
     return classes_map[vcs](path1, revision1, path2, revision2)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT

--- a/rabbitvcs/ui/checkmods.py
+++ b/rabbitvcs/ui/checkmods.py
@@ -24,9 +24,13 @@ from __future__ import absolute_import
 import six.moves._thread
 import threading
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.util.contextmenu import GtkFilesContextMenu, \
@@ -36,7 +40,6 @@ from rabbitvcs.util.contextmenuitems import MenuItem, MenuUpdate, \
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.decorators import gtk_unsafe
 
@@ -348,6 +351,7 @@ classes_map = {
 def checkmods_factory(paths, base_dir):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths, base_dir)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT

--- a/rabbitvcs/ui/checkout.py
+++ b/rabbitvcs/ui/checkout.py
@@ -31,6 +31,7 @@ from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
+from rabbitvcs.util.strings import S
 from rabbitvcs.util import helper
 import rabbitvcs.vcs
 from rabbitvcs.ui.updateto import GitUpdateToRevision
@@ -66,7 +67,7 @@ class Checkout(InterfaceView):
         self.destination = helper.get_user_path()
         if path is not None:
             self.destination = path
-            self.get_widget("destination").set_text(path)
+            self.get_widget("destination").set_text(S(path).display())
 
         if url is not None:
             self.repositories.set_child_text(url)
@@ -91,7 +92,7 @@ class Checkout(InterfaceView):
         chooser = rabbitvcs.ui.dialog.FolderChooser()
         path = chooser.run()
         if path is not None:
-            self.get_widget("destination").set_text(path)
+            self.get_widget("destination").set_text(S(path).display())
 
     def on_repositories_key_released(self, widget, data, userdata=None):
         if Gdk.keyval_name(data.keyval) == "Return":
@@ -194,7 +195,7 @@ class SVNCheckout(Checkout):
                 break
 
         self.get_widget("destination").set_text(
-            os.path.join(self.destination, append)
+            S(os.path.join(self.destination, append)).display()
         )
 
         self.check_form()

--- a/rabbitvcs/ui/checkout.py
+++ b/rabbitvcs/ui/checkout.py
@@ -23,16 +23,19 @@ from __future__ import absolute_import
 
 import os.path
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
 from rabbitvcs.util.strings import S
-from rabbitvcs.util import helper
 import rabbitvcs.vcs
 from rabbitvcs.ui.updateto import GitUpdateToRevision
 from rabbitvcs import gettext
@@ -237,6 +240,7 @@ def checkout_factory(vcs, path=None, url=None, revision=None, quiet=False):
             return GitCheckout(path, url, revision)
 
     return classes_map[vcs](path, url, revision)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT, QUIET_OPT

--- a/rabbitvcs/ui/clean.py
+++ b/rabbitvcs/ui/clean.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import os
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk, Pango
+sa.restore()
 
 from datetime import datetime
 import time
@@ -33,7 +37,6 @@ import time
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import GitAction
 import rabbitvcs.ui.widget
-import rabbitvcs.util.helper
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
@@ -91,6 +94,7 @@ class GitClean(InterfaceView):
 
         if remove_only_ignored.get_active():
             remove_ignored_too.set_active(False)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/cleanup.py
+++ b/rabbitvcs/ui/cleanup.py
@@ -21,9 +21,13 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceNonView
 from rabbitvcs.ui.action import SVNAction

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -33,6 +33,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
@@ -87,7 +88,7 @@ class GitClone(Checkout):
             append = append[:-4]
 
         helper.run_in_main_thread(self.get_widget("destination").set_text,
-                                  os.path.join(self.destination, append))
+                                  S(os.path.join(self.destination, append)).display())
         self.check_form()
 
     def default_text(self):

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -23,16 +23,19 @@ from __future__ import absolute_import
 
 import os.path
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.checkout import Checkout
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 
@@ -113,6 +116,7 @@ classes_map = {
 
 def clone_factory(classes_map, vcs, path=None, url=None):
     return classes_map[vcs](path, url)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT

--- a/rabbitvcs/ui/commit.py
+++ b/rabbitvcs/ui/commit.py
@@ -23,12 +23,15 @@ from __future__ import absolute_import
 
 import os
 import six.moves._thread
+from time import sleep
+
+from rabbitvcs.util import helper
 
 from gi import require_version
 require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk, GLib
-
-from time import sleep
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
@@ -36,7 +39,6 @@ import rabbitvcs.ui.action
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util
-from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.decorators import gtk_unsafe
@@ -412,6 +414,7 @@ classes_map = {
 def commit_factory(paths, base_dir=None, message=None):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths, base_dir, message)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT

--- a/rabbitvcs/ui/commit.py
+++ b/rabbitvcs/ui/commit.py
@@ -82,16 +82,17 @@ class Commit(InterfaceView, GtkContextMenuCaller):
 
         self.files_table = rabbitvcs.ui.widget.Table(
             self.get_widget("files_table"),
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH,
+            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH,
                 GObject.TYPE_STRING, rabbitvcs.ui.widget.TYPE_STATUS,
                 GObject.TYPE_STRING],
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension"),
+            [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"), _("Extension"),
                 _("Text Status"), _("Property Status")],
             filters=[{
                 "callback": rabbitvcs.ui.widget.path_filter,
                 "user_data": {
                     "base_dir": base_dir,
-                    "column": 1
+                    "column": 2
                 }
             }],
             callbacks={
@@ -102,7 +103,7 @@ class Commit(InterfaceView, GtkContextMenuCaller):
             },
             flags={
                 "sortable": True,
-                "sort_on": 1
+                "sort_on": 2
             }
         )
         self.files_table.allow_multiple()
@@ -264,6 +265,7 @@ class Commit(InterfaceView, GtkContextMenuCaller):
 
             self.files_table.append([
                 checked,
+                S(item.path),
                 item.path,
                 helper.get_file_extension(item.path),
                 item.simple_content_status(),

--- a/rabbitvcs/ui/commit.py
+++ b/rabbitvcs/ui/commit.py
@@ -37,6 +37,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.decorators import gtk_unsafe
 import rabbitvcs.vcs.status
@@ -233,7 +234,7 @@ class Commit(InterfaceView, GtkContextMenuCaller):
         dialog = rabbitvcs.ui.dialog.PreviousMessages()
         message = dialog.run()
         if message is not None:
-            self.message.set_text(message)
+            self.message.set_text(S(message).display())
 
     def populate_files_table(self):
         """
@@ -279,7 +280,7 @@ class SVNCommit(Commit):
         self.get_widget("commit_to_box").show()
 
         self.get_widget("to").set_text(
-            self.vcs.svn().get_repo_url(self.base_dir)
+            S(self.vcs.svn().get_repo_url(self.base_dir)).display()
         )
 
         self.items = None
@@ -348,7 +349,7 @@ class GitCommit(Commit):
         active_branch = self.git.get_active_branch()
         if active_branch:
             self.get_widget("to").set_text(
-                active_branch.name
+                S(active_branch.name).display()
             )
         else:
             self.get_widget("to").set_text("No active branch")

--- a/rabbitvcs/ui/create.py
+++ b/rabbitvcs/ui/create.py
@@ -24,9 +24,13 @@ from __future__ import absolute_import
 import os
 import subprocess
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 import rabbitvcs.ui.dialog
 from rabbitvcs.ui.action import GitAction
@@ -76,6 +80,7 @@ classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNCreate,
     rabbitvcs.vcs.VCS_GIT: GitCreate
 }
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT, VCS_OPT_ERROR

--- a/rabbitvcs/ui/createpatch.py
+++ b/rabbitvcs/ui/createpatch.py
@@ -39,6 +39,7 @@ from rabbitvcs.ui.action import SVNAction, GitAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 from rabbitvcs.ui.commit import SVNCommit, GitCommit
 
@@ -85,15 +86,16 @@ class CreatePatch:
 
         self.files_table = rabbitvcs.ui.widget.Table(
             self.get_widget("files_table"),
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH,
+            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH,
                 GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension"),
+            [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"), _("Extension"),
                 _("Text Status"), _("Property Status")],
             filters=[{
                 "callback": rabbitvcs.ui.widget.path_filter,
                 "user_data": {
                     "base_dir": base_dir,
-                    "column": 1
+                    "column": 2
                 }
             }],
             callbacks={
@@ -103,7 +105,7 @@ class CreatePatch:
             },
             flags={
                 "sortable": True,
-                "sort_on": 1
+                "sort_on": 2
             }
         )
         self.files_table.allow_multiple()

--- a/rabbitvcs/ui/createpatch.py
+++ b/rabbitvcs/ui/createpatch.py
@@ -22,21 +22,23 @@ from __future__ import absolute_import
 #
 
 import os
+import tempfile
+import shutil
 import six.moves._thread
+
+from rabbitvcs.util import helper
 
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
-import os
-import tempfile
-import shutil
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import SVNAction, GitAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util
-from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from rabbitvcs.ui.commit import SVNCommit, GitCommit
 
@@ -274,6 +276,7 @@ classes_map = {
 def createpatch_factory(paths, base_dir):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths, base_dir)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT

--- a/rabbitvcs/ui/delete.py
+++ b/rabbitvcs/ui/delete.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import os.path
 
+from rabbitvcs.util import helper
+
 from gi import require_version
 require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject
+sa.restore()
 
 from rabbitvcs.ui import InterfaceNonView
 from rabbitvcs.ui.action import SVNAction
@@ -81,7 +85,7 @@ class Delete(InterfaceNonView):
 
             if unversioned:
                 for path in unversioned:
-                    rabbitvcs.util.helper.delete_item(path)
+                    helper.delete_item(path)
 
 class SVNDelete(Delete):
     def __init__(self, paths):
@@ -107,6 +111,7 @@ classes_map = {
 def delete_factory(paths):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/dialog.py
+++ b/rabbitvcs/ui/dialog.py
@@ -31,6 +31,7 @@ from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.wraplabel
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 
 ERROR_NOTICE = _("""\
 An error has occurred in the RabbitVCS Nautilus extension. Please contact the \
@@ -69,7 +70,7 @@ class PreviousMessages(InterfaceView):
             self.message_table.append([entry[0],entry[1]])
 
         if len(self.entries) > 0:
-            self.message.set_text(self.entries[0][1])
+            self.message.set_text(S(self.entries[0][1]).display())
 
     def run(self):
 
@@ -98,7 +99,7 @@ class PreviousMessages(InterfaceView):
 
         if selection:
             selected_message = selection[-1]
-            self.message.set_text(selected_message)
+            self.message.set_text(S(selected_message).display())
 
 class FolderChooser:
     def __init__(self):
@@ -207,7 +208,7 @@ class SSLClientCertPrompt(InterfaceView):
         filechooser = FileChooser()
         cert = filechooser.run()
         if cert is not None:
-            self.get_widget("sslclientcert_path").set_text(cert)
+            self.get_widget("sslclientcert_path").set_text(S(cert).display())
 
     def run(self):
         self.dialog = self.get_widget("SSLClientCertPrompt")
@@ -315,7 +316,7 @@ class FileSaveAs:
 class Confirmation(InterfaceView):
     def __init__(self, message=_("Are you sure you want to continue?")):
         InterfaceView.__init__(self, "dialogs/confirmation", "Confirmation")
-        self.get_widget("confirm_message").set_text(message)
+        self.get_widget("confirm_message").set_text(S(message).display())
 
     def run(self):
         dialog = self.get_widget("Confirmation")
@@ -328,7 +329,7 @@ class Confirmation(InterfaceView):
 class MessageBox(InterfaceView):
     def __init__(self, message):
         InterfaceView.__init__(self, "dialogs/message_box", "MessageBox")
-        self.get_widget("messagebox_message").set_text(message)
+        self.get_widget("messagebox_message").set_text(S(message).display())
 
         dialog = self.get_widget("MessageBox")
         dialog.run()
@@ -383,10 +384,10 @@ class OneLineTextChange(InterfaceView):
         self.label = self.get_widget("label")
 
         if label:
-            self.label.set_text(label)
+            self.label.set_text(S(label).display())
 
         if current_text:
-            self.new_text.set_text(current_text)
+            self.new_text.set_text(S(current_text).display())
 
         self.dialog = self.get_widget("OneLineTextChange")
 
@@ -502,7 +503,7 @@ class ConflictDecision(InterfaceView):
     def __init__(self, filename=""):
 
         InterfaceView.__init__(self, "dialogs/conflict_decision", "ConflictDecision")
-        self.get_widget("filename").set_text(filename)
+        self.get_widget("filename").set_text(S(filename).display())
 
     def run(self):
         """

--- a/rabbitvcs/ui/diff.py
+++ b/rabbitvcs/ui/diff.py
@@ -21,18 +21,22 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import gi
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk, GLib
 import os
 from shutil import rmtree
 import tempfile
+
+from rabbitvcs.util import helper
+
+import gi
+gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
+from gi.repository import Gtk, Gdk, GLib
+sa.restore()
 
 from rabbitvcs import TEMP_DIR_PREFIX
 from rabbitvcs.ui import InterfaceNonView
 import rabbitvcs.vcs
 from rabbitvcs.ui.action import SVNAction, GitAction
-import rabbitvcs.util.helper
 from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
@@ -69,7 +73,7 @@ class Diff(InterfaceNonView):
             self.stop_loading()
 
     def _build_export_path(self, index, revision, path):
-        dest = rabbitvcs.util.helper.get_tmp_path("rabbitvcs-%s-%s-%s" % (str(index), str(revision)[:5], os.path.basename(path)))
+        dest = helper.get_tmp_path("rabbitvcs-%s-%s-%s" % (str(index), str(revision)[:5], os.path.basename(path)))
         if os.path.exists(dest):
             if os.path.isdir(dest):
                 rmtree(dest, ignore_errors=True)
@@ -150,7 +154,7 @@ class SVNDiff(Diff):
         fh = tempfile.mkstemp("-rabbitvcs-" + str(self.revision1) + "-" + str(self.revision2) + ".diff")
         os.write(fh[0], S(diff_text).bytes())
         os.close(fh[0])
-        rabbitvcs.util.helper.open_item(fh[1])
+        helper.open_item(fh[1])
 
     def launch_sidebyside_diff(self):
         """
@@ -188,7 +192,7 @@ class SVNDiff(Diff):
             )
             action.stop_loader()
 
-        rabbitvcs.util.helper.launch_diff_tool(dest1, dest2)
+        helper.launch_diff_tool(dest1, dest2)
 
 class GitDiff(Diff):
     def __init__(self, path1, revision1=None, path2=None, revision2=None,
@@ -257,7 +261,7 @@ class GitDiff(Diff):
         fh = tempfile.mkstemp("-rabbitvcs-" + str(self.revision1)[:5] + "-" + str(self.revision2)[:5] + ".diff")
         os.write(fh[0], S(diff_text).bytes())
         os.close(fh[0])
-        rabbitvcs.util.helper.open_item(fh[1])
+        helper.open_item(fh[1])
 
     def launch_sidebyside_diff(self):
         """
@@ -291,7 +295,7 @@ class GitDiff(Diff):
         else:
             dest2 = self.path2
 
-        rabbitvcs.util.helper.launch_diff_tool(dest1, dest2)
+        helper.launch_diff_tool(dest1, dest2)
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNDiff,
@@ -305,6 +309,7 @@ def diff_factory(vcs, path1, revision_obj1, path2=None, revision_obj2=None, side
 
     return classes_map[vcs](path1, revision_obj1, path2, revision_obj2, sidebyside)
 
+
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT
     (options, args) = main([
@@ -316,9 +321,9 @@ if __name__ == "__main__":
         usage="Usage: rabbitvcs diff [url1@rev1] [url2@rev2]"
     )
 
-    pathrev1 = rabbitvcs.util.helper.parse_path_revision_string(args.pop(0))
+    pathrev1 = helper.parse_path_revision_string(args.pop(0))
     pathrev2 = (None, None)
     if len(args) > 0:
-        pathrev2 = rabbitvcs.util.helper.parse_path_revision_string(args.pop(0))
+        pathrev2 = helper.parse_path_revision_string(args.pop(0))
 
     diff_factory(options.vcs, pathrev1[0], pathrev1[1], pathrev2[0], pathrev2[1], sidebyside=options.sidebyside)

--- a/rabbitvcs/ui/diff.py
+++ b/rabbitvcs/ui/diff.py
@@ -33,6 +33,7 @@ from rabbitvcs.ui import InterfaceNonView
 import rabbitvcs.vcs
 from rabbitvcs.ui.action import SVNAction, GitAction
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.diff")
@@ -147,7 +148,7 @@ class SVNDiff(Diff):
             diff_text = ""
 
         fh = tempfile.mkstemp("-rabbitvcs-" + str(self.revision1) + "-" + str(self.revision2) + ".diff")
-        os.write(fh[0], diff_text.encode("utf-8"))
+        os.write(fh[0], S(diff_text).bytes())
         os.close(fh[0])
         rabbitvcs.util.helper.open_item(fh[1])
 
@@ -225,7 +226,7 @@ class GitDiff(Diff):
         file = open(path, "wb")
         try:
             try:
-                file.write(data.encode("utf-8"))
+                file.write(S(data).bytes())
             except Exception as e:
                 log.exception(e)
         finally:
@@ -254,7 +255,7 @@ class GitDiff(Diff):
             diff_text = ""
 
         fh = tempfile.mkstemp("-rabbitvcs-" + str(self.revision1)[:5] + "-" + str(self.revision2)[:5] + ".diff")
-        os.write(fh[0], diff_text.encode("utf-8"))
+        os.write(fh[0], S(diff_text).bytes())
         os.close(fh[0])
         rabbitvcs.util.helper.open_item(fh[1])
 

--- a/rabbitvcs/ui/editconflicts.py
+++ b/rabbitvcs/ui/editconflicts.py
@@ -26,16 +26,19 @@ import os.path
 import six.moves._thread
 import shutil
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceNonView
 from rabbitvcs.ui.action import SVNAction, GitAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
 from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.editconflicts")
@@ -87,7 +90,7 @@ class SVNEditConflicts(InterfaceNonView):
             ancestor, theirs = self.get_revisioned_paths(path)
 
             log.debug("launching merge tool with base: %s, mine: %s, theirs: %s, merged: %s"%(ancestor, working, theirs, path))
-            rabbitvcs.util.helper.launch_merge_tool(base=ancestor, mine=working, theirs=theirs, merged=path)
+            helper.launch_merge_tool(base=ancestor, mine=working, theirs=theirs, merged=path)
 
             dialog = rabbitvcs.ui.dialog.MarkResolvedPrompt()
             mark_resolved = dialog.run()
@@ -147,7 +150,7 @@ class GitEditConflicts(InterfaceNonView):
         self.vcs = rabbitvcs.vcs.VCS()
         self.git = self.vcs.git(path)
 
-        rabbitvcs.util.helper.launch_merge_tool(self.path)
+        helper.launch_merge_tool(self.path)
 
         self.close()
 
@@ -159,6 +162,7 @@ classes_map = {
 def editconflicts_factory(path):
     guess = rabbitvcs.vcs.guess(path)
     return classes_map[guess["vcs"]](path)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT

--- a/rabbitvcs/ui/export.py
+++ b/rabbitvcs/ui/export.py
@@ -32,7 +32,8 @@ from rabbitvcs.ui.checkout import SVNCheckout
 from rabbitvcs.ui.clone import GitClone
 from rabbitvcs.ui.dialog import MessageBox
 from rabbitvcs.ui.action import SVNAction, GitAction
-import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
+import rabbitvcs.vcs
 
 from rabbitvcs import gettext
 _ = gettext.gettext
@@ -61,7 +62,7 @@ class SVNExport(SVNCheckout):
             # Path is not a working copy so the user probably wants to export
             # TO this path
             self.repositories.set_child_text("")
-            self.get_widget("destination").set_text(path)
+            self.get_widget("destination").set_text(S(path).display())
 
     def on_ok_clicked(self, widget):
         url = self.repositories.get_active_text()
@@ -189,7 +190,7 @@ class GitExport(GitClone):
                 break
 
         self.get_widget("destination").set_text(
-            os.path.join(self.destination, append)
+            S(os.path.join(self.destination, append)).display()
         )
 
         self.check_form()

--- a/rabbitvcs/ui/export.py
+++ b/rabbitvcs/ui/export.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import os.path
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.checkout import SVNCheckout
@@ -93,7 +97,7 @@ class SVNExport(SVNCheckout):
 
         self.action.append(self.action.set_header, _("Export"))
         self.action.append(self.action.set_status, _("Running Export Command..."))
-        self.action.append(rabbitvcs.util.helper.save_repository_path, url)
+        self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.svn.export,
             url,
@@ -162,7 +166,7 @@ class GitExport(GitClone):
 
         self.action.append(self.action.set_header, _("Export"))
         self.action.append(self.action.set_status, _("Running Export Command..."))
-        self.action.append(rabbitvcs.util.helper.save_repository_path, url)
+        self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.git.export,
             url,
@@ -209,6 +213,7 @@ def export_factory(vcs, path, revision=None):
         vcs = rabbitvcs.vcs.VCS_SVN
 
     return classes_map[vcs](path, revision)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT

--- a/rabbitvcs/ui/ignore.py
+++ b/rabbitvcs/ui/ignore.py
@@ -24,9 +24,13 @@ from __future__ import absolute_import
 from os import getcwd
 import os.path
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceNonView, InterfaceView
 from rabbitvcs.ui.action import SVNAction, GitAction
@@ -119,6 +123,7 @@ classes_map = {
 def ignore_factory(path, pattern):
     guess = rabbitvcs.vcs.guess(path)
     return classes_map[guess["vcs"]](path, pattern)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/import.py
+++ b/rabbitvcs/ui/import.py
@@ -30,6 +30,7 @@ from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
 _ = gettext.gettext
@@ -45,7 +46,7 @@ class SVNImport(InterfaceView):
         self.svn = self.vcs.svn()
 
         if self.svn.is_in_a_or_a_working_copy(path):
-            self.get_widget("repository").set_text(self.svn.get_repo_url(path))
+            self.get_widget("repository").set_text(S(self.svn.get_repo_url(path)).display())
 
         self.repositories = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("repositories"),
@@ -89,7 +90,7 @@ class SVNImport(InterfaceView):
         dialog = rabbitvcs.ui.dialog.PreviousMessages()
         message = dialog.run()
         if message is not None:
-            self.message.set_text(message)
+            self.message.set_text(S(message).display())
 
 
 

--- a/rabbitvcs/ui/import.py
+++ b/rabbitvcs/ui/import.py
@@ -21,15 +21,18 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
-import rabbitvcs.util.helper
 from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
@@ -50,7 +53,7 @@ class SVNImport(InterfaceView):
 
         self.repositories = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("repositories"),
-            rabbitvcs.util.helper.get_repository_paths()
+            helper.get_repository_paths()
         )
 
         self.message = rabbitvcs.ui.widget.TextView(
@@ -101,6 +104,7 @@ classes_map = {
 def import_factory(path):
     vcs = rabbitvcs.vcs.VCS_SVN
     return classes_map[vcs](path)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/lock.py
+++ b/rabbitvcs/ui/lock.py
@@ -70,7 +70,8 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
 
         self.files_table = rabbitvcs.ui.widget.Table(
             self.get_widget("files_table"),
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH, GObject.TYPE_STRING,
+            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH, GObject.TYPE_STRING,
                 GObject.TYPE_STRING],
             [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension"),
                 _("Locked")],
@@ -78,7 +79,7 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
                 "callback": rabbitvcs.ui.widget.path_filter,
                 "user_data": {
                     "base_dir": base_dir,
-                    "column": 1
+                    "column": 2
                 }
             }],
             callbacks={
@@ -128,6 +129,7 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
 
             self.files_table.append([
                 True,
+                S(item.path),
                 item.path,
                 helper.get_file_extension(item.path),
                 locked

--- a/rabbitvcs/ui/lock.py
+++ b/rabbitvcs/ui/lock.py
@@ -22,11 +22,15 @@ from __future__ import absolute_import
 #
 
 import six.moves._thread
-
 import os
+
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import SVNAction
@@ -34,7 +38,6 @@ from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.vcs
-from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
@@ -191,6 +194,7 @@ classes_map = {
 def lock_factory(paths, base_dir):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths, base_dir)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT

--- a/rabbitvcs/ui/lock.py
+++ b/rabbitvcs/ui/lock.py
@@ -35,6 +35,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.vcs
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.lock")
@@ -179,7 +180,7 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
         dialog = rabbitvcs.ui.dialog.PreviousMessages()
         message = dialog.run()
         if message is not None:
-            self.message.set_text(message)
+            self.message.set_text(S(message).display())
 
 
 

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -39,6 +39,7 @@ from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.util.decorators import gtk_unsafe
 import rabbitvcs.ui.widget
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
@@ -67,10 +68,10 @@ def revision_grapher(history):
     last_lines = []
     color = "#d3b9d3"
     for item in history:
-        commit = helper.to_text(item.revision)
+        commit = S(item.revision)
         parents = []
         for parent in item.parents:
-            parents.append(helper.to_text(parent))
+            parents.append(S(parent))
 
         if commit not in revisions:
             revisions.append(commit)
@@ -138,7 +139,7 @@ class Log(InterfaceView):
         self.initialize_revision_labels()
         self.revision_number_column = 0
         self.head_row = 0
-        self.get_widget("limit").set_text(str(self.limit))
+        self.get_widget("limit").set_text(S(self.limit).display())
 
         self.message = rabbitvcs.ui.widget.TextView(
             self.get_widget("message")
@@ -224,11 +225,11 @@ class Log(InterfaceView):
 
     def on_paths_table_row_activated(self, treeview, data=None, col=None):
         try:
-            revision1 = helper.to_text(self.display_items[self.revisions_table.get_selected_rows()[0]].revision)
-            revision2 = helper.to_text(self.display_items[self.revisions_table.get_selected_rows()[0]+1].revision)
+            revision1 = S(self.display_items[self.revisions_table.get_selected_rows()[0]].revision)
+            revision2 = S(self.display_items[self.revisions_table.get_selected_rows()[0]+1].revision)
             path_item = self.paths_table.get_row(self.paths_table.get_selected_rows()[0])[1]
             url = self.root_url + path_item
-            self.view_diff_for_path(url, helper.to_text(revision1), helper.to_text(revision2), sidebyside=True)
+            self.view_diff_for_path(url, S(revision1), S(revision2), sidebyside=True)
         except IndexError:
             pass
 
@@ -297,11 +298,11 @@ class Log(InterfaceView):
 
     @gtk_unsafe
     def set_start_revision(self, rev):
-        self.get_widget("start").set_text(str(rev))
+        self.get_widget("start").set_text(S(rev).display())
 
     @gtk_unsafe
     def set_end_revision(self, rev):
-        self.get_widget("end").set_text(str(rev))
+        self.get_widget("end").set_text(S(rev).display())
 
     def initialize_revision_labels(self):
         self.set_start_revision(_("N/A"))
@@ -441,8 +442,8 @@ class SVNLog(Log):
             return
 
         # Get the starting/ending point from the actual returned revisions
-        self.rev_start = int(helper.to_text(self.revision_items[0].revision))
-        self.rev_end = int(helper.to_text(self.revision_items[-1].revision))
+        self.rev_start = int(S(self.revision_items[0].revision))
+        self.rev_end = int(S(self.revision_items[-1].revision))
 
         if not self.rev_first:
             self.rev_first = self.rev_start
@@ -496,7 +497,7 @@ class SVNLog(Log):
 
     def populate_table(self, revision, author, date, msg, color):
         self.revisions_table.append([
-            helper.to_text(revision),
+            S(revision),
             author,
             helper.format_datetime(date),
             msg,
@@ -553,7 +554,7 @@ class SVNLog(Log):
     def on_log_message_edited(self, index, val):
         self.display_items[index].message = val
         self.revisions_table.set_row_item(index, 3, val)
-        self.message.set_text(val)
+        self.message.set_text(S(val).display())
 
     def on_author_edited(self, index, val):
         self.display_items[index].author = val
@@ -564,16 +565,16 @@ class SVNLog(Log):
         for selected_row in self.revisions_table.get_selected_rows():
             item = self.display_items[selected_row]
 
-            text += "%s: %s\n" % (REVISION_LABEL, helper.to_text(item.revision))
-            text += "%s: %s\n" % (AUTHOR_LABEL, helper.to_text(item.author))
-            text += "%s: %s\n" % (DATE_LABEL, helper.to_text(item.date))
-            text += "%s\n\n"   % item.message
+            text += "%s: %s\n" % (REVISION_LABEL, S(item.revision).display())
+            text += "%s: %s\n" % (AUTHOR_LABEL, S(item.author).display())
+            text += "%s: %s\n" % (DATE_LABEL, S(item.date).display())
+            text += "%s\n\n"   % S(item.message).display()
             if item.changed_paths is not None:
                 for subitem in item.changed_paths:
-                    text += "%s\t%s" % (subitem.action, subitem.path)
+                    text += "%s\t%s" % (S(subitem.action).display(), S(subitem.path).display())
 
                     if subitem.copy_from_path or subitem.copy_from_revision:
-                        text += " (Copied from %s %s)" % (subitem.copy_from_path, subitem.copy_from_revision)
+                        text += " (Copied from %s %s)" % (S(subitem.copy_from_path).display(), S(subitem.copy_from_revision).display())
 
                     text += "\n"
 
@@ -587,14 +588,15 @@ class SVNLog(Log):
 
         for selected_row in self.revisions_table.get_selected_rows():
             item = self.display_items[selected_row]
+            msg = S(item.message).display()
 
             if len(self.revisions_table.get_selected_rows()) == 1:
-                self.message.set_text(item.message)
+                self.message.set_text(msg)
             else:
-                indented_message = item.message.replace("\n","\n\t")
+                indented_message = msg.replace("\n","\n\t")
                 self.message.append_text(
                                          "%s %s:\n\t%s\n" % (REVISION_LABEL,
-                                         helper.to_text(item.revision),
+                                         S(item.revision).display(),
                                          indented_message))
             if item.changed_paths is not None:
                 for subitem in item.changed_paths:
@@ -605,7 +607,7 @@ class SVNLog(Log):
                             subitem.action,
                             subitem.path,
                             subitem.copy_from_path,
-                            helper.to_text(subitem.copy_from_revision)
+                            S(subitem.copy_from_revision)
                         ])
 
         subitems.sort(key = lambda x: x[1])
@@ -614,7 +616,7 @@ class SVNLog(Log):
                 subitem[0],
                 subitem[1],
                 subitem[2],
-                helper.to_text(subitem[3])
+                S(subitem[3])
             ])
 
     def on_previous_clicked(self, widget):
@@ -742,7 +744,7 @@ class GitLog(Log):
             should_add = not self.filter_text
             should_add = should_add or msg.find(self.filter_text) > -1
             should_add = should_add or item.author.lower().find(self.filter_text) > -1
-            should_add = should_add or helper.to_text(item.revision).lower().find(self.filter_text) > -1
+            should_add = should_add or S(item.revision).lower().find(self.filter_text) > -1
             should_add = should_add or str(item.date).lower().find(self.filter_text) > -1
 
             if should_add:
@@ -765,7 +767,7 @@ class GitLog(Log):
 
         index = 0
         for (item, node, in_lines, out_lines) in grapher:
-            revision = helper.to_text(item.revision)
+            revision = S(item.revision)
             msg = helper.html_escape(helper.format_long_text(item.message, cols = 80, line1only = True))
             author = item.author
             date = helper.format_datetime(item.date)
@@ -852,10 +854,10 @@ class GitLog(Log):
         for selected_row in self.revisions_table.get_selected_rows():
             item = self.display_items[selected_row]
 
-            text += "%s: %s\n" % (REVISION_LABEL, helper.to_text(item.revision.short()))
-            text += "%s: %s\n" % (AUTHOR_LABEL, helper.to_text(item.author))
-            text += "%s: %s\n" % (DATE_LABEL, helper.to_text(item.date))
-            text += "%s\n\n" % item.message
+            text += "%s: %s\n" % (REVISION_LABEL, S(item.revision.short()).display())
+            text += "%s: %s\n" % (AUTHOR_LABEL, S(item.author).display())
+            text += "%s: %s\n" % (DATE_LABEL, S(item.date).display())
+            text += "%s\n\n" % S(item.message).display()
 
         self.revision_clipboard.set_text(text, -1)
 
@@ -865,15 +867,16 @@ class GitLog(Log):
 
         for selected_row in self.revisions_table.get_selected_rows():
             item = self.display_items[selected_row]
+            msg = S(item.message).display()
 
             if len(self.revisions_table.get_selected_rows()) == 1:
-                self.message.set_text(item.message)
+                self.message.set_text(msg)
             else:
-                indented_message = item.message.replace("\n","\n\t")
+                indented_message = msg.replace("\n","\n\t")
                 self.message.append_text(
                                          "%s %s:\n\t%s\n" % (REVISION_LABEL,
                                          item.revision.short(),
-                                         indented_message))
+                                         msg))
 
             for subitem in item.changed_paths:
 
@@ -1150,17 +1153,17 @@ class LogTopContextMenuCallbacks:
 
     def find_parent(self, revision):
         if ("parents" in revision) and len(revision["parents"]) > 0:
-            parent = helper.to_text(revision["parents"][0])
+            parent = S(revision["parents"][0])
         elif ("next_revision" in revision):
-            parent = helper.to_text(revision["next_revision"])
+            parent = S(revision["next_revision"])
         else:
-            parent = helper.to_text(int(helper.to_text(revision["revision"])) - 1)
+            parent = S(int(S(revision["revision"])) - 1)
 
         return parent
 
     def view_diff_working_copy(self, widget, data=None):
         helper.launch_ui_window("diff", [
-            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
+            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1172,7 +1175,7 @@ class LogTopContextMenuCallbacks:
 
         helper.launch_ui_window("diff", [
             "%s@%s" % (self.path, parent),
-            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
+            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1183,7 +1186,7 @@ class LogTopContextMenuCallbacks:
 
         helper.launch_ui_window("diff", [
             "%s@%s" % (path_older, self.revisions[1]["revision"].value),
-            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
+            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1194,7 +1197,7 @@ class LogTopContextMenuCallbacks:
 
         helper.launch_ui_window("diff", [
             "-s",
-            "%s@%s" % (path_older, helper.to_text(self.revisions[0]["revision"])),
+            "%s@%s" % (path_older, S(self.revisions[0]["revision"])),
             "%s" % (self.path),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
@@ -1205,7 +1208,7 @@ class LogTopContextMenuCallbacks:
         helper.launch_ui_window("diff", [
             "-s",
             "%s@%s" % (self.path, parent),
-            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
+            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1217,12 +1220,12 @@ class LogTopContextMenuCallbacks:
         helper.launch_ui_window("diff", [
             "-s",
             "%s@%s" % (path_older, self.revisions[1]["revision"].value),
-            "%s@%s" % (self.path, helper.to_text(self.revisions[0]["revision"])),
+            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def show_changes_previous_revision(self, widget, data=None):
-        rev_first = helper.to_text(self.revisions[0]["revision"])
+        rev_first = S(self.revisions[0]["revision"])
         parent = self.find_parent(self.revisions[0])
 
         path = self.path
@@ -1231,35 +1234,35 @@ class LogTopContextMenuCallbacks:
 
         helper.launch_ui_window("changes", [
             "%s@%s" % (path, parent),
-            "%s@%s" % (path, helper.to_text(rev_first)),
+            "%s@%s" % (path, S(rev_first)),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def show_changes_revisions(self, widget, data=None):
-        rev_first = helper.to_text(self.revisions[0]["revision"])
-        rev_last = helper.to_text(self.revisions[-1]["revision"])
+        rev_first = S(self.revisions[0]["revision"])
+        rev_last = S(self.revisions[-1]["revision"])
 
         path = self.path
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path = self.vcs.svn().get_repo_url(self.path)
 
         helper.launch_ui_window("changes", [
-            "%s@%s" % (path, helper.to_text(rev_first)),
-            "%s@%s" % (path, helper.to_text(rev_last)),
+            "%s@%s" % (path, S(rev_first)),
+            "%s@%s" % (path, S(rev_last)),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def update_to_this_revision(self, widget, data=None):
         helper.launch_ui_window("updateto", [
             self.path,
-            "-r", helper.to_text(self.revisions[0]["revision"]),
+            "-r", S(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def revert_changes_from_this_revision(self, widget, data=None):
         helper.launch_ui_window("merge", [
             self.path,
-            helper.to_text(self.revisions[0]["revision"]) + "-" + str(int(helper.to_text(self.revisions[0]["revision"])) - 1),
+            S(self.revisions[0]["revision"]) + "-" + str(int(S(self.revisions[0]["revision"])) - 1),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1271,44 +1274,44 @@ class LogTopContextMenuCallbacks:
         helper.launch_ui_window("checkout", [
             self.path,
             url,
-            "-r", helper.to_text(self.revisions[0]["revision"]),
+            "-r", S(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def branch_tag(self, widget, data=None):
         helper.launch_ui_window("branch", [
             self.path,
-            "-r", helper.to_text(self.revisions[0]["revision"]),
+            "-r", S(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def branches(self, widget, data=None):
         helper.launch_ui_window("branches", [
             self.path,
-            "-r", helper.to_text(self.revisions[0]["revision"]),
+            "-r", S(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def tags(self, widget, data=None):
         helper.launch_ui_window("tags", [
             self.path,
-            "-r", helper.to_text(self.revisions[0]["revision"]),
+            "-r", S(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def export(self, widget, data=None):
         helper.launch_ui_window("export", [
             self.path,
-            "-r", helper.to_text(self.revisions[0]["revision"]),
+            "-r", S(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
     def merge(self, widget, data=None):
         extra = []
         if self.vcs_name == rabbitvcs.vcs.VCS_GIT:
-            extra.append(helper.to_text(self.revisions[0]["revision"]))
+            extra.append(S(self.revisions[0]["revision"]))
             try:
-                fromrev = helper.to_text(self.revisions[1]["revision"])
+                fromrev = S(self.revisions[1]["revision"])
                 extra.append(fromrev)
             except IndexError as e:
                 pass
@@ -1320,7 +1323,7 @@ class LogTopContextMenuCallbacks:
     def reset(self, widget, data=None):
         helper.launch_ui_window("reset", [
             self.path,
-            "-r", helper.to_text(self.revisions[0]["revision"]),
+            "-r", S(self.revisions[0]["revision"]),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1352,7 +1355,7 @@ class LogTopContextMenuCallbacks:
         url = self.vcs.svn().get_repo_url(self.path)
 
         helper.launch_ui_window("revprops", [
-            "%s@%s" % (url, helper.to_text(self.revisions[0]["revision"])),
+            "%s@%s" % (url, S(self.revisions[0]["revision"])),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1489,16 +1492,16 @@ class LogBottomContextMenuCallbacks:
 
     def find_parent(self, revision):
         if ("parents" in revision) and len(revision["parents"]) > 0:
-            parent = helper.to_text(revision["parents"][0])
+            parent = S(revision["parents"][0])
         elif ("next_revision" in revision):
-            parent = helper.to_text(revision["next_revision"])
+            parent = S(revision["next_revision"])
         else:
-            parent = helper.to_text(int(helper.to_text(revision["revision"])) - 1)
+            parent = S(int(S(revision["revision"])) - 1)
 
         return parent
 
     def view_diff_previous_revision(self, widget, data=None):
-        rev = helper.to_text(self.revisions[0]["revision"])
+        rev = S(self.revisions[0]["revision"])
 
         parent = self.find_parent(self.revisions[0])
 
@@ -1507,15 +1510,15 @@ class LogBottomContextMenuCallbacks:
         self.caller.view_diff_for_path(url, rev, parent)
 
     def view_diff_revisions(self, widget, data=None):
-        rev_first = helper.to_text(self.revisions[0]["revision"])
-        rev_last = helper.to_text(self.revisions[-1]["revision"])
+        rev_first = S(self.revisions[0]["revision"])
+        rev_last = S(self.revisions[-1]["revision"])
         path_item = self.paths[0]
         url = self.caller.root_url + path_item
         self.caller.view_diff_for_path(url, latest_revision_number=rev_last,
                                        earliest_revision_number=rev_first)
 
     def compare_previous_revision(self, widget, data=None):
-        rev = helper.to_text(self.revisions[0]["revision"])
+        rev = S(self.revisions[0]["revision"])
 
         parent = self.find_parent(self.revisions[0])
 
@@ -1524,8 +1527,8 @@ class LogBottomContextMenuCallbacks:
         self.caller.view_diff_for_path(url, rev, parent, sidebyside=True)
 
     def compare_revisions(self, widget, data=None):
-        earliest_rev = helper.to_text(self.revisions[0]["revision"])
-        latest_rev = helper.to_text(self.revisions[-1]["revision"])
+        earliest_rev = S(self.revisions[0]["revision"])
+        latest_rev = S(self.revisions[-1]["revision"])
         path_item = self.paths[0]
         url = self.caller.root_url + path_item
         self.caller.view_diff_for_path(url,
@@ -1534,8 +1537,8 @@ class LogBottomContextMenuCallbacks:
                                         earliest_revision_number=earliest_rev)
 
     def show_changes_previous_revision(self, widget, data=None):
-        rev_first = helper.to_text(self.revisions[0]["revision"])
-        rev_last = helper.to_text(self.revisions[-1]["revision"])
+        rev_first = S(self.revisions[0]["revision"])
+        rev_last = S(self.revisions[-1]["revision"])
 
         parent = self.find_parent(self.revisions[0])
 
@@ -1548,8 +1551,8 @@ class LogBottomContextMenuCallbacks:
         ])
 
     def show_changes_revisions(self, widget, data=None):
-        rev_first = helper.to_text(self.revisions[0]["revision"])
-        rev_last = helper.to_text(self.revisions[-1]["revision"])
+        rev_first = S(self.revisions[0]["revision"])
+        rev_last = S(self.revisions[-1]["revision"])
 
         url = self.caller.root_url + self.paths[0]
 
@@ -1566,7 +1569,7 @@ class LogBottomContextMenuCallbacks:
             helper.launch_ui_window("open", [
                 path,
                 "--vcs=%s" % self.vcs_name,
-                "-r", helper.to_text(self.revisions[0]["revision"])
+                "-r", S(self.revisions[0]["revision"])
             ])
 
     def annotate(self, widget, data=None):
@@ -1574,7 +1577,7 @@ class LogBottomContextMenuCallbacks:
         helper.launch_ui_window("annotate", [
             url,
             "--vcs=%s" % self.vcs_name,
-            "-r", helper.to_text(self.revisions[0]["revision"])
+            "-r", S(self.revisions[0]["revision"])
         ])
 
 class LogBottomContextMenu:

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -22,6 +22,7 @@
 
 from __future__ import division
 from __future__ import absolute_import
+import six
 import threading
 from datetime import datetime
 
@@ -1511,14 +1512,14 @@ class LogBottomContextMenuCallbacks:
 
         parent = self.find_parent(self.revisions[0])
 
-        path_item = self.paths[0]
+        path_item = S(self.paths[0]).unicode()
         url = self.caller.root_url + path_item
         self.caller.view_diff_for_path(url, rev, parent)
 
     def view_diff_revisions(self, widget, data=None):
         rev_first = S(self.revisions[0]["revision"])
         rev_last = S(self.revisions[-1]["revision"])
-        path_item = self.paths[0]
+        path_item = S(self.paths[0]).unicode()
         url = self.caller.root_url + path_item
         self.caller.view_diff_for_path(url, latest_revision_number=rev_last,
                                        earliest_revision_number=rev_first)
@@ -1528,14 +1529,14 @@ class LogBottomContextMenuCallbacks:
 
         parent = self.find_parent(self.revisions[0])
 
-        path_item = self.paths[0]
+        path_item = S(self.paths[0]).unicode()
         url = self.caller.root_url + path_item
         self.caller.view_diff_for_path(url, rev, parent, sidebyside=True)
 
     def compare_revisions(self, widget, data=None):
         earliest_rev = S(self.revisions[0]["revision"])
         latest_rev = S(self.revisions[-1]["revision"])
-        path_item = self.paths[0]
+        path_item = S(self.paths[0]).unicode()
         url = self.caller.root_url + path_item
         self.caller.view_diff_for_path(url,
                                         latest_rev,
@@ -1548,11 +1549,11 @@ class LogBottomContextMenuCallbacks:
 
         parent = self.find_parent(self.revisions[0])
 
-        url = self.caller.root_url + self.paths[0]
+        url = self.caller.root_url + S(self.paths[0]).unicode()
 
         helper.launch_ui_window("changes", [
-            "%s@%s" % (url, parent),
-            "%s@%s" % (url, rev_last),
+            six.u("%s@%s") % (url, parent),
+            six.u("%s@%s") % (url, rev_last),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1560,18 +1561,18 @@ class LogBottomContextMenuCallbacks:
         rev_first = S(self.revisions[0]["revision"])
         rev_last = S(self.revisions[-1]["revision"])
 
-        url = self.caller.root_url + self.paths[0]
+        url = self.caller.root_url + S(self.paths[0]).unicode()
 
         helper.launch_ui_window("changes", [
-            "%s@%s" % (url, rev_first),
-            "%s@%s" % (url, rev_last),
+            six.u("%s@%s") % (url, rev_first),
+            six.u("%s@%s") % (url, rev_last),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
 
     def _open(self, widget, data=None):
         for path in self.paths:
-            path = self.caller.root_url + path
+            path = self.caller.root_url + S(path).unicode()
             helper.launch_ui_window("open", [
                 path,
                 "--vcs=%s" % self.vcs_name,
@@ -1579,7 +1580,7 @@ class LogBottomContextMenuCallbacks:
             ])
 
     def annotate(self, widget, data=None):
-        url = self.caller.root_url + self.paths[0]
+        url = self.caller.root_url + S(self.paths[0]).unicode()
         helper.launch_ui_window("annotate", [
             url,
             "--vcs=%s" % self.vcs_name,

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -391,9 +391,9 @@ class SVNLog(Log):
 
         self.paths_table = rabbitvcs.ui.widget.Table(
             self.get_widget("paths_table"),
-            [GObject.TYPE_STRING, GObject.TYPE_STRING,
-                GObject.TYPE_STRING, GObject.TYPE_STRING],
-            [_("Action"), _("Path"),
+            [GObject.TYPE_STRING, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
+            [_("Action"), "", _("Path"),
                 _("Copy From Path"), _("Copy From Revision")],
             callbacks={
                 "mouse-event":      self.on_paths_table_mouse_event,
@@ -401,7 +401,7 @@ class SVNLog(Log):
             },
             flags={
                 "sortable": True,
-                "sort_on": 1
+                "sort_on": 2
             }
         )
 
@@ -617,6 +617,7 @@ class SVNLog(Log):
         for subitem in subitems:
             self.paths_table.append([
                 subitem[0],
+                S(subitem[1]),
                 subitem[1],
                 subitem[2],
                 S(subitem[3])
@@ -679,8 +680,9 @@ class GitLog(Log):
 
         self.paths_table = rabbitvcs.ui.widget.Table(
             self.get_widget("paths_table"),
-            [GObject.TYPE_STRING, GObject.TYPE_STRING],
-            [_("Action"), _("Path")],
+            [GObject.TYPE_STRING, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                GObject.TYPE_STRING],
+            [_("Action"), "", _("Path")],
             callbacks={
                 "mouse-event":      self.on_paths_table_mouse_event,
                 "row-activated":    self.on_paths_table_row_activated
@@ -895,6 +897,7 @@ class GitLog(Log):
         for subitem in subitems:
             self.paths_table.append([
                 subitem[0],
+                S(subitem[1]),
                 subitem[1]
             ])
 

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -27,9 +27,13 @@ from datetime import datetime
 
 import os.path
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import SVNAction, GitAction, vcs_action_factory
@@ -38,7 +42,6 @@ from rabbitvcs.util.contextmenu import GtkContextMenu
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.util.decorators import gtk_unsafe
 import rabbitvcs.ui.widget
-from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 
@@ -1673,6 +1676,7 @@ def log_dialog_factory(path, ok_callback=None, multiple=False, vcs=None):
         vcs = guess["vcs"]
 
     return dialogs_map[vcs](path, ok_callback, multiple)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT

--- a/rabbitvcs/ui/markresolved.py
+++ b/rabbitvcs/ui/markresolved.py
@@ -36,6 +36,7 @@ from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.markresolved")
@@ -48,9 +49,11 @@ class SVNMarkResolved(Add):
         window.set_title(_("Mark as Resolved"))
         self.svn = self.vcs.svn()
         self.statuses = self.svn.STATUSES_FOR_RESOLVE
-        columns[0] = [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH,
+        columns[0] = [GObject.TYPE_BOOLEAN,
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH,
                 GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
-        columns[1] = [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"),
+        columns[1] = [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"),
                 _("Extension"), _("Text Status"), _("Property Status")]
 
     def populate_files_table(self):
@@ -58,6 +61,7 @@ class SVNMarkResolved(Add):
         for item in self.items:
             self.files_table.append([
                 True,
+                S(item.path),
                 item.path,
                 helper.get_file_extension(item.path),
                 item.simple_content_status(),

--- a/rabbitvcs/ui/markresolved.py
+++ b/rabbitvcs/ui/markresolved.py
@@ -23,16 +23,19 @@ from __future__ import absolute_import
 
 import six.moves._thread
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.add import Add
 from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
 from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.markresolved")
@@ -56,7 +59,7 @@ class SVNMarkResolved(Add):
             self.files_table.append([
                 True,
                 item.path,
-                rabbitvcs.util.helper.get_file_extension(item.path),
+                helper.get_file_extension(item.path),
                 item.simple_content_status(),
                 item.simple_metadata_status()
             ])
@@ -88,6 +91,7 @@ classes_map = {
 def markresolved_factory(paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths, base_dir)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT

--- a/rabbitvcs/ui/merge.py
+++ b/rabbitvcs/ui/merge.py
@@ -21,16 +21,19 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.log import SVNLogDialog
 from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.vcs
 import rabbitvcs.ui.widget
-from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext

--- a/rabbitvcs/ui/merge.py
+++ b/rabbitvcs/ui/merge.py
@@ -31,6 +31,7 @@ from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.vcs
 import rabbitvcs.ui.widget
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
 _ = gettext.gettext
@@ -257,7 +258,7 @@ class SVNMerge(InterfaceView):
                 next = 1
                 self.type = "range"
                 if self.revision_range:
-                    self.get_widget("mergerange_revisions").set_text(self.revision_range)
+                    self.get_widget("mergerange_revisions").set_text(S(self.revision_range).display())
             elif self.get_widget("mergetype_tree_opt").get_active():
                 next = 2
                 self.type = "tree"
@@ -280,7 +281,7 @@ class SVNMerge(InterfaceView):
                 self.repo_paths
             )
             self.mergerange_repos.set_child_text(self.root_url)
-            self.get_widget("mergerange_working_copy").set_text(self.path)
+            self.get_widget("mergerange_working_copy").set_text(S(self.path).display())
 
         self.mergerange_check_ready()
 
@@ -298,7 +299,7 @@ class SVNMerge(InterfaceView):
 
     def on_mergerange_log1_closed(self, data):
         if not data is None:
-            self.get_widget("mergerange_revisions").set_text(data)
+            self.get_widget("mergerange_revisions").set_text(S(data).display())
 
     def on_mergerange_from_urls_changed(self, widget):
         self.mergerange_check_ready()
@@ -329,7 +330,7 @@ class SVNMerge(InterfaceView):
                 self.repo_paths
             )
             self.merge_reintegrate_repos.cb.connect("changed", self.on_merge_reintegrate_from_urls_changed)
-            self.get_widget("merge_reintegrate_working_copy").set_text(self.path)
+            self.get_widget("merge_reintegrate_working_copy").set_text(S(self.path).display())
 
         if not hasattr(self, "merge_reintegrate_revision"):
             self.merge_reintegrate_revision = rabbitvcs.ui.widget.RevisionSelector(
@@ -371,7 +372,7 @@ class SVNMerge(InterfaceView):
                 self.get_widget("mergetree_to_urls"),
                 self.repo_paths
             )
-            self.get_widget("mergetree_working_copy").set_text(self.path)
+            self.get_widget("mergetree_working_copy").set_text(S(self.path).display())
 
     def on_mergetree_from_show_log_clicked(self, widget):
         SVNLogDialog(
@@ -381,7 +382,7 @@ class SVNMerge(InterfaceView):
         )
 
     def on_mergetree_from_show_log_closed(self, data):
-        self.get_widget("mergetree_from_revision_number").set_text(data)
+        self.get_widget("mergetree_from_revision_number").set_text(S(data).display())
         self.get_widget("mergetree_from_revision_number_opt").set_active(True)
 
     def on_mergetree_to_show_log_clicked(self, widget):
@@ -392,7 +393,7 @@ class SVNMerge(InterfaceView):
         )
 
     def on_mergetree_to_show_log_closed(self, data):
-        self.get_widget("mergetree_to_revision_number").set_text(data)
+        self.get_widget("mergetree_to_revision_number").set_text(S(data).display())
         self.get_widget("mergetree_to_revision_number_opt").set_active(True)
 
     def on_mergetree_working_copy_show_log_clicked(self, widget):
@@ -469,7 +470,7 @@ class GitMerge(BranchMerge):
 
         self.active_branch = self.git.get_active_branch()
         if self.active_branch:
-            self.get_widget("to_branch").set_text(self.active_branch.name + " (" + self.active_branch.revision[0:7] + ")")
+            self.get_widget("to_branch").set_text(S(self.active_branch.name + " (" + self.active_branch.revision[0:7] + ")").display())
         else:
             self.get_widget("to_branch").set_text(_("No active branch"))
 
@@ -538,10 +539,10 @@ class GitMerge(BranchMerge):
             log = self.git.log(self.path, limit=1, revision=from_branch, showtype="branch")
             if log:
                 from_info = log[0]
-                self.info['from']['author'].set_text(from_info.author)
+                self.info['from']['author'].set_text(S(from_info.author).display())
                 self.info['from']['date'].set_text(helper.format_datetime(from_info.date))
-                self.info['from']['revision'].set_text(helper.to_text(from_info.revision)[0:7])
-                self.info['from']['message'].set_text(helper.html_escape(helper.format_long_text(from_info.message, 500)))
+                self.info['from']['revision'].set_text(S(from_info.revision).display()[0:7])
+                self.info['from']['message'].set_text(S(helper.html_escape(helper.format_long_text(from_info.message, 500))).display())
 
     def on_from_branches_changed(self, widget):
         self.update_branch_info()

--- a/rabbitvcs/ui/open.py
+++ b/rabbitvcs/ui/open.py
@@ -24,15 +24,18 @@ from __future__ import absolute_import
 from os import getcwd
 import os.path
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceNonView
 from rabbitvcs.ui.action import SVNAction, GitAction
 
 import rabbitvcs.vcs
-from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
@@ -138,6 +141,7 @@ def open_factory(vcs, path, revision):
         vcs = guess["vcs"]
 
     return classes_map[vcs](path, revision)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT

--- a/rabbitvcs/ui/open.py
+++ b/rabbitvcs/ui/open.py
@@ -64,7 +64,7 @@ class SVNOpen(InterfaceNonView):
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
 
-        if revision and type(revision) in (str, six.text_type):
+        if revision and isinstance(revision, (str, six.text_type)):
             revision_obj = self.svn.revision("number", number=revision)
         else:
             revision_obj = self.svn.revision("HEAD")

--- a/rabbitvcs/ui/open.py
+++ b/rabbitvcs/ui/open.py
@@ -33,6 +33,7 @@ from rabbitvcs.ui.action import SVNAction, GitAction
 
 import rabbitvcs.vcs
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
 _ = gettext.gettext
@@ -107,7 +108,7 @@ class GitOpen(InterfaceNonView):
         else:
             revision_obj = self.git.revision("HEAD")
 
-        dest_dir = helper.get_tmp_path("rabbitvcs-" + helper.to_text(revision))
+        dest_dir = helper.get_tmp_path("rabbitvcs-" + S(revision))
 
         self.git.export(
             path,

--- a/rabbitvcs/ui/properties.py
+++ b/rabbitvcs/ui/properties.py
@@ -29,6 +29,7 @@ from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.properties")
@@ -56,7 +57,7 @@ class PropertiesBase(InterfaceView):
             _("Properties - %s") % path
         )
 
-        self.get_widget("path").set_text(path)
+        self.get_widget("path").set_text(S(path).display())
 
         self.table = rabbitvcs.ui.widget.Table(
             self.get_widget("table"),

--- a/rabbitvcs/ui/properties.py
+++ b/rabbitvcs/ui/properties.py
@@ -21,9 +21,13 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
@@ -175,6 +179,7 @@ class SVNProperties(PropertiesBase):
             rabbitvcs.ui.dialog.MessageBox(_("There was a problem saving your properties."))
 
         self.close()
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/property_editor.py
+++ b/rabbitvcs/ui/property_editor.py
@@ -33,9 +33,13 @@ from __future__ import print_function
 
 import os.path
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.util.contextmenu import GtkContextMenu, GtkContextMenuCaller
@@ -279,6 +283,7 @@ class PropMenuConditions:
 
     def property_edit(self):
         return len(list(self.propdetails.keys())) == 1
+
 
 if __name__ == "__main__":
     # These are some dumb tests before I add any functionality.

--- a/rabbitvcs/ui/property_editor.py
+++ b/rabbitvcs/ui/property_editor.py
@@ -44,7 +44,7 @@ import rabbitvcs.util.contextmenuitems
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.vcs
-from rabbitvcs.util.helper import format_long_text
+from rabbitvcs.util.strings import S
 from rabbitvcs.vcs.svn import Revision
 from rabbitvcs.util.log import Log
 
@@ -95,7 +95,7 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
 
         self.path = path
 
-        self.get_widget("wc_text").set_text(self.get_local_path(os.path.realpath(path)))
+        self.get_widget("wc_text").set_text(S(self.get_local_path(os.path.realpath(path))).display())
 
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
@@ -105,7 +105,7 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
             self.close()
             return
 
-        self.get_widget("remote_uri_text").set_text(self.svn.get_repo_url(path))
+        self.get_widget("remote_uri_text").set_text(S(self.svn.get_repo_url(path)).display())
 
         self.table = rabbitvcs.ui.widget.Table(
             self.get_widget("table"),

--- a/rabbitvcs/ui/property_page.py
+++ b/rabbitvcs/ui/property_page.py
@@ -34,7 +34,7 @@ import rabbitvcs.vcs
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 from rabbitvcs.ui import STATUS_EMBLEMS
 
-from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.ui.property_page")
 
@@ -88,17 +88,17 @@ class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
         self.vcs = vcs or rabbitvcs.vcs.VCS()
         self.checker = StatusChecker()
 
-        self.get_widget("file_name").set_text(os.path.basename(path))
+        self.get_widget("file_name").set_text(S(os.path.basename(path)).display())
 
         self.status = self.checker.check_status(path,
                                                 recurse = False,
                                                 invalidate = False,
                                                 summary = False)
 
-        self.get_widget("vcs_type").set_text(self.status.vcs_type)
+        self.get_widget("vcs_type").set_text(S(self.status.vcs_type).display())
 
-        self.get_widget("content_status").set_text(helper.to_text(self.status.simple_content_status()))
-        self.get_widget("prop_status").set_text(helper.to_text(self.status.simple_metadata_status()))
+        self.get_widget("content_status").set_text(S(self.status.simple_content_status()).display())
+        self.get_widget("prop_status").set_text(S(self.status.simple_metadata_status()).display())
 
 
         self.set_icon_from_status(self.get_widget("content_status_icon"),
@@ -140,14 +140,14 @@ class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
 
     def get_additional_info_svn(self):
 
-        repo_url = self.vcs.svn().get_repo_url(self.path)
+        repo_url = S(self.vcs.svn().get_repo_url(self.path))
 
         return [
             (_("Repository URL"), repo_url)]
 
     def get_additional_info_git(self):
 
-        repo_url = self.vcs.git().config_get(("remote", "origin"), "url").decode("utf-8")
+        repo_url = S(self.vcs.git().config_get(("remote", "origin"), "url"))
         return [
             (_("Repository URL"), repo_url)]
 

--- a/rabbitvcs/ui/push.py
+++ b/rabbitvcs/ui/push.py
@@ -23,17 +23,20 @@ from __future__ import absolute_import
 
 import os.path
 import six.moves._thread
+from datetime import datetime
+
+from rabbitvcs.util import helper
 
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
-from datetime import datetime
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-from rabbitvcs.util import helper
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
@@ -166,6 +169,7 @@ classes_map = {
 def push_factory(path):
     guess = rabbitvcs.vcs.guess(path)
     return classes_map[guess["vcs"]](path)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/relocate.py
+++ b/rabbitvcs/ui/relocate.py
@@ -21,15 +21,18 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui.dialog import MessageBox
 import rabbitvcs.vcs
-import rabbitvcs.util.helper
 from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
@@ -61,7 +64,7 @@ class Relocate(InterfaceView):
 
         self.repositories = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("to_urls"),
-            rabbitvcs.util.helper.get_repository_paths()
+            helper.get_repository_paths()
         )
 
     def on_ok_clicked(self, widget):
@@ -91,6 +94,7 @@ class Relocate(InterfaceView):
         self.action.append(self.action.set_status, _("Completed Relocate"))
         self.action.append(self.action.finish)
         self.action.schedule()
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/relocate.py
+++ b/rabbitvcs/ui/relocate.py
@@ -30,6 +30,7 @@ from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui.dialog import MessageBox
 import rabbitvcs.vcs
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
 _ = gettext.gettext
@@ -54,7 +55,7 @@ class Relocate(InterfaceView):
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
 
-        repo = self.svn.get_repo_url(self.path)
+        repo = S(self.svn.get_repo_url(self.path)).display()
         self.get_widget("from_url").set_text(repo)
         self.get_widget("to_url").set_text(repo)
 

--- a/rabbitvcs/ui/remotes.py
+++ b/rabbitvcs/ui/remotes.py
@@ -24,9 +24,13 @@ from __future__ import print_function
 
 import os
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk, Pango
+sa.restore()
 
 from datetime import datetime
 import time
@@ -35,7 +39,6 @@ from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import GitAction
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.dialog import DeleteConfirmation
-import rabbitvcs.util.helper
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
@@ -156,6 +159,7 @@ class GitRemotes(InterfaceView):
 
     def show_edit(self, remote_name):
         self.state = STATE_EDIT
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/rename.py
+++ b/rabbitvcs/ui/rename.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import os.path
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceNonView
 from rabbitvcs.ui.action import SVNAction
@@ -132,6 +136,7 @@ classes_map = {
 def rename_factory(path):
     guess = rabbitvcs.vcs.guess(path)
     return classes_map[guess["vcs"]](path)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/reset.py
+++ b/rabbitvcs/ui/reset.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import os
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk, Pango
+sa.restore()
 
 from datetime import datetime
 import time
@@ -33,7 +37,6 @@ import time
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import GitAction
 import rabbitvcs.ui.widget
-import rabbitvcs.util.helper
 from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 
@@ -120,6 +123,7 @@ class GitReset(InterfaceView):
         root = self.git.find_repository_path(path)
         if root != path:
             self.get_widget("none_opt").set_active(True)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT

--- a/rabbitvcs/ui/reset.py
+++ b/rabbitvcs/ui/reset.py
@@ -34,6 +34,7 @@ from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import GitAction
 import rabbitvcs.ui.widget
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
@@ -54,7 +55,7 @@ class GitReset(InterfaceView):
         if revision:
             self.revision_obj = self.git.revision(revision)
 
-        self.get_widget("path").set_text(path)
+        self.get_widget("path").set_text(S(path).display())
 
         self.revision_selector = rabbitvcs.ui.widget.RevisionSelector(
             self.get_widget("revision_container"),
@@ -109,7 +110,7 @@ class GitReset(InterfaceView):
         chooser = rabbitvcs.ui.dialog.FolderChooser()
         path = chooser.run()
         if path is not None:
-            self.get_widget("path").set_text(path)
+            self.get_widget("path").set_text(S(path).display())
 
     def on_path_changed(self, widget, data=None):
         self.check_path()

--- a/rabbitvcs/ui/revert.py
+++ b/rabbitvcs/ui/revert.py
@@ -39,6 +39,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
 import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 from rabbitvcs.vcs.status import Status
 
@@ -72,14 +73,14 @@ class Revert(InterfaceView, GtkContextMenuCaller):
         self.statuses = self.vcs.statuses_for_revert(paths)
         self.files_table = rabbitvcs.ui.widget.Table(
             self.get_widget("files_table"),
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_PATH,
-                GObject.TYPE_STRING],
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension")],
+            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH, GObject.TYPE_STRING],
+            [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"), _("Extension")],
             filters=[{
                 "callback": rabbitvcs.ui.widget.path_filter,
                 "user_data": {
                     "base_dir": base_dir,
-                    "column": 1
+                    "column": 2
                 }
             }],
             callbacks={
@@ -90,17 +91,6 @@ class Revert(InterfaceView, GtkContextMenuCaller):
         )
 
         self.initialize_items()
-
-    def populate_files_table(self):
-        self.files_table.clear()
-        for item in self.items:
-            self.files_table.append([
-                True,
-                item.path,
-                helper.get_file_extension(item.path),
-                item.simple_content_status(),
-                item.simple_metadata_status()
-            ])
 
     def on_ok_clicked(self, widget):
         return True
@@ -117,6 +107,7 @@ class Revert(InterfaceView, GtkContextMenuCaller):
         for item in self.items:
             self.files_table.append([
                 True,
+                S(item.path),
                 item.path,
                 helper.get_file_extension(item.path)
             ])

--- a/rabbitvcs/ui/revert.py
+++ b/rabbitvcs/ui/revert.py
@@ -25,9 +25,13 @@ import os
 import six.moves._thread
 from time import sleep
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
@@ -35,7 +39,6 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
 import rabbitvcs.vcs
-from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from rabbitvcs.vcs.status import Status
 
@@ -241,6 +244,7 @@ quiet_classes_map = {
 def revert_factory(classes_map, paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths, base_dir)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT

--- a/rabbitvcs/ui/revprops.py
+++ b/rabbitvcs/ui/revprops.py
@@ -28,6 +28,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.ui.properties import PropertiesBase
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
+from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 from rabbitvcs.util.log import Log
 from rabbitvcs.ui.action import SVNAction
@@ -45,7 +46,7 @@ class SVNRevisionProperties(PropertiesBase):
 
         if not self.svn.is_path_repository_url(path):
             self.path = self.svn.get_repo_url(path)
-            self.get_widget("path").set_text(self.path)
+            self.get_widget("path").set_text(S(self.path).display())
 
         self.revision = revision
         self.revision_obj = None

--- a/rabbitvcs/ui/revprops.py
+++ b/rabbitvcs/ui/revprops.py
@@ -21,9 +21,13 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui.properties import PropertiesBase
 import rabbitvcs.ui.widget
@@ -103,6 +107,7 @@ class SVNRevisionProperties(PropertiesBase):
 
         self.close()
 
+
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT
     (options, args) = main(
@@ -110,7 +115,7 @@ if __name__ == "__main__":
         usage="Usage: rabbitvcs revprops [url1@rev1]"
     )
 
-    pathrev = rabbitvcs.util.helper.parse_path_revision_string(args.pop(0))
+    pathrev = helper.parse_path_revision_string(args.pop(0))
     window = SVNRevisionProperties(pathrev[0], pathrev[1])
     window.register_gtk_quit()
     Gtk.main()

--- a/rabbitvcs/ui/settings.py
+++ b/rabbitvcs/ui/settings.py
@@ -25,14 +25,14 @@ import os
 
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk, Pango
-import dbus
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util.settings
-import rabbitvcs.util.helper
 from rabbitvcs.util.strings import S
 
 import rabbitvcs.services.checkerservice
@@ -318,7 +318,7 @@ class Settings(InterfaceView):
             _("Are you sure you want to clear your repository paths?")
         )
         if confirmation.run() == Gtk.ResponseType.OK:
-            path = rabbitvcs.util.helper.get_repository_paths_path()
+            path = helper.get_repository_paths_path()
             fh = open(path, "w")
             fh.write("")
             fh.close()
@@ -329,7 +329,7 @@ class Settings(InterfaceView):
             _("Are you sure you want to clear your previous messages?")
         )
         if confirmation.run() == Gtk.ResponseType.OK:
-            path = rabbitvcs.util.helper.get_previous_messages_path()
+            path = helper.get_previous_messages_path()
             fh = open(path, "w")
             fh.write("")
             fh.close()
@@ -340,7 +340,7 @@ class Settings(InterfaceView):
             _("Are you sure you want to clear your authentication information?")
         )
         if confirmation.run() == Gtk.ResponseType.OK:
-            home_dir = rabbitvcs.util.helper.get_user_path()
+            home_dir = helper.get_user_path()
             subpaths = [
                 '/.subversion/auth/svn.simple',
                 '/.subversion/auth/svn.ssl.server',

--- a/rabbitvcs/ui/settings.py
+++ b/rabbitvcs/ui/settings.py
@@ -33,6 +33,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.util.settings
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 
 import rabbitvcs.services.checkerservice
 from rabbitvcs.services.checkerservice import StatusCheckerStub
@@ -77,22 +78,22 @@ class Settings(InterfaceView):
         )
         self.default_commit_message = rabbitvcs.ui.widget.TextView(self.get_widget("default_commit_message"))
         self.default_commit_message.set_text(
-            self.settings.get_multiline("general", "default_commit_message")
+            S(self.settings.get_multiline("general", "default_commit_message")).display()
         )
         self.get_widget("diff_tool").set_text(
-            self.settings.get("external", "diff_tool")
+            S(self.settings.get("external", "diff_tool")).display()
         )
         self.get_widget("diff_tool_swap").set_active(
             int(self.settings.get("external", "diff_tool_swap"))
         )
         self.get_widget("merge_tool").set_text(
-            self.settings.get("external", "merge_tool")
+            S(self.settings.get("external", "merge_tool")).display()
         )
         self.get_widget("cache_number_repositories").set_text(
-            str(self.settings.get("cache", "number_repositories"))
+            S(self.settings.get("cache", "number_repositories")).display()
         )
         self.get_widget("cache_number_messages").set_text(
-            str(self.settings.get("cache", "number_messages"))
+            S(self.settings.get("cache", "number_messages")).display()
         )
 
         self.logging_type = rabbitvcs.ui.widget.ComboBox(
@@ -165,8 +166,8 @@ class Settings(InterfaceView):
         self.get_widget("stop_checker").set_sensitive(bool(checker_service))
 
         if(checker_service):
-            self.get_widget("checker_type").set_text(checker_service.CheckerType())
-            self.get_widget("pid").set_text(str(checker_service.PID()))
+            self.get_widget("checker_type").set_text(S(checker_service.CheckerType()).display())
+            self.get_widget("pid").set_text(S(checker_service.PID()).display())
 
             memory = checker_service.MemoryUsage()
 
@@ -175,7 +176,7 @@ class Settings(InterfaceView):
             else:
                 self.get_widget("memory_usage").set_text(CHECKER_UNKNOWN_INFO)
 
-            self.get_widget("locale").set_text(".".join(checker_service.SetLocale()))
+            self.get_widget("locale").set_text(S(".".join(checker_service.SetLocale())).display())
 
             self._populate_info_table(checker_service.ExtraInformation())
 
@@ -310,7 +311,7 @@ class Settings(InterfaceView):
         path = chooser.run()
         if not path is None:
             path = path.replace("file://", "")
-            self.get_widget("diff_tool").set_text(path)
+            self.get_widget("diff_tool").set_text(S(path).display())
 
     def on_cache_clear_repositories_clicked(self, widget):
         confirmation = rabbitvcs.ui.dialog.Confirmation(

--- a/rabbitvcs/ui/settings.py
+++ b/rabbitvcs/ui/settings.py
@@ -22,6 +22,9 @@ from __future__ import absolute_import
 #
 
 import os
+import dbus
+
+from rabbitvcs.util import helper
 
 import gi
 gi.require_version("Gtk", "3.0")

--- a/rabbitvcs/ui/stage.py
+++ b/rabbitvcs/ui/stage.py
@@ -58,6 +58,7 @@ class GitStage(Add):
         for item in self.items:
             self.files_table.append([
                 True,
+                S(item.path),
                 item.path,
                 helper.get_file_extension(item.path)
             ])

--- a/rabbitvcs/ui/stage.py
+++ b/rabbitvcs/ui/stage.py
@@ -34,6 +34,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/stage.py
+++ b/rabbitvcs/ui/stage.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import six.moves._thread
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.add import Add
@@ -33,7 +37,6 @@ from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
 from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
@@ -56,7 +59,7 @@ class GitStage(Add):
             self.files_table.append([
                 True,
                 item.path,
-                rabbitvcs.util.helper.get_file_extension(item.path)
+                helper.get_file_extension(item.path)
             ])
 
     def on_ok_clicked(self, widget):
@@ -103,6 +106,7 @@ quiet_classes_map = {
 def stage_factory(classes_map, paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths, base_dir)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT

--- a/rabbitvcs/ui/switch.py
+++ b/rabbitvcs/ui/switch.py
@@ -21,15 +21,19 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
-import rabbitvcs.util.helper
+from rabbitvcs.util.strings import *
 
 from rabbitvcs import gettext
 _ = gettext.gettext
@@ -42,10 +46,10 @@ class SVNSwitch(InterfaceView):
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
 
-        self.get_widget("path").set_text(self.path)
+        self.get_widget("path").set_text(S(self.path).display())
         self.repositories = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("repositories"),
-            rabbitvcs.util.helper.get_repository_paths()
+            helper.get_repository_paths()
         )
 
         self.revision_selector = rabbitvcs.ui.widget.RevisionSelector(
@@ -56,7 +60,7 @@ class SVNSwitch(InterfaceView):
             expand=True
         )
 
-        self.repositories.set_child_text(rabbitvcs.util.helper.unquote_url(self.svn.get_repo_url(self.path)))
+        self.repositories.set_child_text(helper.unquote_url(self.svn.get_repo_url(self.path)))
 
     def on_ok_clicked(self, widget):
         url = self.repositories.get_active_text()
@@ -74,11 +78,11 @@ class SVNSwitch(InterfaceView):
 
         self.action.append(self.action.set_header, _("Switch"))
         self.action.append(self.action.set_status, _("Running Switch Command..."))
-        self.action.append(rabbitvcs.util.helper.save_repository_path, url)
+        self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.svn.switch,
             self.path,
-            rabbitvcs.util.helper.quote_url(url),
+            helper.quote_url(url),
             revision=revision
         )
         self.action.append(self.action.set_status, _("Completed Switch"))
@@ -92,6 +96,7 @@ classes_map = {
 def switch_factory(path, revision=None):
     guess = rabbitvcs.vcs.guess(path)
     return classes_map[guess["vcs"]](path, revision)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT

--- a/rabbitvcs/ui/tags.py
+++ b/rabbitvcs/ui/tags.py
@@ -22,20 +22,22 @@ from __future__ import absolute_import
 #
 
 import os
+from datetime import datetime
+import time
+
+from rabbitvcs.util import helper
 
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk, Pango
-
-from datetime import datetime
-import time
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.action import GitAction
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.dialog import DeleteConfirmation
 from rabbitvcs.ui.log import log_dialog_factory
-from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 

--- a/rabbitvcs/ui/tags.py
+++ b/rabbitvcs/ui/tags.py
@@ -36,6 +36,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.ui.dialog import DeleteConfirmation
 from rabbitvcs.ui.log import log_dialog_factory
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
 
 from rabbitvcs import gettext
@@ -111,7 +112,7 @@ class GitTagManager(InterfaceView):
         self.start_point_entry.set_size_request(300, -1)
         self.start_point_entry.set_hexpand(True)
         if self.revision_obj.value:
-            self.start_point_entry.set_text(helper.to_text(self.revision_obj))
+            self.start_point_entry.set_text(S(self.revision_obj).display())
         self.log_dialog_button = Gtk.Button()
         self.log_dialog_button.connect("clicked", self.on_log_dialog_button_clicked)
         image = Gtk.Image()
@@ -288,16 +289,16 @@ class GitTagManager(InterfaceView):
     def show_detail(self, tag_name):
         self.selected_tag = None
         for item in self.tag_list:
-            if helper.to_text(item.name) == tag_name:
+            if S(item.name) == tag_name:
                 self.selected_tag = item
                 break
 
         self.save_button.set_label(_("Save"))
         if self.selected_tag:
-            self.tag_entry.set_text(helper.to_text(self.selected_tag.name))
-            self.revision_label.set_text(helper.to_text(self.selected_tag.sha))
-            self.message_label.set_text(helper.to_text(self.selected_tag.message).rstrip("\n"))
-            self.tagger_label.set_text(helper.to_text(self.selected_tag.tagger))
+            self.tag_entry.set_text(S(self.selected_tag.name).display())
+            self.revision_label.set_text(S(self.selected_tag.sha).display())
+            self.message_label.set_text(S(self.selected_tag.message).display().rstrip("\n"))
+            self.tagger_label.set_text(S(self.selected_tag.tagger).display())
             self.date_label.set_text(helper.format_datetime(datetime.fromtimestamp(self.selected_tag.tag_time)))
 
             self.show_rows(self.view_rows)
@@ -312,7 +313,8 @@ class GitTagManager(InterfaceView):
 
     def on_log_dialog_closed(self, data):
         if data:
-            self.start_point_entry.set_text(data)
+            self.start_point_entry.set_text(S(data).display())
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT

--- a/rabbitvcs/ui/unlock.py
+++ b/rabbitvcs/ui/unlock.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import six.moves._thread
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView, InterfaceNonView
 from rabbitvcs.ui.add import Add
@@ -33,7 +37,6 @@ from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
 from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.unlock")
@@ -83,7 +86,7 @@ class SVNUnlock(Add):
             self.files_table.append([
                 True,
                 item.path,
-                rabbitvcs.util.helper.get_file_extension(item.path)
+                helper.get_file_extension(item.path)
             ])
             found += 1
 
@@ -138,6 +141,7 @@ quiet_classes_map = {
 def unlock_factory(cmap, paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])
     return cmap[guess["vcs"]](paths, base_dir)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT

--- a/rabbitvcs/ui/unlock.py
+++ b/rabbitvcs/ui/unlock.py
@@ -37,6 +37,7 @@ from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.unlock")
@@ -85,6 +86,7 @@ class SVNUnlock(Add):
 
             self.files_table.append([
                 True,
+                S(item.path),
                 item.path,
                 helper.get_file_extension(item.path)
             ])

--- a/rabbitvcs/ui/unstage.py
+++ b/rabbitvcs/ui/unstage.py
@@ -37,6 +37,7 @@ from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
+from rabbitvcs.util.strings import S
 from rabbitvcs.util.log import Log
 
 import rabbitvcs.vcs
@@ -57,6 +58,7 @@ class GitUnstage(Add):
         for item in self.items:
             self.files_table.append([
                 True,
+                S(item.path),
                 item.path,
                 helper.get_file_extension(item.path)
             ])

--- a/rabbitvcs/ui/unstage.py
+++ b/rabbitvcs/ui/unstage.py
@@ -23,9 +23,13 @@ from __future__ import absolute_import
 
 import six.moves._thread
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 from rabbitvcs.ui.add import Add
@@ -33,7 +37,6 @@ from rabbitvcs.ui.action import SVNAction
 import rabbitvcs.ui.widget
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.action
-import rabbitvcs.util.helper
 from rabbitvcs.util.log import Log
 
 import rabbitvcs.vcs
@@ -55,7 +58,7 @@ class GitUnstage(Add):
             self.files_table.append([
                 True,
                 item.path,
-                rabbitvcs.util.helper.get_file_extension(item.path)
+                helper.get_file_extension(item.path)
             ])
 
     def on_ok_clicked(self, widget):
@@ -102,6 +105,7 @@ quiet_classes_map = {
 def unstage_factory(classes_map, paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths, base_dir)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT

--- a/rabbitvcs/ui/update.py
+++ b/rabbitvcs/ui/update.py
@@ -21,9 +21,13 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceNonView, InterfaceView
 from rabbitvcs.ui.action import SVNAction, GitAction
@@ -133,6 +137,7 @@ classes_map = {
 def update_factory(paths):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main

--- a/rabbitvcs/ui/updateto.py
+++ b/rabbitvcs/ui/updateto.py
@@ -21,9 +21,13 @@ from __future__ import absolute_import
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GObject, Gdk
+sa.restore()
 
 from rabbitvcs.ui import InterfaceView
 import rabbitvcs.ui.action
@@ -160,6 +164,7 @@ def updateto_factory(vcs, path, revision=None):
         vcs = guess["vcs"]
 
     return classes_map[vcs](path, revision)
+
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -66,6 +66,7 @@ TYPE_ELLIPSIZED = 'TYPE_ELLIPSIZED'
 TYPE_GRAPH = 'TYPE_GRAPH'
 TYPE_MARKUP = 'TYPE_MARKUP'
 TYPE_HIDDEN = 'TYPE_HIDDEN'
+TYPE_HIDDEN_OBJECT = 'TYPE_HIDDEN_OBJECT'
 
 ELLIPSIZE_COLUMN_CHARS = 20
 
@@ -343,7 +344,11 @@ class TableBase:
                 col.set_attributes(cell, text=i)
             elif coltypes[i] == TYPE_HIDDEN:
                 coltypes[i] = str
-                col = Gtk.TreeViewColumn(name, cell)
+                col = Gtk.TreeViewColumn(name)
+                col.set_visible(False)
+            elif coltypes[i] == TYPE_HIDDEN_OBJECT:
+                coltypes[i] = GObject.TYPE_PYOBJECT
+                col = Gtk.TreeViewColumn(name)
                 col.set_visible(False)
             elif coltypes[i] == TYPE_ELLIPSIZED:
                 coltypes[i] = str
@@ -486,9 +491,12 @@ class TableBase:
             self._reassert_selection = True
 
     @gtk_unsafe
+    def real_append(self, row):
+        self.data.append(row)
+
     def append(self, row):
         # Python 3 needs type conversions.
-        self.data.append([S(item).display() if self.coltypes[i] in [GObject.TYPE_STRING, str] else item for i, item in enumerate(row)])
+        self.real_append([S(item).display() if self.coltypes[i] in [GObject.TYPE_STRING, str] else item for i, item in enumerate(row)])
 
     @gtk_unsafe
     def remove(self, index):

--- a/rabbitvcs/ui/wraplabel.py
+++ b/rabbitvcs/ui/wraplabel.py
@@ -28,6 +28,8 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Pango
 
+from rabbitvcs.util.strings import S
+
 class WrapLabel(Gtk.Label):
     __gtype_name__ = 'WrapLabel'
 
@@ -39,7 +41,7 @@ class WrapLabel(Gtk.Label):
         self.layout.set_wrap(Pango.WrapMode.WORD_CHAR)
 
         if str != None:
-            self.set_text(str)
+            self.set_text(S(str).display())
 
         self.set_alignment(0.0, 0.0)
 
@@ -54,7 +56,7 @@ class WrapLabel(Gtk.Label):
         self.__set_wrap_width(allocation.width)
 
     def set_text(self, str):
-        Gtk.Label.set_text(self, str)
+        Gtk.Label.set_text(self, S(str).display())
         self.__set_wrap_width(self.__wrap_width)
 
     def set_markup(self, str):

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -31,16 +31,20 @@ from six.moves import range
 # Yes, * imports are bad. You write it out then.
 from .contextmenuitems import *
 
+from rabbitvcs.util import helper
+
 import gi
 gi.require_version("Gtk", "3.0")
+sa = helper.SanitizeArgv()
 from gi.repository import Gtk as gtk
 from gi.repository import GLib as glib
+sa.restore()
 
 from rabbitvcs.vcs import create_vcs_instance, VCS_SVN, VCS_GIT, VCS_DUMMY, VCS_MERCURIAL
 from rabbitvcs.util.log import Log
 from rabbitvcs import gettext
 from rabbitvcs.util.settings import SettingsManager
-import rabbitvcs.util.helper
+import rabbitvcs.vcs
 
 log = Log("rabbitvcs.util.contextmenu")
 _ = gettext.gettext
@@ -104,7 +108,7 @@ class MenuBuilder(object):
         last_item = last_menuitem = None
 
         stack = [] # ([items], last_item, last_menuitem)
-        flat_structure = rabbitvcs.util.helper.walk_tree_depth_first(
+        flat_structure = helper.walk_tree_depth_first(
                                 structure,
                                 show_levels=True,
                                 preprocess=lambda x: x(conditions, callbacks),
@@ -339,39 +343,39 @@ class ContextMenuCallbacks:
     # End debugging callbacks
 
     def checkout(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("checkout", self.paths)
+        proc = helper.launch_ui_window("checkout", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def update(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("update", self.paths)
+        proc = helper.launch_ui_window("update", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def commit(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("commit", self.paths)
+        proc = helper.launch_ui_window("commit", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def add(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("add", self.paths)
+        proc = helper.launch_ui_window("add", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def check_for_modifications(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("checkmods", self.paths)
+        proc = helper.launch_ui_window("checkmods", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def delete(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("delete", self.paths)
+        proc = helper.launch_ui_window("delete", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def revert(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("revert", self.paths)
+        proc = helper.launch_ui_window("revert", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def diff(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("diff", self.paths)
+        proc = helper.launch_ui_window("diff", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def diff_multiple(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("diff", self.paths)
+        proc = helper.launch_ui_window("diff", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def diff_previous_revision(self, widget, data1=None, data2=None):
@@ -379,10 +383,10 @@ class ContextMenuCallbacks:
         if guess["vcs"] == rabbitvcs.vcs.VCS_SVN:
             previous_revision_number = self.vcs_client.svn().get_revision(self.paths[0]) - 1
 
-            pathrev1 = rabbitvcs.util.helper.create_path_revision_string(self.vcs_client.svn().get_repo_url(self.paths[0]), previous_revision_number)
-            pathrev2 = rabbitvcs.util.helper.create_path_revision_string(self.paths[0], "working")
+            pathrev1 = helper.create_path_revision_string(self.vcs_client.svn().get_repo_url(self.paths[0]), previous_revision_number)
+            pathrev2 = helper.create_path_revision_string(self.paths[0], "working")
 
-            proc = rabbitvcs.util.helper.launch_ui_window("diff", [
+            proc = helper.launch_ui_window("diff", [
                 "-s",
                 pathrev1,
                 pathrev2,
@@ -391,10 +395,10 @@ class ContextMenuCallbacks:
             self.caller.rescan_after_process_exit(proc, self.paths)
 
     def compare_tool(self, widget, data1=None, data2=None):
-        pathrev1 = rabbitvcs.util.helper.create_path_revision_string(self.paths[0], "base")
-        pathrev2 = rabbitvcs.util.helper.create_path_revision_string(self.paths[0], "working")
+        pathrev1 = helper.create_path_revision_string(self.paths[0], "base")
+        pathrev2 = helper.create_path_revision_string(self.paths[0], "working")
 
-        proc = rabbitvcs.util.helper.launch_ui_window("diff", [
+        proc = helper.launch_ui_window("diff", [
             "-s",
             pathrev1,
             pathrev2
@@ -402,7 +406,7 @@ class ContextMenuCallbacks:
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def compare_tool_multiple(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("diff", ["-s"] + self.paths)
+        proc = helper.launch_ui_window("diff", ["-s"] + self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def compare_tool_previous_revision(self, widget, data1=None, data2=None):
@@ -410,10 +414,10 @@ class ContextMenuCallbacks:
         if guess["vcs"] == rabbitvcs.vcs.VCS_SVN:
             previous_revision_number = self.vcs_client.svn().get_revision(self.paths[0]) - 1
 
-            pathrev1 = rabbitvcs.util.helper.create_path_revision_string(self.vcs_client.svn().get_repo_url(self.paths[0]), previous_revision_number)
-            pathrev2 = rabbitvcs.util.helper.create_path_revision_string(self.paths[0], "working")
+            pathrev1 = helper.create_path_revision_string(self.vcs_client.svn().get_repo_url(self.paths[0]), previous_revision_number)
+            pathrev2 = helper.create_path_revision_string(self.paths[0], "working")
 
-            proc = rabbitvcs.util.helper.launch_ui_window("diff", [
+            proc = helper.launch_ui_window("diff", [
                 "-s",
                 pathrev1,
                 pathrev2,
@@ -422,123 +426,123 @@ class ContextMenuCallbacks:
             self.caller.rescan_after_process_exit(proc, self.paths)
 
     def show_changes(self, widget, data1=None, data2=None):
-        pathrev1 = rabbitvcs.util.helper.create_path_revision_string(self.paths[0])
+        pathrev1 = helper.create_path_revision_string(self.paths[0])
         pathrev2 = pathrev1
         if len(self.paths) == 2:
-            pathrev2 = rabbitvcs.util.helper.create_path_revision_string(self.paths[1])
+            pathrev2 = helper.create_path_revision_string(self.paths[1])
 
-        proc = rabbitvcs.util.helper.launch_ui_window("changes", [pathrev1, pathrev2])
+        proc = helper.launch_ui_window("changes", [pathrev1, pathrev2])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def show_log(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("log", self.paths)
+        proc = helper.launch_ui_window("log", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def rename(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("rename", self.paths)
+        proc = helper.launch_ui_window("rename", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def create_patch(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("createpatch", self.paths)
+        proc = helper.launch_ui_window("createpatch", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def apply_patch(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("applypatch", self.paths)
+        proc = helper.launch_ui_window("applypatch", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def properties(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("property_editor", self.paths)
+        proc = helper.launch_ui_window("property_editor", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def about(self, widget, data1=None, data2=None):
-        rabbitvcs.util.helper.launch_ui_window("about")
+        helper.launch_ui_window("about")
 
     def settings(self, widget, data1=None, data2=None):
         base_dir = self.base_dir
         if len(self.paths) == 1 and os.path.isdir(self.paths[0]):
             base_dir = self.paths[0]
-        proc = rabbitvcs.util.helper.launch_ui_window("settings", [base_dir])
+        proc = helper.launch_ui_window("settings", [base_dir])
         self.caller.reload_settings(proc)
 
     def ignore_by_filename(self, widget, data1=None, data2=None):
         path = self.paths[0]
         base_dir = os.path.join(self.base_dir, os.path.dirname(path))
-        proc = rabbitvcs.util.helper.launch_ui_window("ignore", [base_dir, os.path.basename(path)])
+        proc = helper.launch_ui_window("ignore", [base_dir, os.path.basename(path)])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def ignore_by_file_extension(self, widget, data1=None, data2=None):
         path = self.paths[0]
-        pattern = "*%s" % rabbitvcs.util.helper.get_file_extension(path)
+        pattern = "*%s" % helper.get_file_extension(path)
         base_dir = os.path.join(self.base_dir, os.path.dirname(path))
-        proc = rabbitvcs.util.helper.launch_ui_window("ignore", [base_dir, pattern])
+        proc = helper.launch_ui_window("ignore", [base_dir, pattern])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def get_lock(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("lock", self.paths)
+        proc = helper.launch_ui_window("lock", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def branch_tag(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("branch", self.paths)
+        proc = helper.launch_ui_window("branch", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def switch(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("switch", self.paths)
+        proc = helper.launch_ui_window("switch", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def merge(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("merge", self.paths)
+        proc = helper.launch_ui_window("merge", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def _import(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("import", self.paths)
+        proc = helper.launch_ui_window("import", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def export(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("export", self.paths)
+        proc = helper.launch_ui_window("export", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def svn_export(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("export", ["--vcs=svn", self.paths[0]])
+        proc = helper.launch_ui_window("export", ["--vcs=svn", self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def git_export(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("export", ["--vcs=git", self.paths[0]])
+        proc = helper.launch_ui_window("export", ["--vcs=git", self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def update_to_revision(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("updateto", self.paths)
+        proc = helper.launch_ui_window("updateto", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def mark_resolved(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("markresolved", self.paths)
+        proc = helper.launch_ui_window("markresolved", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def annotate(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("annotate", self.paths)
+        proc = helper.launch_ui_window("annotate", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def unlock(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("unlock", self.paths)
+        proc = helper.launch_ui_window("unlock", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def create_repository(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("create", ["--vcs", "svn", self.paths[0]])
+        proc = helper.launch_ui_window("create", ["--vcs", "svn", self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def relocate(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("relocate", self.paths)
+        proc = helper.launch_ui_window("relocate", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def cleanup(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("cleanup", self.paths)
+        proc = helper.launch_ui_window("cleanup", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def restore(self, widget, data1=None, data2=None):
         guess = self.vcs_client.guess(self.paths[0])
         if guess["vcs"] == rabbitvcs.vcs.VCS_SVN:
-            proc = rabbitvcs.util.helper.launch_ui_window("update", self.paths)
+            proc = helper.launch_ui_window("update", self.paths)
         elif guess["vcs"] == rabbitvcs.vcs.VCS_GIT:
-            proc = rabbitvcs.util.helper.launch_ui_window("checkout", ["-q", "--vcs", "git"] + self.paths)
+            proc = helper.launch_ui_window("checkout", ["-q", "--vcs", "git"] + self.paths)
 
         self.caller.rescan_after_process_exit(proc, self.paths)
 
@@ -549,50 +553,50 @@ class ContextMenuCallbacks:
         pass
 
     def repo_browser(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("browser", [self.paths[0]])
+        proc = helper.launch_ui_window("browser", [self.paths[0]])
 
     def initialize_repository(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("create", ["--vcs", "git", self.paths[0]])
+        proc = helper.launch_ui_window("create", ["--vcs", "git", self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def clone(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("clone", [self.paths[0]])
+        proc = helper.launch_ui_window("clone", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def push(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("push", self.paths)
+        proc = helper.launch_ui_window("push", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def branches(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("branches", [self.paths[0]])
+        proc = helper.launch_ui_window("branches", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def tags(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("tags", [self.paths[0]])
+        proc = helper.launch_ui_window("tags", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def remotes(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("remotes", [self.paths[0]])
+        proc = helper.launch_ui_window("remotes", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def clean(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("clean", [self.paths[0]])
+        proc = helper.launch_ui_window("clean", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def reset(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("reset", [self.paths[0]])
+        proc = helper.launch_ui_window("reset", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def stage(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("stage", [self.paths[0]])
+        proc = helper.launch_ui_window("stage", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def unstage(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("unstage", [self.paths[0]])
+        proc = helper.launch_ui_window("unstage", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def edit_conflicts(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("editconflicts", [self.paths[0]])
+        proc = helper.launch_ui_window("editconflicts", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, [self.paths[0]])
 
 class ContextMenuConditions:
@@ -1006,46 +1010,46 @@ class GtkFilesContextMenuCallbacks(ContextMenuCallbacks):
 
     def _open(self, widget, data1=None, data2=None):
         for path in self.paths:
-            rabbitvcs.util.helper.open_item(path)
+            helper.open_item(path)
 
     def add(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("add", ["-q"] + self.paths)
+        proc = helper.launch_ui_window("add", ["-q"] + self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def revert(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("revert", ["-q"] + self.paths)
+        proc = helper.launch_ui_window("revert", ["-q"] + self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def mark_resolved(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("markresolved", ["-q"] + self.paths)
+        proc = helper.launch_ui_window("markresolved", ["-q"] + self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def browse_to(self, widget, data1=None, data2=None):
-        rabbitvcs.util.helper.browse_to_item(self.paths[0])
+        helper.browse_to_item(self.paths[0])
 
     def delete(self, widget, data1=None, data2=None):
         if len(self.paths) > 0:
-            proc = rabbitvcs.util.helper.launch_ui_window("delete", self.paths)
+            proc = helper.launch_ui_window("delete", self.paths)
             self.caller.rescan_after_process_exit(proc, self.paths)
 
     def update(self, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("update", self.paths)
+        proc = helper.launch_ui_window("update", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def unlock(self, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("unlock", ["-q"] + self.paths)
+        proc = helper.launch_ui_window("unlock", ["-q"] + self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def show_log(self, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("log", self.paths)
+        proc = helper.launch_ui_window("log", self.paths)
         self.caller.rescan_after_process_exit(proc, [self.paths[0]])
 
     def stage(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("stage", ["-q"] + self.paths)
+        proc = helper.launch_ui_window("stage", ["-q"] + self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def unstage(self, widget, data1=None, data2=None):
-        proc = rabbitvcs.util.helper.launch_ui_window("unstage", ["-q"] + self.paths)
+        proc = helper.launch_ui_window("unstage", ["-q"] + self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
 class GtkFilesContextMenuConditions(ContextMenuConditions):

--- a/rabbitvcs/util/contextmenuitems.py
+++ b/rabbitvcs/util/contextmenuitems.py
@@ -28,6 +28,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 import rabbitvcs.util.helper
+from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
 _ = gettext.gettext
@@ -271,8 +272,7 @@ class MenuItem(object):
         return menuitem
 
     def make_label(self):
-        label = self.label.replace('_', '__')
-
+        label = S(self.label).display().replace('_', '__')
         return label
 
 class MenuSeparator(MenuItem):

--- a/rabbitvcs/util/contextmenuitems.py
+++ b/rabbitvcs/util/contextmenuitems.py
@@ -27,7 +27,7 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
-import rabbitvcs.util.helper
+from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
@@ -762,7 +762,7 @@ def get_ignore_list_items(paths):
     # These are ignore-by-extension items
     ignorebyfileext_index = 0
     for path in paths:
-        extension = rabbitvcs.util.helper.get_file_extension(path)
+        extension = helper.get_file_extension(path)
 
         ext_str = "*%s"%extension
         if ext_str not in added_ignore_labels:

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -39,7 +39,7 @@ import time
 import shutil
 import hashlib
 import threading
-import encodings
+import codecs
 
 from gi.repository import GLib
 
@@ -1073,8 +1073,7 @@ def parse_patch_output(patch_file, base_dir, strip=0):
                                       env = env)
 
     # Intialise things...
-    out = encodings.utf_8.StreamReader(patch_proc.stdout,
-                                       errors='backslashreplace')
+    out = codecs.getreader(UTF8_ENCODING)(patch_proc.stdout, SURROGATEESCAPE)
     line = out.readline()
     patch_match = PATCHING_RE.match(line)
 

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -77,7 +77,7 @@ DT_FORMAT_THISWEEK = _("%a %I:%M%p")
 DT_FORMAT_THISYEAR = _("%b %d")
 DT_FORMAT_ALL = _("%b %d %Y")
 
-LINE_BREAK_CHAR = u'\u23CE'
+LINE_BREAK_CHAR = six.unichr(0x23CE)
 
 
 def compare_version(version1, version2, length = None):
@@ -178,13 +178,13 @@ def format_long_text(text, cols = None, line1only = False):
     line. If the param "cols" is given, the text
     beyond cols is replaced by "...".
     """
-    text = text.strip().replace(u"\n", LINE_BREAK_CHAR)
+    text = S(text.strip()).unicode().replace(six.u("\n"), LINE_BREAK_CHAR)
     if line1only:
         i = text.find(LINE_BREAK_CHAR)
         if i >= 0:
             text = text[:i]
     if cols and len(text) > cols:
-        text = u"%s..." % text[0:cols]
+        text = six.u("%s...") % text[0:cols]
 
     return text
 

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -49,6 +49,7 @@ from six.moves import range
 from six.moves.urllib.parse import urlparse, urlunparse, quote, quote_plus, unquote, unquote_plus
 
 import rabbitvcs.util.settings
+from rabbitvcs.util.strings import *
 
 from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.util.helper")
@@ -97,22 +98,7 @@ def gobject_threads_init():
     if compare_version(GObject.pygobject_version, [3, 10, 2]) < 0:
         GObject.threads_init()
 
-def to_text(s):
-    """
-    We cannot use a six.text_type() constructor alone as a bytes to text
-    converter because it uses the str() function that stores the bytes type
-    mark in the result under Python 3.
-    Instead, decode it as UTF-8.
-    """
-
-    if isinstance(s, bytearray):
-        s = bytes(s)
-    if not isinstance(s, six.text_type):
-        if isinstance(s, bytes):
-            s = s.decode("utf-8")
-    return six.text_type(s)
-
-def to_bytes(s, encoding = "utf-8"):
+def to_bytes(s, encoding=UTF8_ENCODING):
     """
     Convert string in arguments to bytes in the given encoding.
     """
@@ -151,7 +137,7 @@ def run_in_main_thread(func, *args, **kwargs):
 
 def get_tmp_path(filename):
     day = datetime.datetime.now().day
-    day_string = (str(day) + str(os.geteuid())).encode("utf-8")
+    day_string = S(str(day) + str(os.geteuid())).bytes()
     m = hashlib.md5(day_string).hexdigest()[0:10]
 
     tmpdir = "/tmp/rabbitvcs-%s" %m
@@ -202,10 +188,7 @@ def format_long_text(text, cols = None, line1only = False):
 
 def format_datetime(dt, format=None):
     if format:
-        enc = locale.getpreferredencoding(False)
-        if enc is None or len(enc) == 0:
-            enc = "UTF8"
-        return dt.strftime(format).decode(enc)
+        return S(dt.strftime(format), None).unicode()
 
     now = datetime.datetime.now()
     delta = now - dt
@@ -732,7 +715,7 @@ def save_repository_path(path):
         paths.pop()
 
     f = open(get_repository_paths_path(), "w")
-    f.write(to_text("\n".join(paths).encode("utf-8")))
+    f.write(S("\n".join(paths)))
     f.close()
 
 def launch_ui_window(filename, args=[], block=False):

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -46,7 +46,7 @@ from gi.repository import GLib
 import six
 from six.moves import filter
 from six.moves import range
-from six.moves.urllib.parse import urlparse, urlunparse, quote, quote_plus, unquote, unquote_plus
+import six.moves.urllib.parse
 
 import rabbitvcs.util.settings
 from rabbitvcs.util.decorators import structure_map
@@ -907,39 +907,70 @@ def create_path_revision_string(path, revision=None):
 def url_join(path, *args):
     return "/".join([path.rstrip("/")] + list(args))
 
+def _quote(text):
+    return six.moves.urllib.parse.quote(text,
+                                        encoding=UTF8_ENCODING,
+                                        errors=SURROGATEESCAPE)
+
+def _quote_plus(text):
+    return six.moves.urllib.parse.quote_plus(text,
+                                             encoding=UTF8_ENCODING,
+                                             errors=SURROGATEESCAPE)
+
+def _unquote(text):
+    return six.moves.urllib.parse.unquote(text,
+                                          encoding=UTF8_ENCODING,
+                                          errors=SURROGATEESCAPE)
+
+def _unquote_plus(text):
+    return six.moves.urllib.parse.unquote_plus(text,
+                                               encoding=UTF8_ENCODING,
+                                               errors=SURROGATEESCAPE)
+
+quote = _quote
+quote_plus = _quote_plus
+unquote = _unquote
+unquote_plus = _unquote_plus
+
+try:
+    unquote("")
+except TypeError:
+    quote = six.moves.urllib.parse.quote
+    quote_plus = six.moves.urllib.parse.quote_plus
+    unquote = six.moves.urllib.parse.unquote
+    unquote_plus = six.moves.urllib.parse.unquote_plus
+
 def quote_url(url_text):
-    (scheme, netloc, path, params, query, fragment) = urlparse(url_text)
+    (scheme, netloc, path, params, query, fragment) = six.moves.urllib.parse.urlparse(url_text)
     # netloc_quoted = quote(netloc)
     path_quoted = quote(path)
     params_quoted = quote(query)
     query_quoted = quote_plus(query)
     fragment_quoted = quote(fragment)
 
-    url_quoted = urlunparse(
-                            (scheme,
-                             netloc,
-                             path_quoted,
-                             params_quoted,
-                             query_quoted,
-                             fragment_quoted))
+    url_quoted = six.moves.urllib.parse.urlunparse((scheme,
+                                                    netloc,
+                                                    path_quoted,
+                                                    params_quoted,
+                                                    query_quoted,
+                                                    fragment_quoted))
 
     return url_quoted
 
 def unquote_url(url_text):
-    (scheme, netloc, path, params, query, fragment) = urlparse(url_text)
+    (scheme, netloc, path, params, query, fragment) = six.moves.urllib.parse.urlparse(url_text)
     # netloc_unquoted = unquote(netloc)
     path_unquoted = unquote(path)
     params_unquoted = unquote(query)
     query_unquoted = unquote_plus(query)
     fragment_unquoted = unquote(fragment)
 
-    url_unquoted = urlunparse(
-                            (scheme,
-                             netloc,
-                             path_unquoted,
-                             params_unquoted,
-                             query_unquoted,
-                             fragment_unquoted))
+    url_unquoted = six.moves.urllib.parse.urlunparse((scheme,
+                                                      netloc,
+                                                      path_unquoted,
+                                                      params_unquoted,
+                                                      query_unquoted,
+                                                      fragment_unquoted))
 
     return url_unquoted
 

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -910,22 +910,22 @@ def url_join(path, *args):
 def _quote(text):
     return six.moves.urllib.parse.quote(text,
                                         encoding=UTF8_ENCODING,
-                                        errors=SURROGATEESCAPE)
+                                        errors=SURROGATE_ESCAPE)
 
 def _quote_plus(text):
     return six.moves.urllib.parse.quote_plus(text,
                                              encoding=UTF8_ENCODING,
-                                             errors=SURROGATEESCAPE)
+                                             errors=SURROGATE_ESCAPE)
 
 def _unquote(text):
     return six.moves.urllib.parse.unquote(text,
                                           encoding=UTF8_ENCODING,
-                                          errors=SURROGATEESCAPE)
+                                          errors=SURROGATE_ESCAPE)
 
 def _unquote_plus(text):
     return six.moves.urllib.parse.unquote_plus(text,
                                                encoding=UTF8_ENCODING,
-                                               errors=SURROGATEESCAPE)
+                                               errors=SURROGATE_ESCAPE)
 
 quote = _quote
 quote_plus = _quote_plus
@@ -1104,7 +1104,7 @@ def parse_patch_output(patch_file, base_dir, strip=0):
                                       env = env)
 
     # Intialise things...
-    out = codecs.getreader(UTF8_ENCODING)(patch_proc.stdout, SURROGATEESCAPE)
+    out = codecs.getreader(UTF8_ENCODING)(patch_proc.stdout, SURROGATE_ESCAPE)
     line = out.readline()
     patch_match = PATCHING_RE.match(line)
 

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -49,6 +49,7 @@ from six.moves import range
 from six.moves.urllib.parse import urlparse, urlunparse, quote, quote_plus, unquote, unquote_plus
 
 import rabbitvcs.util.settings
+from rabbitvcs.util.decorators import structure_map
 from rabbitvcs.util.strings import *
 
 from rabbitvcs.util.log import Log
@@ -98,18 +99,19 @@ def gobject_threads_init():
     if compare_version(GObject.pygobject_version, [3, 10, 2]) < 0:
         GObject.threads_init()
 
+@structure_map
 def to_bytes(s, encoding=UTF8_ENCODING):
     """
-    Convert string in arguments to bytes in the given encoding.
+    Convert string (whatever type it is) to bytes in the given encoding.
     """
-    if isinstance(s, str):
-        return s.encode(encoding)
-    if isinstance(s, list):
-        return [to_bytes(x, encoding) for x in s]
-    if isinstance(s, set):
-        return {to_bytes(x, encoding) for x in s}
-    if isinstance(s, dict):
-        return {x: to_bytes(s[x], encoding) for x in s}
+    if isinstance(s, six.text_type):
+        return S(s).bytes(encoding)
+    if isinstance(s, bytearray):
+        if encoding.lower() == UTF8_ENCODING:
+            return s
+        return bytearray(S(s).bytes(encoding))
+    if isinstance(s, bytes) and encoding.lower() != UTF8_ENCODING:
+        return S(s).bytes(encoding)
     return s
 
 def run_in_main_thread(func, *args, **kwargs):

--- a/rabbitvcs/util/log.py
+++ b/rabbitvcs/util/log.py
@@ -47,6 +47,7 @@ import logging
 import logging.handlers
 
 from rabbitvcs.util.settings import SettingsManager, get_home_folder
+from rabbitvcs.util.strings import *
 
 LEVELS = {
     "debug":    logging.DEBUG,
@@ -248,7 +249,7 @@ class FileLog(BaseLog):
 
         BaseLog.__init__(self, logger, level)
         self.set_handler(
-            logging.handlers.TimedRotatingFileHandler(LOG_PATH, "D", 1, 7, "utf-8"),
+            logging.handlers.TimedRotatingFileHandler(LOG_PATH, "D", 1, 7, UTF8_ENCODING),
             FILE_FORMAT
         )
 
@@ -277,7 +278,7 @@ class DualLog(BaseLog):
 
         BaseLog.__init__(self, logger, level)
         self.set_handler(
-            logging.handlers.TimedRotatingFileHandler(LOG_PATH, "D", 1, 7, "utf-8"),
+            logging.handlers.TimedRotatingFileHandler(LOG_PATH, "D", 1, 7, UTF8_ENCODING),
             FILE_FORMAT
         )
         self.set_handler(logging.StreamHandler(), CONSOLE_FORMAT)

--- a/rabbitvcs/util/strings.py
+++ b/rabbitvcs/util/strings.py
@@ -171,7 +171,7 @@ class S(str):
         def encode(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
             encoding, errors = self._codeargs(encoding, errors)
             if encoding.lower() == UTF8_ENCODING:
-                return self
+                return str(self)
             value = super(S, self).decode(UTF8_ENCODING, SURROGATE_ESCAPE)
             return value.encode(encoding, errors)
 
@@ -182,7 +182,7 @@ class S(str):
         def display(self, encoding=None, errors='replace'):
             encoding, errors = self._codeargs(encoding, errors)
             if encoding.lower() == UTF8_ENCODING:
-                return self
+                return str(self)
             value = super(S, self).decode(UTF8_ENCODING, 'replace')
             return value.encode(encoding, errors)
 
@@ -203,7 +203,7 @@ class S(str):
             return super(S, self).encode(encoding, errors)
 
         def decode(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
-            return self;
+            return str(self);
 
         def display(self, encoding=None, errors='replace'):
             return RE_SURROGATE.sub(six.unichr(0xFFFD), self)

--- a/rabbitvcs/util/strings.py
+++ b/rabbitvcs/util/strings.py
@@ -1,0 +1,230 @@
+#
+# This is an extension to the Nautilus file manager to allow better
+# integration with the Subversion source control system.
+#
+# Copyright (C) 2006-2008 by Jason Field <jason@jasonfield.com>
+# Copyright (C) 2007-2008 by Bruce van der Kooij <brucevdkooij@gmail.com>
+# Copyright (C) 2008-2010 by Adam Plumb <adamplumb@gmail.com>
+#
+# RabbitVCS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# RabbitVCS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+
+Additional strings support.
+
+"""
+
+import sys
+import codecs
+import re
+import six
+import locale
+
+__all__ = ["S", "IDENTITY_ENCODING", "UTF8_ENCODING", "SURROGATEESCAPE"]
+
+unicode_null_string = six.u("")
+non_alpha_num_re = re.compile("[^A-Za-z0-9]+")
+SURROGATE_BASE = 0xDC00
+RE_SURROGATE = re.compile(six.u("[") + six.unichr(SURROGATE_BASE + 0x80) +
+                          six.u("-") + six.unichr(SURROGATE_BASE + 0xFF) +
+                          six.u("]"))
+RE_UTF8 = re.compile("^[Uu][Tt][Ff][ _-]?8$")
+
+#   Codec that maps ord(byte) == ord(unicode_char).
+
+IDENTITY_ENCODING = "latin-1"
+
+
+
+#   An UTF-8 codec that implements surrogates, even in Python 2.
+
+UTF8_ENCODING = "rabbitvcs-utf8"
+
+def utf8_decode(input, errors="strict"):
+    return codecs.utf_8_decode(input, errors, True)
+
+
+def utf8_encode(input, errors="strict"):
+    output = b''
+    pos = 0
+    end = len(input)
+    eh = None
+    while pos < end:
+        n = end
+        m = RE_SURROGATE.search(input, pos)
+        if m:
+            n = m.start()
+        if n > pos:
+            p, m = codecs.utf_8_encode(input[pos:n], errors)
+            output += p
+            pos = n
+        if pos < end:
+            e = UnicodeEncodeError(UTF8_ENCODING,
+                                   input, pos, pos + 1,
+                                   "surrogates not allowed")
+            if not eh:
+                eh = codecs.lookup_error(errors)
+            p, n = eh(e)
+            output += p
+            if n <= pos:
+                n = pos + 1
+            pos = n
+    return (output, len(input))
+
+class utf8_IncrementalEncoder(codecs.IncrementalEncoder):
+    def encode(self, input, final=False):
+        return utf8_encode(input, self.errors)[0]
+
+class utf8_IncrementalDecoder(codecs.BufferedIncrementalDecoder):
+    _buffer_decode = codecs.utf_8_decode
+
+class utf8_StreamWriter(codecs.StreamWriter):
+    def encode(self, input, errors='strict'):
+        return utf8_encode(input, errors)
+
+class utf8_StreamReader(codecs.StreamReader):
+    decode = codecs.utf_8_decode
+
+
+def utf8_search(encoding):
+    encoding = non_alpha_num_re.sub("-", encoding).strip("-").lower()
+    if encoding != UTF8_ENCODING:
+        return None
+    return codecs.CodecInfo(
+                   name=UTF8_ENCODING,
+                   encode=utf8_encode,
+                   decode=utf8_decode,
+                   incrementalencoder=utf8_IncrementalEncoder,
+                   incrementaldecoder=utf8_IncrementalDecoder,
+                   streamwriter=utf8_StreamWriter,
+                   streamreader=utf8_StreamReader
+    )
+
+codecs.register(utf8_search)
+
+
+#   Emulate surrogateescape codecs error handler because it is not available
+#   Before Python 3.1
+
+SURROGATEESCAPE = "rabbitvcs-surrogateescape"
+
+def rabbitvcs_surrogateescape(e):
+    if not isinstance(e, UnicodeError):
+        raise e
+    input = e.object[e.start:e.end]
+    if isinstance(e, UnicodeDecodeError):
+        output = [six.unichr(b) if b < 0x80 else                             \
+                  six.unichr(SURROGATE_BASE + b) for b in bytearray(input)]
+        return (unicode_null_string.join(output), e.end)
+    if isinstance(e, UnicodeEncodeError):
+        output = b""
+        for c in input:
+            b = ord(c) - SURROGATE_BASE
+            if not 0x80 <= b <= 0xFF:
+                raise e
+            output += six.int2byte(b)
+        return (output, e.end)
+    raise e
+
+codecs.register_error(SURROGATEESCAPE, rabbitvcs_surrogateescape)
+
+
+class S(str):
+    """
+    Stores a string in native form: unicode with surrogates in Python 3 and
+        utf-8 in Python 2.
+    Provides the following methods:
+    encode: overloaded to use UTF8_ENCODING and SURROGATEESCAPE error handler.
+    decode: overloaded to use UTF8_ENCODING and SURROGATEESCAPE error handler.
+    bytes: get the string as bytes.
+    unicode: get the string as unicode.
+    display: get the string in native form, without surrogates.
+    """
+
+    if str == bytes:
+        # Python 2.
+        def __new__(cls, value, encoding=UTF8_ENCODING, errors=SURROGATEESCAPE):
+            if isinstance(value, bytearray):
+                value = bytes(value)
+            if isinstance(value, str):
+                encoding, errors = S._codeargs(encoding, errors)
+                if encoding.lower() != UTF8_ENCODING:
+                    value = value.decode(encoding, errors)
+            if isinstance(value, six.text_type):
+                value = value.encode(UTF8_ENCODING, SURROGATEESCAPE)
+            elif not isinstance(value, str):
+                value = str(value)
+            return str.__new__(cls, value)
+
+        def encode(self, encoding=UTF8_ENCODING, errors=SURROGATEESCAPE):
+            encoding, errors = self._codeargs(encoding, errors)
+            if encoding.lower() == UTF8_ENCODING:
+                return self
+            value = super(S, self).decode(UTF8_ENCODING, SURROGATEESCAPE)
+            return value.encode(encoding, errors)
+
+        def decode(self, encoding=UTF8_ENCODING, errors=SURROGATEESCAPE):
+            encoding, errors = self._codeargs(encoding, errors)
+            return super(S, self).decode(encoding, errors)
+
+        def display(self, encoding=None, errors='replace'):
+            encoding, errors = self._codeargs(encoding, errors)
+            if encoding.lower() == UTF8_ENCODING:
+                return self
+            value = super(S, self).decode(UTF8_ENCODING, 'replace')
+            return value.encode(encoding, errors)
+
+    else:
+        # Python 3.
+        def __new__(cls, value, encoding=UTF8_ENCODING, errors=SURROGATEESCAPE):
+            if isinstance(value, bytearray):
+                value = bytes(value)
+            if isinstance(value, bytes):
+                encoding, errors = S._codeargs(encoding, errors)
+                value = value.decode(encoding, errors)
+            elif not isinstance(value, str):
+                value = str(value)
+            return str.__new__(cls, value)
+
+        def encode(self, encoding=UTF8_ENCODING, errors=SURROGATEESCAPE):
+            encoding, errors = self._codeargs(encoding, errors)
+            return super(S, self).encode(encoding, errors)
+
+        def decode(self, encoding=UTF8_ENCODING, errors=SURROGATEESCAPE):
+            return self;
+
+        def display(self, encoding=None, errors='replace'):
+            return RE_SURROGATE.sub(six.unichr(0xFFFD), self)
+
+    def bytes(self, encoding=UTF8_ENCODING, errors=SURROGATEESCAPE):
+        return self.encode(encoding, errors)
+
+    def unicode(self):
+        return self.decode()
+
+    def valid(self, encoding=None, errors=SURROGATEESCAPE):
+        return self.display(encoding, errors) == self
+
+    @staticmethod
+    def _codeargs(encoding, errors):
+        if not encoding:
+            encoding = locale.getlocale(locale.LC_MESSAGES)[1]
+            if not encoding:
+                encoding = sys.getdefaultencoding()
+        if RE_UTF8.match(encoding):
+            encoding = UTF8_ENCODING
+        if errors.lower() == 'strict':
+            errors = SURROGATEESCAPE
+        return encoding, errors

--- a/rabbitvcs/vcs/git/__init__.py
+++ b/rabbitvcs/vcs/git/__init__.py
@@ -32,6 +32,7 @@ from .gittyup.client import GittyupClient
 from .gittyup import objects
 
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 
 import rabbitvcs.vcs
 import rabbitvcs.vcs.status
@@ -59,23 +60,22 @@ class Revision:
 
         self.is_revision_object = True
 
-    def __unicode__(self):
+    def __str__(self):
         if self.value:
-            return helper.to_text(self.value)
-        else:
-            return self.kind
+            return S(self.value)
+        return  S(self.kind)
+
+    def __unicode__(self):
+        return self.__str__().unicode()
 
     def short(self):
         if self.value:
-            return helper.to_text(self.value)[0:7]
+            return S(self.value)[0:7]
         else:
             return self.kind
 
-    def __str__(self):
-        return self.__unicode__()
-
     def __repr__(self):
-        return self.__unicode__()
+        return self.__str__()
 
     def primitive(self):
         return self.value

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -30,6 +30,7 @@ from .objects import *
 from .command import GittyupCommand
 
 from rabbitvcs.util import helper
+from rabbitvcs.util.strings import *
 
 import six.moves.tkinter
 import six.moves.tkinter_messagebox
@@ -70,7 +71,7 @@ def get_tmp_path(filename):
     return os.path.join(tmpdir, filename)
 
 class GittyupClient:
-    UTF8 = "utf-8"
+    UTF8 = UTF8_ENCODING
 
     def __init__(self, path=None, create=False):
         self.callback_notify = callback_notify_null
@@ -359,8 +360,8 @@ class GittyupClient:
 
     def _get_config_user(self):
         try:
-            config_user_name = helper.to_text(self._config_get(("user", ), "name"))
-            config_user_email = helper.to_text(self._config_get(("user", ), "email"))
+            config_user_name = S(self._config_get(("user", ), "name"))
+            config_user_email = S(self._config_get(("user", ), "email"))
             if config_user_name == "" or config_user_email == "":
                 raise KeyError()
         except KeyError:
@@ -376,7 +377,10 @@ class GittyupClient:
 
     def string_unescape(self, s):
         # Portable utf-8 string unescape.
-        return b"".join([struct.pack("B", ord(x)) for x in s.encode("ascii").decode("unicode_escape")]).decode("utf-8")
+        if isinstance(s, six.text_type):
+            s = s.encode(IDENTITY_ENCODING)
+        s = S(s.decode("unicode_escape"), IDENTITY_ENCODING)
+        return S(s.bytes(IDENTITY_ENCODING))
 
     #
     # Start Public Methods
@@ -402,7 +406,7 @@ class GittyupClient:
         return self.repo.path
 
     def find_repository_path(self, path):
-        path_to_check = path
+        path_to_check = S(path)
         while path_to_check != "/" and path_to_check != "":
             if os.path.isdir(os.path.join(path_to_check, ".git")):
                 return path_to_check
@@ -412,11 +416,13 @@ class GittyupClient:
         return None
 
     def get_relative_path(self, path):
+        path = S(path)
         if path == self.repo.path:
             return "."
         return util.relativepath(self.repo.path, path)
 
     def get_absolute_path(self, path):
+        path = S(path)
         if path == ".":
             return self.repo.path
         return os.path.join(self.repo.path, path).rstrip("/")
@@ -456,7 +462,7 @@ class GittyupClient:
                 "path": absolute_path,
                 "mime_type": guess_type(absolute_path)[0]
             })
-            to_stage.append(relative_path)
+            to_stage.append(S(relative_path))
         self.repo.stage(to_stage)
 
     def stage_all(self):
@@ -493,7 +499,7 @@ class GittyupClient:
             paths = [paths]
 
         for path in paths:
-            relative_path = self.get_relative_path(path).encode("utf-8")
+            relative_path = S(self.get_relative_path(path)).bytes()
             if relative_path in index:
                 if relative_path in tree:
                     (ctime, mtime, dev, ino, mode, uid, gid, size, blob_id, flags) = index[relative_path]
@@ -862,9 +868,8 @@ class GittyupClient:
             if (branch_components != None):
                 branch = branch_components.group(1)
 
-                self.notify("[%s] -> %s" % (helper.to_text(commit_id),
-                                            helper.to_text(branch)))
-                self.notify("To branch: " + helper.to_text(branch))
+                self.notify("[%s] -> %s" % (S(commit_id), S(branch)))
+                self.notify("To branch: " + S(branch))
 
         #Print tree changes.
         #dulwich.patch.write_tree_diff(sys.stdout, self.repo.object_store, commit.tree, commit.id)
@@ -1096,7 +1101,7 @@ class GittyupClient:
 
         if remoteKey.find("://") == -1:
             # Get existing url from config, otherwise just use what was provided (the url from cloning, etc).
-            originalRemoteUrl = helper.to_text(self._config_get(remoteKey, "url"))
+            originalRemoteUrl = S(self._config_get(remoteKey, "url"))
 
         if originalRemoteUrl.find('@') == -1:
             # No username or password. Prompt for both. Create dialog.
@@ -1153,7 +1158,7 @@ class GittyupClient:
 
         if remoteKey.find("://") == -1:
             # Get existing url from config, otherwise just use what was provided (the url from cloning, etc).
-            originalRemoteUrl = helper.to_text(self._config_get(remoteKey, "url"))
+            originalRemoteUrl = S(self._config_get(remoteKey, "url"))
 
         # If the url contains a username (@) without a password (:), then prompt for a password.
         if originalRemoteUrl.find('@') > -1 and originalRemoteUrl.rfind(':') <= 5:
@@ -1366,7 +1371,7 @@ class GittyupClient:
 
         """
 
-        ref_name = helper.to_bytes("refs/tags/%s" % name)
+        ref_name = S("refs/tags/%s" % name).bytes()
         refs = self.repo.get_refs()
         if ref_name in refs:
             del self.repo.refs[ref_name]
@@ -1380,8 +1385,8 @@ class GittyupClient:
         refs = self.repo.get_refs()
 
         tags = []
-        for ref,tag_sha in list(refs.items()):
-            if helper.to_text(ref).startswith("refs/tags"):
+        for ref, tag_sha in list(refs.items()):
+            if S(ref).startswith("refs/tags"):
                 if type(self.repo[tag_sha]) == dulwich.objects.Commit:
                     tag = CommitTag(ref[10:], tag_sha, self.repo[tag_sha])
                 else:

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -450,7 +450,7 @@ class GittyupClient:
         index = self._get_index()
         to_stage = []
 
-        if type(paths) in (str, six.text_type):
+        if isinstance(paths, (str, six.text_type)):
             paths = [paths]
 
         for path in paths:
@@ -495,7 +495,7 @@ class GittyupClient:
         index = self._get_index()
         tree = self._get_tree_index()
 
-        if type(paths) in (str, six.text_type):
+        if isinstance(paths, (str, six.text_type)):
             paths = [paths]
 
         for path in paths:
@@ -885,7 +885,7 @@ class GittyupClient:
 
         """
 
-        if type(paths) in (str, six.text_type):
+        if isinstance(paths, (str, six.text_type)):
             paths = [paths]
 
         index = self._get_index()

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -1479,11 +1479,11 @@ class GittyupClient:
             ignore_file=False
             untracked_file=False
             for ignored_path in ignored_directories:
-                if ignored_path in file:
+                if S(ignored_path) in file:
                     ignore_file=True
                     break
             for untracked_path in untracked_directories:
-                if untracked_path in file:
+                if S(untracked_path) in file:
                     untracked_file=True
                     break
             if untracked_file==True:

--- a/rabbitvcs/vcs/git/gittyup/command.py
+++ b/rabbitvcs/vcs/git/gittyup/command.py
@@ -57,7 +57,7 @@ class GittyupCommand:
                                 close_fds=True,
                                 preexec_fn=os.setsid)
 
-        out = codecs.getreader(UTF8_ENCODING)(proc.stdout, SURROGATEESCAPE)
+        out = codecs.getreader(UTF8_ENCODING)(proc.stdout, SURROGATE_ESCAPE)
         stdout = []
 
         while True:

--- a/rabbitvcs/vcs/git/gittyup/command.py
+++ b/rabbitvcs/vcs/git/gittyup/command.py
@@ -6,10 +6,13 @@ from __future__ import absolute_import
 import subprocess
 import fcntl
 import select
-import encodings
+import codecs
 import os
 
 from .exceptions import GittyupCommandError
+
+from rabbitvcs.util.strings import *
+
 
 def notify_func(data):
     pass
@@ -54,8 +57,7 @@ class GittyupCommand:
                                 close_fds=True,
                                 preexec_fn=os.setsid)
 
-        out = encodings.utf_8.StreamReader(proc.stdout,
-                                           errors='backslashreplace')
+        out = codecs.getreader(UTF8_ENCODING)(proc.stdout, SURROGATEESCAPE)
         stdout = []
 
         while True:

--- a/rabbitvcs/vcs/mercurial/__init__.py
+++ b/rabbitvcs/vcs/mercurial/__init__.py
@@ -30,7 +30,7 @@ from datetime import datetime
 
 from mercurial import commands, ui, hg
 
-from rabbitvcs.util import helper
+from rabbitvcs.util.strings import S
 
 import rabbitvcs.vcs
 import rabbitvcs.vcs.status
@@ -59,23 +59,22 @@ class Revision:
 
         self.is_revision_object = True
 
-    def __unicode__(self):
+    def __str__(self):
         if self.value:
-            return helper.to_text(self.value)
-        else:
-            return self.kind
+            return S(self.value)
+        return S(self.kind)
+
+    def __unicode__(self):
+        return self.__str__().unicode()
 
     def short(self):
         if self.value:
-            return helper.to_text(self.value)[0:7]
+            return S(self.value)[0:7]
         else:
             return self.kind
 
-    def __str__(self):
-        return self.__unicode__()
-
     def __repr__(self):
-        return self.__unicode__()
+        return self.__str__()
 
     def primitive(self):
         return self.value


### PR DESCRIPTION
This is an attempt to fix most problems related to encoding and support badly encoded filenames as far as possible.
Subversion is still failing on such filenames (they're causing exceptions in pysvn itself). Git is now able to use them.
This is accomplished by the following new features:
- a new str subclass called S implementing portable unicode/utf8 conversions with surrpogates,
- Duplicating path strings in dialog tables as a displayable field and a hidden unaltered value.
- Implementing workarounds for external library problems (pysvn wants genuine string arguments, Gtk/Gdk fails on invalid characters in sys.argv).

Apart from svn, I have carefully checked possible problems but I probably have missed some of them: comments and reports are welcome!
