### PR TITLE
Fix commit message line spacing

### DIFF
--- a/rabbitvcs/ui/xml/commit.xml
+++ b/rabbitvcs/ui/xml/commit.xml
@@ -167,7 +167,7 @@
                             <property name="has_focus">True</property>
                             <property name="hexpand">True</property>
                             <property name="vexpand">True</property>
-                            <property name="pixels_below_lines">7</property>
+                            <property name="pixels_below_lines">0</property>
                             <property name="wrap_mode">word</property>
                             <property name="accepts_tab">False</property>
                           </object>


### PR DESCRIPTION
Changed the line spacing in the commit dialog message box from 7 to 0. This gets rid of the 1.5x spacing in the text box and makes it single spaced. This fixes my issue #280 