### PR TITLE
Fix revision selection not working in log dialog

### DIFF
--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -296,7 +296,7 @@ class Log(InterfaceView):
             revisions.append(int(self.revisions_table.get_row(row)[self.revision_number_column]))
 
         revisions.sort()
-        helper.encode_revisions(revisions)
+        return helper.encode_revisions(revisions)
 
     def get_selected_revision_number(self):
         if len(self.revisions_table.get_selected_rows()):


### PR DESCRIPTION
This fixes a bug when selecting a revision from the log dialog (for example, when merging a range of revisions in SVN), which did not fill the "Revision range" input with the selected revisions.