### PR TITLE
Compare revision numbers as ints not strings

### DIFF
--- a/rabbitvcs/ui/editconflicts.py
+++ b/rabbitvcs/ui/editconflicts.py
@@ -130,7 +130,7 @@ class SVNEditConflicts(InterfaceNonView):
                     log.debug("revision: %s"%revision)
                     revisionPaths.append((revision,name))
         if len(revisionPaths) == 2:
-            if revisionPaths[0][0] < revisionPaths[1][0]:
+            if int(revisionPaths[0][0]) < int(revisionPaths[1][0]):
                 ancestorPath = os.path.join(baseDir, revisionPaths[0][1])
                 theirsPath = os.path.join(baseDir, revisionPaths[1][1])
             else:


### PR DESCRIPTION
In conflict editing, revision numbers (which are taken from filenames) were compared as strings, which meant that a conflict betwen `r99` and `r100` would treat `r100` as the common ancestor and `r99` as "theirs".