### PR TITLE
Improve pylint errors - Autopep8 a number of items.

### DIFF
--- a/clients/caja/RabbitVCS.py
+++ b/clients/caja/RabbitVCS.py
@@ -39,7 +39,12 @@ from rabbitvcs.util.log import Log, reload_log_settings
 import rabbitvcs.ui.property_page
 import rabbitvcs.ui
 from rabbitvcs.util.strings import S
-from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
+from rabbitvcs.util.contextmenu import (
+    MenuBuilder,
+    MainContextMenu,
+    SEPARATOR,
+    ContextMenuConditions,
+)
 from rabbitvcs.util.decorators import timeit, disable
 from rabbitvcs.util.helper import pretty_timedelta
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
@@ -61,23 +66,25 @@ def log_all_exceptions(type, value, tb):
     import sys
     import traceback
     from rabbitvcs.util.log import Log
-    log = Log("rabbitvcs.util.extensions.Caja.RabbitVCS")
-    log.exception_info("Error caught by master exception hook!",
-                       (type, value, tb))
 
-    text = ''.join(traceback.format_exception(type, value,
-                                              tb, limit=None))
+    log = Log("rabbitvcs.util.extensions.Caja.RabbitVCS")
+    log.exception_info("Error caught by master exception hook!", (type, value, tb))
+
+    text = "".join(traceback.format_exception(type, value, tb, limit=None))
 
     try:
         import rabbitvcs.ui.dialog
+
         rabbitvcs.ui.dialog.ErrorNotification(text)
     except Exception as ex:
-        log.exception("Additional exception when attempting"
-                      " to display error dialog.")
+        log.exception(
+            "Additional exception when attempting" " to display error dialog."
+        )
         log.exception(ex)
         raise
 
     sys.__excepthook__(type, value, tb)
+
 
 # import sys
 # sys.excepthook = log_all_exceptions
@@ -95,8 +102,13 @@ _ = gettext.gettext
 settings = SettingsManager()
 
 
-class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
-                Caja.ColumnProvider, Caja.PropertyPageProvider, GObject.GObject):
+class RabbitVCS(
+    Caja.InfoProvider,
+    Caja.MenuProvider,
+    Caja.ColumnProvider,
+    Caja.PropertyPageProvider,
+    GObject.GObject,
+):
     """
     This is the main class that implements all of our awesome features.
 
@@ -184,7 +196,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
             "scalable/actions/rabbitvcs-checkmods.svg",
             "scalable/apps/rabbitvcs.svg",
             "scalable/apps/rabbitvcs-small.svg",
-            "16x16/actions/rabbitvcs-push.png"
+            "16x16/actions/rabbitvcs-push.png",
         ]
 
         rabbitvcs_icon_path = get_icon_path()
@@ -219,26 +231,26 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
                 name="RabbitVCS::status_column",
                 attribute="status",
                 label=_("RVCS Status"),
-                description=""
+                description="",
             ),
             Caja.Column(
                 name="RabbitVCS::revision_column",
                 attribute="revision",
                 label=_("RVCS Revision"),
-                description=""
+                description="",
             ),
             Caja.Column(
                 name="RabbitVCS::author_column",
                 attribute="author",
                 label=_("RVCS Author"),
-                description=""
+                description="",
             ),
             Caja.Column(
                 name="RabbitVCS::age_column",
                 attribute="age",
                 label=_("RVCS Age"),
-                description=""
-            )
+                description="",
+            ),
         )
 
     def update_file_info(self, item):
@@ -286,8 +298,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
         # TODO: how come the statuses for a few directories are incorrect
         # when we remove this line (detected as working copies, even though
         # they are not)? That shouldn't happen.
-        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(
-            path)
+        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(path)
         if not is_in_a_or_a_working_copy:
             return Caja.OperationResult.COMPLETE
 
@@ -312,12 +323,13 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
 
         # Don't bother the checker if we already have the info from a callback
         if not found:
-            status = \
-                self.status_checker.check_status(path,
-                                                 recurse=True,
-                                                 summary=True,
-                                                 callback=self.cb_status,
-                                                 invalidate=invalidate)
+            status = self.status_checker.check_status(
+                path,
+                recurse=True,
+                summary=True,
+                callback=self.cb_status,
+                invalidate=invalidate,
+            )
 
         # FIXME: when did this get disabled?
         if enable_attrs:
@@ -342,8 +354,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
         age = ""
         if status.date:
             age = pretty_timedelta(
-                datetime.datetime.fromtimestamp(status.date),
-                datetime.datetime.now()
+                datetime.datetime.fromtimestamp(status.date), datetime.datetime.now()
             )
 
         author = ""
@@ -354,7 +365,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
             "status": status.simple_content_status(),
             "revision": revision,
             "author": author,
-            "age": age
+            "age": age,
         }
 
         for key, value in list(values.items()):
@@ -408,13 +419,13 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
             conditions_dict = self.items_cache[paths_str]
             if conditions_dict and conditions_dict != "in-progress":
                 conditions = CajaMenuConditions(conditions_dict)
-                menu = CajaMainContextMenu(
-                    self, base_dir, paths, conditions).get_menu()
+                menu = CajaMainContextMenu(self, base_dir, paths, conditions).get_menu()
                 return menu
 
         if conditions_dict != "in-progress":
             self.status_checker.generate_menu_conditions_async(
-                provider, base_dir, paths, self.update_file_items)
+                provider, base_dir, paths, self.update_file_items
+            )
             self.items_cache[path] = "in-progress"
 
         return ()
@@ -446,12 +457,11 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
     def get_background_items_profile(self, window, item):
         import cProfile
 
-        path = S(gnomevfs.get_local_path_from_uri(
-            item.get_uri())).replace("/", ":")
+        path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
-            helper.get_home_folder(),
-            "checkerservice_%s.stats" % path)
+            helper.get_home_folder(), "checkerservice_%s.stats" % path
+        )
 
         prof = cProfile.Profile()
         retval = prof.runcall(self.get_background_items_real, window, item)
@@ -487,13 +497,13 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
             conditions_dict = self.items_cache[path]
             if conditions_dict and conditions_dict != "in-progress":
                 conditions = CajaMenuConditions(conditions_dict)
-                menu = CajaMainContextMenu(
-                    self, path, [path], conditions).get_menu()
+                menu = CajaMainContextMenu(self, path, [path], conditions).get_menu()
                 return menu
 
         if conditions_dict != "in-progress":
             self.status_checker.generate_menu_conditions_async(
-                provider, path, [path], self.update_background_items)
+                provider, path, [path], self.update_background_items
+            )
             self.items_cache[path] = "in-progress"
 
         return ()
@@ -537,7 +547,6 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
     #
 
     def rescan_after_process_exit(self, proc, paths):
-
         def do_check():
             # We'll check the paths first (these were the paths that
             # were originally passed along to the context menu).
@@ -548,16 +557,17 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
             #
             for path in paths:
                 # We're not interested in the result now, just the callback
-                self.status_checker.check_status(path,
-                                                 recurse=True,
-                                                 invalidate=True,
-                                                 callback=self.cb_status,
-                                                 summary=True)
+                self.status_checker.check_status(
+                    path,
+                    recurse=True,
+                    invalidate=True,
+                    callback=self.cb_status,
+                    summary=True,
+                )
 
         self.execute_after_process_exit(proc, do_check)
 
     def execute_after_process_exit(self, proc, func=None):
-
         def is_process_still_alive():
             log.debug("is_process_still_alive() for pid: %i" % proc.pid)
             # First we need to see if the commit process is still running
@@ -566,7 +576,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
 
             log.debug("%s" % retval)
 
-            still_going = (retval is None)
+            still_going = retval is None
 
             if not still_going and callable(func):
                 func()
@@ -591,8 +601,7 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
 
         def do_reload_settings():
             globals()["settings"] = SettingsManager()
-            globals()["log"] = reload_log_settings()(
-                "rabbitvcs.util.extensions.caja")
+            globals()["log"] = reload_log_settings()("rabbitvcs.util.extensions.caja")
             log.debug("Re-scanning settings")
 
         self.execute_after_process_exit(proc, do_reload_settings)
@@ -646,13 +655,15 @@ class RabbitVCS(Caja.InfoProvider, Caja.MenuProvider,
             return []
 
         label = rabbitvcs.ui.property_page.PropertyPageLabel(
-            claim_domain=False).get_widget()
+            claim_domain=False
+        ).get_widget()
         page = rabbitvcs.ui.property_page.PropertyPage(
-            paths, claim_domain=False).get_widget()
+            paths, claim_domain=False
+        ).get_widget()
 
-        ppage = Caja.PropertyPage(name='RabbitVCS::PropertyPage',
-                                  label=label,
-                                  page=page)
+        ppage = Caja.PropertyPage(
+            name="RabbitVCS::PropertyPage", label=label, page=page
+        )
 
         return [ppage]
 
@@ -669,10 +680,7 @@ class CajaContextMenu(MenuBuilder):
         identifier = item.make_magic_id(id_magic)
 
         menuitem = Caja.MenuItem(
-            name=identifier,
-            label=item.make_label(),
-            tip=item.tooltip,
-            icon=item.icon
+            name=identifier, label=item.make_label(), tip=item.tooltip, icon=item.icon
         )
 
         if type(item) is MenuSeparator:

--- a/clients/gedit/rabbitvcs-plugin.py
+++ b/clients/gedit/rabbitvcs-plugin.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is a Gedit plugin to allow for RabbitVCS integration in the Gedit
 # text editor.
@@ -28,9 +29,14 @@ from gi.repository import Gtk as gtk
 
 import rabbitvcs.util.helper
 from rabbitvcs.vcs import create_vcs_instance
-from rabbitvcs.util.contextmenu import GtkFilesContextMenuConditions, \
-    GtkFilesContextMenuCallbacks, MainContextMenu, MainContextMenuCallbacks, \
-    MenuBuilder, GtkContextMenuCaller
+from rabbitvcs.util.contextmenu import (
+    GtkFilesContextMenuConditions,
+    GtkFilesContextMenuCallbacks,
+    MainContextMenu,
+    MainContextMenuCallbacks,
+    MenuBuilder,
+    GtkContextMenuCaller,
+)
 from rabbitvcs.util.contextmenuitems import *
 
 # Menu item example, insert a new item in the Tools menu
@@ -220,7 +226,7 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Git/RabbitVCS::Apply_Patch",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Git/RabbitVCS::Create_Patch",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::Settings",
-        "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::About"
+        "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::About",
     ]
 
     _default_base_dir = os.path.expanduser("~")
@@ -251,14 +257,18 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         # Get the GtkUIManager
         manager = self._window.get_ui_manager()
 
-        self._menubar_menu = GeditMenu(self, self.vcs_client, self.base_dir, [
-                                       self._get_document_path()])
-        self._menu_action = gtk.Action(name="RabbitVCSMenu", label="RabbitVCS",
-                                       tooltip="Excellent Version Control for Linux", stock_id=None)
+        self._menubar_menu = GeditMenu(
+            self, self.vcs_client, self.base_dir, [self._get_document_path()]
+        )
+        self._menu_action = gtk.Action(
+            name="RabbitVCSMenu",
+            label="RabbitVCS",
+            tooltip="Excellent Version Control for Linux",
+            stock_id=None,
+        )
 
         self._action_group = gtk.ActionGroup("RabbitVCSActions")
-        self._action_group = self._menubar_menu.get_action_group(
-            self._action_group)
+        self._action_group = self._menubar_menu.get_action_group(self._action_group)
         self._action_group.add_action(self._menu_action)
 
         # Insert the action group
@@ -287,14 +297,12 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         self._action_group.set_sensitive(document != None)
         if document != None:
             manager = self._window.get_ui_manager()
-            manager.get_widget(
-                "/MenuBar/ExtraMenu_1/RabbitVCSMenu").set_sensitive(True)
+            manager.get_widget("/MenuBar/ExtraMenu_1/RabbitVCSMenu").set_sensitive(True)
             self._menubar_menu.set_paths([self._get_document_path()])
             self._determine_menu_sensitivity([self._get_document_path()])
 
     def connect_view(self, view, id_name):
-        handler_id = view.connect(
-            "populate-popup", self.on_view_populate_popup)
+        handler_id = view.connect("populate-popup", self.on_view_populate_popup)
         view.set_data(id_name, [handler_id])
 
     def disconnect_view(self, view, id_name):
@@ -305,8 +313,9 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         menu.append(separator)
         separator.show()
 
-        context_menu = GeditMainContextMenu(self, self.vcs_client, self.base_dir, [
-                                            self._get_document_path()]).get_menu()
+        context_menu = GeditMainContextMenu(
+            self, self.vcs_client, self.base_dir, [self._get_document_path()]
+        ).get_menu()
         for context_menu_item in context_menu:
             menu.append(context_menu_item)
 
@@ -364,19 +373,17 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
             self.id_name = "RabbitVCSContextMenuID"
 
         def do_activate(self):
-            self._instances[self.window] = RabbitVCSWindowHelper(
-                self, self.window)
+            self._instances[self.window] = RabbitVCSWindowHelper(self, self.window)
 
             handler_ids = []
-            for signal in ('tab-added', 'tab-removed'):
-                method = getattr(self, 'on_window_' + signal.replace('-', '_'))
+            for signal in ("tab-added", "tab-removed"):
+                method = getattr(self, "on_window_" + signal.replace("-", "_"))
                 handler_ids.append(self.window.connect(signal, method))
 
             self.window.set_data(self.id_name, handler_ids)
             if self.window in self._instances:
                 for view in self.window.get_views():
-                    self._instances[self.window].connect_view(
-                        view, self.id_name)
+                    self._instances[self.window].connect_view(view, self.id_name)
 
         def do_deactivate(self):
             widgets = [self.window] + self.window.get_views()
@@ -400,13 +407,13 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
 
         def on_window_tab_added(self, window, tab):
             if self.window in self._instances:
-                self._instances[self.window].connect_view(
-                    tab.get_view(), self.id_name)
+                self._instances[self.window].connect_view(tab.get_view(), self.id_name)
 
         def on_window_tab_removed(self, window, tab):
             if window in self._instances:
                 self._instances[self.window].disconnect_view(
-                    tab.get_view(), self.id_name)
+                    tab.get_view(), self.id_name
+                )
 
 
 class MenuIgnoreByFilename(MenuItem):
@@ -473,15 +480,15 @@ class GeditMenuBuilder(object):
 
             default_name = MenuItem.make_default_name(item.identifier)
             action = RabbitVCSAction(
-                item.identifier, item.label, item.tooltip, item.icon)
+                item.identifier, item.label, item.tooltip, item.icon
+            )
 
             if item.icon and hasattr(action, "set_icon_name"):
                 action.set_icon_name(item.icon)
 
             if item.callback:
                 if item.callback_args:
-                    action.connect("activate", item.callback,
-                                   item.callback_args)
+                    action.connect("activate", item.callback, item.callback_args)
                 else:
                     action.connect("activate", item.callback)
 
@@ -531,14 +538,10 @@ class GeditMenu(object):
         self.base_dir = base_dir
         self.vcs_client = vcs_client
 
-        self.conditions = GtkFilesContextMenuConditions(
-            self.vcs_client, self.paths)
+        self.conditions = GtkFilesContextMenuConditions(self.vcs_client, self.paths)
 
         self.callbacks = GtkFilesContextMenuCallbacks(
-            self.caller,
-            self.base_dir,
-            self.vcs_client,
-            self.paths
+            self.caller, self.base_dir, self.vcs_client, self.paths
         )
 
         self.structure = [
@@ -595,7 +598,7 @@ class GeditMenu(object):
             MenuSettings,
             MenuAbout,
             MenuIgnoreByFilename,
-            MenuIgnoreByFileExtension
+            MenuIgnoreByFileExtension,
         ]
 
     def set_paths(self, paths):
@@ -609,7 +612,9 @@ class GeditMenu(object):
         self.conditions.base_dir = base_dir
 
     def get_action_group(self, action_group):
-        return GeditMenuBuilder(self.structure, self.conditions, self.callbacks, action_group).action_group
+        return GeditMenuBuilder(
+            self.structure, self.conditions, self.callbacks, action_group
+        ).action_group
 
     def update_conditions(self, paths):
         self.conditions.generate_statuses(paths)
@@ -640,8 +645,9 @@ class GeditContextMenu(MenuBuilder):
 
 
 class GeditMainContextMenu(MainContextMenu):
-    def __init__(self, caller, vcs_client, base_dir, paths=[],
-                 conditions=None, callbacks=None):
+    def __init__(
+        self, caller, vcs_client, base_dir, paths=[], conditions=None, callbacks=None
+    ):
         """
         @param  caller: The calling object
         @type   caller: RabbitVCS extension
@@ -669,16 +675,12 @@ class GeditMainContextMenu(MainContextMenu):
 
         self.conditions = conditions
         if self.conditions is None:
-            self.conditions = GtkFilesContextMenuConditions(
-                self.vcs_client, paths)
+            self.conditions = GtkFilesContextMenuConditions(self.vcs_client, paths)
 
         self.callbacks = callbacks
         if self.callbacks is None:
             self.callbacks = MainContextMenuCallbacks(
-                self.caller,
-                self.base_dir,
-                self.vcs_client,
-                paths
+                self.caller, self.base_dir, self.vcs_client, paths
             )
 
         ignore_items = get_ignore_list_items(paths)
@@ -690,93 +692,105 @@ class GeditMainContextMenu(MainContextMenu):
             (MenuUpdate, None),
             (MenuCommit, None),
             (MenuPush, None),
-            (MenuRabbitVCSSvn, [
-                (MenuCheckout, None),
-                (MenuDiffMenu, [
-                    (MenuDiff, None),
-                    (MenuDiffPrevRev, None),
-                    (MenuDiffMultiple, None),
-                    (MenuCompareTool, None),
-                    (MenuCompareToolPrevRev, None),
-                    (MenuCompareToolMultiple, None),
-                    (MenuShowChanges, None),
-                ]),
-                (MenuShowLog, None),
-                (MenuRepoBrowser, None),
-                (MenuCheckForModifications, None),
-                (MenuSeparator, None),
-                (MenuAdd, None),
-                (MenuAddToIgnoreList, ignore_items),
-                (MenuSeparator, None),
-                (MenuUpdateToRevision, None),
-                (MenuRename, None),
-                (MenuDelete, None),
-                (MenuRevert, None),
-                (MenuEditConflicts, None),
-                (MenuMarkResolved, None),
-                (MenuRelocate, None),
-                (MenuGetLock, None),
-                (MenuUnlock, None),
-                (MenuCleanup, None),
-                (MenuSeparator, None),
-                (MenuExport, None),
-                (MenuCreateRepository, None),
-                (MenuImport, None),
-                (MenuSeparator, None),
-                (MenuBranchTag, None),
-                (MenuSwitch, None),
-                (MenuMerge, None),
-                (MenuSeparator, None),
-                (MenuAnnotate, None),
-                (MenuSeparator, None),
-                (MenuCreatePatch, None),
-                (MenuApplyPatch, None),
-                (MenuProperties, None),
-                (MenuSeparator, None),
-                (MenuSettings, None),
-                (MenuAbout, None)
-            ]),
-            (MenuRabbitVCSGit, [
-                (MenuClone, None),
-                (MenuInitializeRepository, None),
-                (MenuSeparator, None),
-                (MenuDiffMenu, [
-                    (MenuDiff, None),
-                    (MenuDiffPrevRev, None),
-                    (MenuDiffMultiple, None),
-                    (MenuCompareTool, None),
-                    (MenuCompareToolPrevRev, None),
-                    (MenuCompareToolMultiple, None),
-                    (MenuShowChanges, None),
-                ]),
-                (MenuShowLog, None),
-                (MenuStage, None),
-                (MenuUnstage, None),
-                (MenuAddToIgnoreList, ignore_items),
-                (MenuSeparator, None),
-                (MenuRename, None),
-                (MenuDelete, None),
-                (MenuRevert, None),
-                (MenuEditConflicts, None),
-                (MenuClean, None),
-                (MenuReset, None),
-                (MenuCheckout, None),
-                (MenuSeparator, None),
-                (MenuBranches, None),
-                (MenuTags, None),
-                (MenuRemotes, None),
-                (MenuSeparator, None),
-                (MenuExport, None),
-                (MenuMerge, None),
-                (MenuSeparator, None),
-                (MenuAnnotate, None),
-                (MenuSeparator, None),
-                (MenuCreatePatch, None),
-                (MenuApplyPatch, None),
-                (MenuSeparator, None),
-                (MenuSettings, None),
-                (MenuAbout, None)
-            ])
+            (
+                MenuRabbitVCSSvn,
+                [
+                    (MenuCheckout, None),
+                    (
+                        MenuDiffMenu,
+                        [
+                            (MenuDiff, None),
+                            (MenuDiffPrevRev, None),
+                            (MenuDiffMultiple, None),
+                            (MenuCompareTool, None),
+                            (MenuCompareToolPrevRev, None),
+                            (MenuCompareToolMultiple, None),
+                            (MenuShowChanges, None),
+                        ],
+                    ),
+                    (MenuShowLog, None),
+                    (MenuRepoBrowser, None),
+                    (MenuCheckForModifications, None),
+                    (MenuSeparator, None),
+                    (MenuAdd, None),
+                    (MenuAddToIgnoreList, ignore_items),
+                    (MenuSeparator, None),
+                    (MenuUpdateToRevision, None),
+                    (MenuRename, None),
+                    (MenuDelete, None),
+                    (MenuRevert, None),
+                    (MenuEditConflicts, None),
+                    (MenuMarkResolved, None),
+                    (MenuRelocate, None),
+                    (MenuGetLock, None),
+                    (MenuUnlock, None),
+                    (MenuCleanup, None),
+                    (MenuSeparator, None),
+                    (MenuExport, None),
+                    (MenuCreateRepository, None),
+                    (MenuImport, None),
+                    (MenuSeparator, None),
+                    (MenuBranchTag, None),
+                    (MenuSwitch, None),
+                    (MenuMerge, None),
+                    (MenuSeparator, None),
+                    (MenuAnnotate, None),
+                    (MenuSeparator, None),
+                    (MenuCreatePatch, None),
+                    (MenuApplyPatch, None),
+                    (MenuProperties, None),
+                    (MenuSeparator, None),
+                    (MenuSettings, None),
+                    (MenuAbout, None),
+                ],
+            ),
+            (
+                MenuRabbitVCSGit,
+                [
+                    (MenuClone, None),
+                    (MenuInitializeRepository, None),
+                    (MenuSeparator, None),
+                    (
+                        MenuDiffMenu,
+                        [
+                            (MenuDiff, None),
+                            (MenuDiffPrevRev, None),
+                            (MenuDiffMultiple, None),
+                            (MenuCompareTool, None),
+                            (MenuCompareToolPrevRev, None),
+                            (MenuCompareToolMultiple, None),
+                            (MenuShowChanges, None),
+                        ],
+                    ),
+                    (MenuShowLog, None),
+                    (MenuStage, None),
+                    (MenuUnstage, None),
+                    (MenuAddToIgnoreList, ignore_items),
+                    (MenuSeparator, None),
+                    (MenuRename, None),
+                    (MenuDelete, None),
+                    (MenuRevert, None),
+                    (MenuEditConflicts, None),
+                    (MenuClean, None),
+                    (MenuReset, None),
+                    (MenuCheckout, None),
+                    (MenuSeparator, None),
+                    (MenuBranches, None),
+                    (MenuTags, None),
+                    (MenuRemotes, None),
+                    (MenuSeparator, None),
+                    (MenuExport, None),
+                    (MenuMerge, None),
+                    (MenuSeparator, None),
+                    (MenuAnnotate, None),
+                    (MenuSeparator, None),
+                    (MenuCreatePatch, None),
+                    (MenuApplyPatch, None),
+                    (MenuSeparator, None),
+                    (MenuSettings, None),
+                    (MenuAbout, None),
+                ],
+            ),
         ]
 
     def get_menu(self):

--- a/clients/gedit/rabbitvcs-plugin.py
+++ b/clients/gedit/rabbitvcs-plugin.py
@@ -140,10 +140,12 @@ ui_str = """<ui>
   </menubar>
 </ui>
 """
+
+
 class RabbitVCSWindowHelper(GtkContextMenuCaller):
 
     _menu_paths = [
-#        "/MenuBar/RabbitVCSMenu",
+        #        "/MenuBar/RabbitVCSMenu",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Svn",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Svn/RabbitVCS::Commit",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Svn/RabbitVCS::Update",
@@ -249,12 +251,15 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         # Get the GtkUIManager
         manager = self._window.get_ui_manager()
 
-        self._menubar_menu = GeditMenu(self, self.vcs_client, self.base_dir, [self._get_document_path()])
-        self._menu_action = gtk.Action( name="RabbitVCSMenu", label="RabbitVCS", tooltip="Excellent Version Control for Linux", stock_id=None )
+        self._menubar_menu = GeditMenu(self, self.vcs_client, self.base_dir, [
+                                       self._get_document_path()])
+        self._menu_action = gtk.Action(name="RabbitVCSMenu", label="RabbitVCS",
+                                       tooltip="Excellent Version Control for Linux", stock_id=None)
 
         self._action_group = gtk.ActionGroup("RabbitVCSActions")
-        self._action_group = self._menubar_menu.get_action_group(self._action_group)
-        self._action_group.add_action( self._menu_action )
+        self._action_group = self._menubar_menu.get_action_group(
+            self._action_group)
+        self._action_group.add_action(self._menu_action)
 
         # Insert the action group
         manager.insert_action_group(self._action_group, 0)
@@ -282,12 +287,14 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         self._action_group.set_sensitive(document != None)
         if document != None:
             manager = self._window.get_ui_manager()
-            manager.get_widget("/MenuBar/ExtraMenu_1/RabbitVCSMenu").set_sensitive(True)
+            manager.get_widget(
+                "/MenuBar/ExtraMenu_1/RabbitVCSMenu").set_sensitive(True)
             self._menubar_menu.set_paths([self._get_document_path()])
             self._determine_menu_sensitivity([self._get_document_path()])
 
     def connect_view(self, view, id_name):
-        handler_id = view.connect("populate-popup", self.on_view_populate_popup)
+        handler_id = view.connect(
+            "populate-popup", self.on_view_populate_popup)
         view.set_data(id_name, [handler_id])
 
     def disconnect_view(self, view, id_name):
@@ -298,7 +305,8 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         menu.append(separator)
         separator.show()
 
-        context_menu = GeditMainContextMenu(self, self.vcs_client, self.base_dir, [self._get_document_path()]).get_menu()
+        context_menu = GeditMainContextMenu(self, self.vcs_client, self.base_dir, [
+                                            self._get_document_path()]).get_menu()
         for context_menu_item in context_menu:
             menu.append(context_menu_item)
 
@@ -356,7 +364,8 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
             self.id_name = "RabbitVCSContextMenuID"
 
         def do_activate(self):
-            self._instances[self.window] = RabbitVCSWindowHelper(self, self.window)
+            self._instances[self.window] = RabbitVCSWindowHelper(
+                self, self.window)
 
             handler_ids = []
             for signal in ('tab-added', 'tab-removed'):
@@ -366,7 +375,8 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
             self.window.set_data(self.id_name, handler_ids)
             if self.window in self._instances:
                 for view in self.window.get_views():
-                    self._instances[self.window].connect_view(view, self.id_name)
+                    self._instances[self.window].connect_view(
+                        view, self.id_name)
 
         def do_deactivate(self):
             widgets = [self.window] + self.window.get_views()
@@ -390,21 +400,26 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
 
         def on_window_tab_added(self, window, tab):
             if self.window in self._instances:
-                self._instances[self.window].connect_view(tab.get_view(), self.id_name)
+                self._instances[self.window].connect_view(
+                    tab.get_view(), self.id_name)
 
         def on_window_tab_removed(self, window, tab):
             if window in self._instances:
-                self._instances[self.window].disconnect_view(tab.get_view(), self.id_name)
+                self._instances[self.window].disconnect_view(
+                    tab.get_view(), self.id_name)
+
 
 class MenuIgnoreByFilename(MenuItem):
     identifier = "RabbitVCS::Ignore_By_Filename"
     label = _("Ignore by File Name")
     tooltip = _("Ignore item by filename")
 
+
 class MenuIgnoreByFileExtension(MenuItem):
     identifier = "RabbitVCS::Ignore_By_File_Extension"
     label = _("Ignore by File Extension")
     tooltip = _("Ignore item by extension")
+
 
 class GeditMenuBuilder(object):
     """
@@ -457,14 +472,16 @@ class GeditMenuBuilder(object):
             item = item_class(conditions, callbacks)
 
             default_name = MenuItem.make_default_name(item.identifier)
-            action = RabbitVCSAction(item.identifier, item.label, item.tooltip, item.icon)
+            action = RabbitVCSAction(
+                item.identifier, item.label, item.tooltip, item.icon)
 
             if item.icon and hasattr(action, "set_icon_name"):
                 action.set_icon_name(item.icon)
 
             if item.callback:
                 if item.callback_args:
-                    action.connect("activate", item.callback, item.callback_args)
+                    action.connect("activate", item.callback,
+                                   item.callback_args)
                 else:
                     action.connect("activate", item.callback)
 
@@ -485,6 +502,7 @@ class GeditMenuBuilder(object):
                 function = attr
 
         return function
+
 
 class GeditMenu(object):
     def __init__(self, caller, vcs_client, base_dir, paths):
@@ -513,7 +531,8 @@ class GeditMenu(object):
         self.base_dir = base_dir
         self.vcs_client = vcs_client
 
-        self.conditions = GtkFilesContextMenuConditions(self.vcs_client, self.paths)
+        self.conditions = GtkFilesContextMenuConditions(
+            self.vcs_client, self.paths)
 
         self.callbacks = GtkFilesContextMenuCallbacks(
             self.caller,
@@ -599,6 +618,7 @@ class GeditMenu(object):
     def update_action(self, action):
         action.set_property("visible", action.get_data("item").show())
 
+
 class GeditContextMenu(MenuBuilder):
     """
     Provides a standard gtk context menu (ie. a list of
@@ -618,9 +638,10 @@ class GeditContextMenu(MenuBuilder):
     def top_level_menu(self, items):
         return items
 
+
 class GeditMainContextMenu(MainContextMenu):
     def __init__(self, caller, vcs_client, base_dir, paths=[],
-            conditions=None, callbacks=None):
+                 conditions=None, callbacks=None):
         """
         @param  caller: The calling object
         @type   caller: RabbitVCS extension
@@ -648,7 +669,8 @@ class GeditMainContextMenu(MainContextMenu):
 
         self.conditions = conditions
         if self.conditions is None:
-            self.conditions = GtkFilesContextMenuConditions(self.vcs_client, paths)
+            self.conditions = GtkFilesContextMenuConditions(
+                self.vcs_client, paths)
 
         self.callbacks = callbacks
         if self.callbacks is None:

--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -26,11 +26,38 @@ Our module for everything related to the Nautilus extension.
 
 """
 from __future__ import with_statement
+from rabbitvcs.util.contextmenuitems import *
+import copy
+from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
+import rabbitvcs.services.service
+from rabbitvcs.util.settings import SettingsManager
+from rabbitvcs import version as EXT_VERSION
+from rabbitvcs import gettext, get_icon_path
+from rabbitvcs.util.log import Log, reload_log_settings
+import rabbitvcs.ui.property_page
+import rabbitvcs.ui
+from rabbitvcs.util.strings import S
+from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
+from rabbitvcs.util.decorators import timeit, disable
+from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import get_file_extension, get_common_directory
+from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
+import rabbitvcs.vcs.status
+from rabbitvcs.vcs import VCS
+import pysvn
+from gi.repository import Nautilus, GObject, Gtk, GdkPixbuf
+from rabbitvcs.util import helper
+import datetime
+from os.path import isdir, isfile, realpath, basename, dirname
+import os.path
+import os
 from __future__ import absolute_import
 from six.moves import range
 
+
 def log_all_exceptions(type, value, tb):
-    import sys, traceback
+    import sys
+    import traceback
     from rabbitvcs.util.log import Log
     log = Log("rabbitvcs.util.extensions.Nautilus.RabbitVCS")
     log.exception_info("Error caught by master exception hook!",
@@ -53,53 +80,21 @@ def log_all_exceptions(type, value, tb):
 # import sys
 # sys.excepthook = log_all_exceptions
 
-import copy
-
-import os
-import os.path
-from os.path import isdir, isfile, realpath, basename, dirname
-import datetime
-
-from rabbitvcs.util import helper
 
 sa = helper.SanitizeArgv()
-from gi.repository import Nautilus, GObject, Gtk, GdkPixbuf
 sa.restore()
 
-import pysvn
 
-from rabbitvcs.vcs import VCS
-import rabbitvcs.vcs.status
-
-from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
-from rabbitvcs.util.helper import get_file_extension, get_common_directory
-from rabbitvcs.util.helper import pretty_timedelta
-
-from rabbitvcs.util.decorators import timeit, disable
-
-from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
-
-from rabbitvcs.util.strings import S
-
-import rabbitvcs.ui
-import rabbitvcs.ui.property_page
-
-from rabbitvcs.util.log import Log, reload_log_settings
 log = Log("rabbitvcs.util.extensions.Nautilus.RabbitVCS")
 
-from rabbitvcs import gettext, get_icon_path
 _ = gettext.gettext
 
-from rabbitvcs import version as EXT_VERSION
 
-from rabbitvcs.util.settings import SettingsManager
 settings = SettingsManager()
 
-import rabbitvcs.services.service
-from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 
 class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
-                 Nautilus.ColumnProvider, Nautilus.PropertyPageProvider, GObject.GObject):
+                Nautilus.ColumnProvider, Nautilus.PropertyPageProvider, GObject.GObject):
     """
     This is the main class that implements all of our awesome features.
 
@@ -269,9 +264,11 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         enable_emblems = bool(int(settings.get("general", "enable_emblems")))
         enable_attrs = bool(int(settings.get("general", "enable_attributes")))
 
-        if not (enable_emblems or enable_attrs): return Nautilus.OperationResult.COMPLETE
+        if not (enable_emblems or enable_attrs):
+            return Nautilus.OperationResult.COMPLETE
 
-        if not self.valid_uri(item.get_uri()): return Nautilus.OperationResult.FAILED
+        if not self.valid_uri(item.get_uri()):
+            return Nautilus.OperationResult.FAILED
 
         path = self.get_local_path(item)
 
@@ -290,8 +287,10 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         # TODO: how come the statuses for a few directories are incorrect
         # when we remove this line (detected as working copies, even though
         # they are not)? That shouldn't happen.
-        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(path)
-        if not is_in_a_or_a_working_copy: return Nautilus.OperationResult.COMPLETE
+        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(
+            path)
+        if not is_in_a_or_a_working_copy:
+            return Nautilus.OperationResult.COMPLETE
 
         # Do our magic...
 
@@ -305,9 +304,10 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         # Need to catch exception
         for idx in range(len(self.statuses_from_callback)):
             found = (self.statuses_from_callback[idx].path) == path
-            if found: break
+            if found:
+                break
 
-        if found: # We're here because we were triggered by a callback
+        if found:  # We're here because we were triggered by a callback
             status = self.statuses_from_callback[idx]
             del self.statuses_from_callback[idx]
 
@@ -321,8 +321,10 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
                                                  invalidate=invalidate)
 
         # FIXME: when did this get disabled?
-        if enable_attrs: self.update_columns(item, path, status)
-        if enable_emblems: self.update_status(item, path, status)
+        if enable_attrs:
+            self.update_columns(item, path, status)
+        if enable_emblems:
+            self.update_status(item, path, status)
 
         return Nautilus.OperationResult.COMPLETE
 
@@ -365,7 +367,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             self.emblem_mod_cache[path] = True
             item.add_emblem(rabbitvcs.ui.STATUS_EMBLEMS[status.summary])
 
-    #~ @disable
+    # ~ @disable
     # @timeit
     # FIXME: this is a bottleneck. See generate_statuses() in
     # MainContextMenuConditions.
@@ -396,7 +398,8 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
                 paths.append(path)
                 self.VFSFile_table[path] = item
 
-        if len(paths) == 0: return []
+        if len(paths) == 0:
+            return []
 
         # log.debug("get_file_items_full() called")
 
@@ -408,31 +411,34 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             conditions_dict = self.items_cache[paths_str]
             if conditions_dict and conditions_dict != "in-progress":
                 conditions = NautilusMenuConditions(conditions_dict)
-                menu = NautilusMainContextMenu(self, base_dir, paths, conditions).get_menu()
+                menu = NautilusMainContextMenu(
+                    self, base_dir, paths, conditions).get_menu()
                 return menu
 
         if conditions_dict != "in-progress":
-            self.status_checker.generate_menu_conditions_async(provider, base_dir, paths, self.update_file_items)
+            self.status_checker.generate_menu_conditions_async(
+                provider, base_dir, paths, self.update_file_items)
             self.items_cache[path] = "in-progress"
 
         return ()
 
     def update_file_items(self, provider, base_dir, paths, conditions_dict):
         paths_str = "-".join(paths)
-        self.items_cache[paths_str] =  conditions_dict
+        self.items_cache[paths_str] = conditions_dict
         Nautilus.MenuProvider.emit_items_updated_signal(provider)
 
-    #~ @disable
+    # ~ @disable
     # This is useful for profiling. Rename it to "get_background_items" and then
     # rename the real function "get_background_items_real".
     def get_background_items_profile(self, window, item):
         import cProfile
 
-        path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
+        path = S(gnomevfs.get_local_path_from_uri(
+            item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
-                               helper.get_home_folder(),
-                               "checkerservice_%s.stats" % path)
+            helper.get_home_folder(),
+            "checkerservice_%s.stats" % path)
 
         prof = cProfile.Profile()
         retval = prof.runcall(self.get_background_items_real, window, item)
@@ -463,7 +469,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
 
         # Early exit when we are already waiting for new info on a path
         if path in self.items_cache and self.items_cache[path] == "in-progress":
-            log.error ("Sceduled task already pending, exit early, in progress")
+            log.error("Sceduled task already pending, exit early, in progress")
             return ()
 
         # Schedule menu conditions computation for directory contents.
@@ -471,18 +477,21 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             subpath = os.path.join(path, file)
             if not subpath in self.items_cache:
                 self.items_cache[subpath] = "in-progress"
-                self.status_checker.generate_menu_conditions_async(provider, path, [subpath], self.update_background_items)
+                self.status_checker.generate_menu_conditions_async(
+                    provider, path, [subpath], self.update_background_items)
 
         conditions_dict = None
         if path in self.items_cache:
             conditions_dict = self.items_cache[path]
             if conditions_dict and conditions_dict != "in-progress":
                 conditions = NautilusMenuConditions(conditions_dict)
-                menu = NautilusMainContextMenu(self, path, [path], conditions).get_menu()
+                menu = NautilusMainContextMenu(
+                    self, path, [path], conditions).get_menu()
                 return menu
 
         if conditions_dict != "in-progress":
-            self.status_checker.generate_menu_conditions_async(provider, path, [path], self.update_background_items)
+            self.status_checker.generate_menu_conditions_async(
+                provider, path, [path], self.update_background_items)
             self.items_cache[path] = "in-progress"
 
         return ()
@@ -490,7 +499,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
     def update_background_items(self, provider, base_dir, paths, conditions_dict):
         paths_str = "-".join(paths)
         conditions = NautilusMenuConditions(conditions_dict)
-        self.items_cache[paths_str] =  conditions_dict
+        self.items_cache[paths_str] = conditions_dict
         Nautilus.MenuProvider.emit_items_updated_signal(provider)
 
     #
@@ -506,7 +515,8 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
 
         """
 
-        if not uri.startswith("file://"): return False
+        if not uri.startswith("file://"):
+            return False
 
         return True
 
@@ -569,11 +579,11 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
 
         def do_reload_settings():
             globals()["settings"] = SettingsManager()
-            globals()["log"] = reload_log_settings()("rabbitvcs.util.extensions.nautilus")
+            globals()["log"] = reload_log_settings()(
+                "rabbitvcs.util.extensions.nautilus")
             log.debug("Re-scanning settings")
 
         self.execute_after_process_exit(proc, do_reload_settings)
-
 
     #
     # Callbacks
@@ -626,18 +636,20 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
                     paths.append(path)
                     self.VFSFile_table[path] = item
 
-        if len(paths) == 0: return []
+        if len(paths) == 0:
+            return []
 
-        label = rabbitvcs.ui.property_page.PropertyPageLabel(claim_domain=False).get_widget()
-        page = rabbitvcs.ui.property_page.PropertyPage(paths, claim_domain=False).get_widget()
+        label = rabbitvcs.ui.property_page.PropertyPageLabel(
+            claim_domain=False).get_widget()
+        page = rabbitvcs.ui.property_page.PropertyPage(
+            paths, claim_domain=False).get_widget()
 
         ppage = Nautilus.PropertyPage(name='RabbitVCS::PropertyPage',
-            label=label,
-            page=page)
+                                      label=label,
+                                      page=page)
 
         return [ppage]
 
-from rabbitvcs.util.contextmenuitems import *
 
 class NautilusContextMenu(MenuBuilder):
     """
@@ -658,9 +670,11 @@ class NautilusContextMenu(MenuBuilder):
     def top_level_menu(self, items):
         return items
 
+
 class NautilusMenuConditions(ContextMenuConditions):
     def __init__(self, path_dict):
         self.path_dict = path_dict
+
 
 class NautilusMainContextMenu(MainContextMenu):
     def get_menu(self):

--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -37,7 +37,12 @@ from rabbitvcs.util.log import Log, reload_log_settings
 import rabbitvcs.ui.property_page
 import rabbitvcs.ui
 from rabbitvcs.util.strings import S
-from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
+from rabbitvcs.util.contextmenu import (
+    MenuBuilder,
+    MainContextMenu,
+    SEPARATOR,
+    ContextMenuConditions,
+)
 from rabbitvcs.util.decorators import timeit, disable
 from rabbitvcs.util.helper import pretty_timedelta
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
@@ -59,23 +64,25 @@ def log_all_exceptions(type, value, tb):
     import sys
     import traceback
     from rabbitvcs.util.log import Log
-    log = Log("rabbitvcs.util.extensions.Nautilus.RabbitVCS")
-    log.exception_info("Error caught by master exception hook!",
-                       (type, value, tb))
 
-    text = ''.join(traceback.format_exception(type, value,
-                                              tb, limit=None))
+    log = Log("rabbitvcs.util.extensions.Nautilus.RabbitVCS")
+    log.exception_info("Error caught by master exception hook!", (type, value, tb))
+
+    text = "".join(traceback.format_exception(type, value, tb, limit=None))
 
     try:
         import rabbitvcs.ui.dialog
+
         rabbitvcs.ui.dialog.ErrorNotification(text)
     except Exception as ex:
-        log.exception("Additional exception when attempting"
-                      " to display error dialog.")
+        log.exception(
+            "Additional exception when attempting" " to display error dialog."
+        )
         log.exception(ex)
         raise
 
     sys.__excepthook__(type, value, tb)
+
 
 # import sys
 # sys.excepthook = log_all_exceptions
@@ -93,8 +100,13 @@ _ = gettext.gettext
 settings = SettingsManager()
 
 
-class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
-                Nautilus.ColumnProvider, Nautilus.PropertyPageProvider, GObject.GObject):
+class RabbitVCS(
+    Nautilus.InfoProvider,
+    Nautilus.MenuProvider,
+    Nautilus.ColumnProvider,
+    Nautilus.PropertyPageProvider,
+    GObject.GObject,
+):
     """
     This is the main class that implements all of our awesome features.
 
@@ -182,7 +194,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             "scalable/actions/rabbitvcs-checkmods.svg",
             "scalable/apps/rabbitvcs.svg",
             "scalable/apps/rabbitvcs-small.svg",
-            "16x16/actions/rabbitvcs-push.png"
+            "16x16/actions/rabbitvcs-push.png",
         ]
 
         rabbitvcs_icon_path = get_icon_path()
@@ -220,26 +232,26 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
                 name="RabbitVCS::status_column",
                 attribute="status",
                 label=_("RVCS Status"),
-                description=""
+                description="",
             ),
             Nautilus.Column(
                 name="RabbitVCS::revision_column",
                 attribute="revision",
                 label=_("RVCS Revision"),
-                description=""
+                description="",
             ),
             Nautilus.Column(
                 name="RabbitVCS::author_column",
                 attribute="author",
                 label=_("RVCS Author"),
-                description=""
+                description="",
             ),
             Nautilus.Column(
                 name="RabbitVCS::age_column",
                 attribute="age",
                 label=_("RVCS Age"),
-                description=""
-            )
+                description="",
+            ),
         )
 
     def update_file_info(self, item):
@@ -287,8 +299,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         # TODO: how come the statuses for a few directories are incorrect
         # when we remove this line (detected as working copies, even though
         # they are not)? That shouldn't happen.
-        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(
-            path)
+        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(path)
         if not is_in_a_or_a_working_copy:
             return Nautilus.OperationResult.COMPLETE
 
@@ -313,12 +324,13 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
 
         # Don't bother the checker if we already have the info from a callback
         if not found:
-            status = \
-                self.status_checker.check_status(path,
-                                                 recurse=True,
-                                                 summary=True,
-                                                 callback=self.cb_status,
-                                                 invalidate=invalidate)
+            status = self.status_checker.check_status(
+                path,
+                recurse=True,
+                summary=True,
+                callback=self.cb_status,
+                invalidate=invalidate,
+            )
 
         # FIXME: when did this get disabled?
         if enable_attrs:
@@ -343,8 +355,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         age = ""
         if status.date:
             age = pretty_timedelta(
-                datetime.datetime.fromtimestamp(status.date),
-                datetime.datetime.now()
+                datetime.datetime.fromtimestamp(status.date), datetime.datetime.now()
             )
 
         author = ""
@@ -355,7 +366,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             "status": status.simple_content_status(),
             "revision": revision,
             "author": author,
-            "age": age
+            "age": age,
         }
 
         for key, value in list(values.items()):
@@ -363,7 +374,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
 
     def update_status(self, item, path, status):
         if status.summary in rabbitvcs.ui.STATUS_EMBLEMS:
-            #log.error ("Add emblem"+path)
+            # log.error ("Add emblem"+path)
             self.emblem_mod_cache[path] = True
             item.add_emblem(rabbitvcs.ui.STATUS_EMBLEMS[status.summary])
 
@@ -412,12 +423,14 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             if conditions_dict and conditions_dict != "in-progress":
                 conditions = NautilusMenuConditions(conditions_dict)
                 menu = NautilusMainContextMenu(
-                    self, base_dir, paths, conditions).get_menu()
+                    self, base_dir, paths, conditions
+                ).get_menu()
                 return menu
 
         if conditions_dict != "in-progress":
             self.status_checker.generate_menu_conditions_async(
-                provider, base_dir, paths, self.update_file_items)
+                provider, base_dir, paths, self.update_file_items
+            )
             self.items_cache[path] = "in-progress"
 
         return ()
@@ -433,12 +446,11 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
     def get_background_items_profile(self, window, item):
         import cProfile
 
-        path = S(gnomevfs.get_local_path_from_uri(
-            item.get_uri())).replace("/", ":")
+        path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
-            helper.get_home_folder(),
-            "checkerservice_%s.stats" % path)
+            helper.get_home_folder(), "checkerservice_%s.stats" % path
+        )
 
         prof = cProfile.Profile()
         retval = prof.runcall(self.get_background_items_real, window, item)
@@ -478,7 +490,8 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             if not subpath in self.items_cache:
                 self.items_cache[subpath] = "in-progress"
                 self.status_checker.generate_menu_conditions_async(
-                    provider, path, [subpath], self.update_background_items)
+                    provider, path, [subpath], self.update_background_items
+                )
 
         conditions_dict = None
         if path in self.items_cache:
@@ -486,12 +499,14 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             if conditions_dict and conditions_dict != "in-progress":
                 conditions = NautilusMenuConditions(conditions_dict)
                 menu = NautilusMainContextMenu(
-                    self, path, [path], conditions).get_menu()
+                    self, path, [path], conditions
+                ).get_menu()
                 return menu
 
         if conditions_dict != "in-progress":
             self.status_checker.generate_menu_conditions_async(
-                provider, path, [path], self.update_background_items)
+                provider, path, [path], self.update_background_items
+            )
             self.items_cache[path] = "in-progress"
 
         return ()
@@ -525,7 +540,6 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
     #
 
     def rescan_after_process_exit(self, proc, paths):
-
         def do_check():
             # We'll check the paths first (these were the paths that
             # were originally passed along to the context menu).
@@ -536,16 +550,17 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             #
             for path in paths:
                 # We're not interested in the result now, just the callback
-                self.status_checker.check_status(path,
-                                                 recurse=True,
-                                                 invalidate=True,
-                                                 callback=self.cb_status,
-                                                 summary=True)
+                self.status_checker.check_status(
+                    path,
+                    recurse=True,
+                    invalidate=True,
+                    callback=self.cb_status,
+                    summary=True,
+                )
 
         self.execute_after_process_exit(proc, do_check)
 
     def execute_after_process_exit(self, proc, func=None):
-
         def is_process_still_alive():
             log.debug("is_process_still_alive() for pid: %i" % proc.pid)
             # First we need to see if the commit process is still running
@@ -554,7 +569,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
 
             log.debug("%s" % retval)
 
-            still_going = (retval is None)
+            still_going = retval is None
 
             if not still_going and callable(func):
                 func()
@@ -580,7 +595,8 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
         def do_reload_settings():
             globals()["settings"] = SettingsManager()
             globals()["log"] = reload_log_settings()(
-                "rabbitvcs.util.extensions.nautilus")
+                "rabbitvcs.util.extensions.nautilus"
+            )
             log.debug("Re-scanning settings")
 
         self.execute_after_process_exit(proc, do_reload_settings)
@@ -620,7 +636,7 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
                 if status.path in self.emblem_mod_cache:
                     del self.emblem_mod_cache[status.path]
                 else:
-                    #log.error ("Remove path from cache: "+status.path)
+                    # log.error ("Remove path from cache: "+status.path)
                     del self.items_cache[status.path]
         else:
             log.debug("Path [%s] not found in file table" % status.path)
@@ -640,13 +656,15 @@ class RabbitVCS(Nautilus.InfoProvider, Nautilus.MenuProvider,
             return []
 
         label = rabbitvcs.ui.property_page.PropertyPageLabel(
-            claim_domain=False).get_widget()
+            claim_domain=False
+        ).get_widget()
         page = rabbitvcs.ui.property_page.PropertyPage(
-            paths, claim_domain=False).get_widget()
+            paths, claim_domain=False
+        ).get_widget()
 
-        ppage = Nautilus.PropertyPage(name='RabbitVCS::PropertyPage',
-                                      label=label,
-                                      page=page)
+        ppage = Nautilus.PropertyPage(
+            name="RabbitVCS::PropertyPage", label=label, page=page
+        )
 
         return [ppage]
 

--- a/clients/nemo/RabbitVCS.py
+++ b/clients/nemo/RabbitVCS.py
@@ -38,7 +38,12 @@ from rabbitvcs import gettext, get_icon_path
 from rabbitvcs.util.log import Log, reload_log_settings
 import rabbitvcs.ui.property_page
 import rabbitvcs.ui
-from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
+from rabbitvcs.util.contextmenu import (
+    MenuBuilder,
+    MainContextMenu,
+    SEPARATOR,
+    ContextMenuConditions,
+)
 from rabbitvcs.util.decorators import timeit, disable
 from rabbitvcs.util.strings import S
 from rabbitvcs.util.helper import pretty_timedelta
@@ -60,6 +65,7 @@ from __future__ import absolute_import
 from six.moves import range
 
 import signal
+
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 
@@ -67,29 +73,31 @@ def log_all_exceptions(type, value, tb):
     import sys
     import traceback
     from rabbitvcs.util.log import Log
-    log = Log("rabbitvcs.util.extensions.Nemo.RabbitVCS")
-    log.exception_info("Error caught by master exception hook!",
-                       (type, value, tb))
 
-    text = ''.join(traceback.format_exception(type, value,
-                                              tb, limit=None))
+    log = Log("rabbitvcs.util.extensions.Nemo.RabbitVCS")
+    log.exception_info("Error caught by master exception hook!", (type, value, tb))
+
+    text = "".join(traceback.format_exception(type, value, tb, limit=None))
 
     try:
         import rabbitvcs.ui.dialog
+
         rabbitvcs.ui.dialog.ErrorNotification(text)
     except Exception as ex:
-        log.exception("Additional exception when attempting"
-                      " to display error dialog.")
+        log.exception(
+            "Additional exception when attempting" " to display error dialog."
+        )
         log.exception(ex)
         raise
 
     sys.__excepthook__(type, value, tb)
 
+
 # import sys
 # sys.excepthook = log_all_exceptions
 
 
-gi.require_version('Nemo', '3.0')
+gi.require_version("Nemo", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
 
@@ -102,8 +110,14 @@ _ = gettext.gettext
 settings = SettingsManager()
 
 
-class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
-                Nemo.ColumnProvider, Nemo.PropertyPageProvider, Nemo.NameAndDescProvider, GObject.GObject):
+class RabbitVCS(
+    Nemo.InfoProvider,
+    Nemo.MenuProvider,
+    Nemo.ColumnProvider,
+    Nemo.PropertyPageProvider,
+    Nemo.NameAndDescProvider,
+    GObject.GObject,
+):
     """
     This is the main class that implements all of our awesome features.
 
@@ -191,7 +205,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
             "scalable/actions/rabbitvcs-checkmods.svg",
             "scalable/apps/rabbitvcs.svg",
             "scalable/apps/rabbitvcs-small.svg",
-            "16x16/actions/rabbitvcs-push.png"
+            "16x16/actions/rabbitvcs-push.png",
         ]
 
         rabbitvcs_icon_path = get_icon_path()
@@ -226,26 +240,26 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
                 name="RabbitVCS::status_column",
                 attribute="status",
                 label=_("RVCS Status"),
-                description=""
+                description="",
             ),
             Nemo.Column(
                 name="RabbitVCS::revision_column",
                 attribute="revision",
                 label=_("RVCS Revision"),
-                description=""
+                description="",
             ),
             Nemo.Column(
                 name="RabbitVCS::author_column",
                 attribute="author",
                 label=_("RVCS Author"),
-                description=""
+                description="",
             ),
             Nemo.Column(
                 name="RabbitVCS::age_column",
                 attribute="age",
                 label=_("RVCS Age"),
-                description=""
-            )
+                description="",
+            ),
         )
 
     def update_file_info(self, item):
@@ -293,8 +307,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
         # TODO: how come the statuses for a few directories are incorrect
         # when we remove this line (detected as working copies, even though
         # they are not)? That shouldn't happen.
-        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(
-            path)
+        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(path)
         if not is_in_a_or_a_working_copy:
             return Nemo.OperationResult.COMPLETE
 
@@ -319,12 +332,13 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
 
         # Don't bother the checker if we already have the info from a callback
         if not found:
-            status = \
-                self.status_checker.check_status(path,
-                                                 recurse=True,
-                                                 summary=True,
-                                                 callback=self.cb_status,
-                                                 invalidate=invalidate)
+            status = self.status_checker.check_status(
+                path,
+                recurse=True,
+                summary=True,
+                callback=self.cb_status,
+                invalidate=invalidate,
+            )
 
         # FIXME: when did this get disabled?
         if enable_attrs:
@@ -349,8 +363,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
         age = ""
         if status.date:
             age = pretty_timedelta(
-                datetime.datetime.fromtimestamp(status.date),
-                datetime.datetime.now()
+                datetime.datetime.fromtimestamp(status.date), datetime.datetime.now()
             )
 
         author = ""
@@ -361,7 +374,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
             "status": status.simple_content_status(),
             "revision": revision,
             "author": author,
-            "age": age
+            "age": age,
         }
 
         for key, value in values.items():
@@ -412,15 +425,21 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
         conditions_dict = None
         if paths_str in self.items_cache:
             conditions_dict = self.items_cache[paths_str]
-            if conditions_dict and conditions_dict != "in-progress" and hasattr(window, 'base_dir'):
+            if (
+                conditions_dict
+                and conditions_dict != "in-progress"
+                and hasattr(window, "base_dir")
+            ):
                 conditions = NemoMenuConditions(conditions_dict)
                 menu = NemoMainContextMenu(
-                    self, window.base_dir, paths, conditions).get_menu()
+                    self, window.base_dir, paths, conditions
+                ).get_menu()
                 return menu
 
-        if conditions_dict != "in-progress" and hasattr(window, 'base_dir'):
+        if conditions_dict != "in-progress" and hasattr(window, "base_dir"):
             self.status_checker.generate_menu_conditions_async(
-                provider, window.base_dir, paths, self.update_file_items)
+                provider, window.base_dir, paths, self.update_file_items
+            )
             self.items_cache[path] = "in-progress"
 
         return ()
@@ -451,12 +470,11 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
     def get_background_items_profile(self, window, item):
         import cProfile
 
-        path = S(gnomevfs.get_local_path_from_uri(
-            item.get_uri())).replace("/", ":")
+        path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
-            get_home_folder(),
-            "checkerservice_%s.stats" % path)
+            get_home_folder(), "checkerservice_%s.stats" % path
+        )
 
         prof = cProfile.Profile()
         retval = prof.runcall(self.get_background_items_real, window, item)
@@ -492,15 +510,15 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
             conditions_dict = self.items_cache[path]
             if conditions_dict and conditions_dict != "in-progress":
                 conditions = NemoMenuConditions(conditions_dict)
-                menu = NemoMainContextMenu(
-                    self, path, [path], conditions).get_menu()
+                menu = NemoMainContextMenu(self, path, [path], conditions).get_menu()
                 return menu
 
         window.base_dir = path
 
         if conditions_dict != "in-progress":
             self.status_checker.generate_menu_conditions_async(
-                provider, path, [path], self.update_background_items)
+                provider, path, [path], self.update_background_items
+            )
             self.items_cache[path] = "in-progress"
 
         return ()
@@ -546,7 +564,6 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
     #
 
     def rescan_after_process_exit(self, proc, paths):
-
         def do_check():
             # We'll check the paths first (these were the paths that
             # were originally passed along to the context menu).
@@ -557,16 +574,17 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
             #
             for path in paths:
                 # We're not interested in the result now, just the callback
-                self.status_checker.check_status(path,
-                                                 recurse=True,
-                                                 invalidate=True,
-                                                 callback=self.cb_status,
-                                                 summary=True)
+                self.status_checker.check_status(
+                    path,
+                    recurse=True,
+                    invalidate=True,
+                    callback=self.cb_status,
+                    summary=True,
+                )
 
         self.execute_after_process_exit(proc, do_check)
 
     def execute_after_process_exit(self, proc, func=None):
-
         def is_process_still_alive():
             log.debug("is_process_still_alive() for pid: %i" % proc.pid)
             # First we need to see if the commit process is still running
@@ -575,7 +593,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
 
             log.debug("%s" % retval)
 
-            still_going = (retval is None)
+            still_going = retval is None
 
             if not still_going and callable(func):
                 func()
@@ -600,8 +618,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
 
         def do_reload_settings():
             globals()["settings"] = SettingsManager()
-            globals()["log"] = reload_log_settings()(
-                "rabbitvcs.util.extensions.nemo")
+            globals()["log"] = reload_log_settings()("rabbitvcs.util.extensions.nemo")
             log.debug("Re-scanning settings")
 
         self.execute_after_process_exit(proc, do_reload_settings)
@@ -655,13 +672,15 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
             return []
 
         label = rabbitvcs.ui.property_page.PropertyPageLabel(
-            claim_domain=False).get_widget("rabbitvcs-title")
+            claim_domain=False
+        ).get_widget("rabbitvcs-title")
         page = rabbitvcs.ui.property_page.PropertyPage(
-            paths, claim_domain=False).get_widget()
+            paths, claim_domain=False
+        ).get_widget()
 
-        ppage = Nemo.PropertyPage(name='RabbitVCS::PropertyPage',
-                                  label=label,
-                                  page=page)
+        ppage = Nemo.PropertyPage(
+            name="RabbitVCS::PropertyPage", label=label, page=page
+        )
 
         return [ppage]
 
@@ -679,10 +698,9 @@ class NemoContextMenu(MenuBuilder):
 
     def make_menu_item(self, item, id_magic):
         identifier = item.make_magic_id(id_magic)
-        menuitem = Nemo.MenuItem(name=identifier,
-                                 label=item.make_label(),
-                                 tip=item.tooltip,
-                                 icon=item.icon)
+        menuitem = Nemo.MenuItem(
+            name=identifier, label=item.make_label(), tip=item.tooltip, icon=item.icon
+        )
 
         return menuitem
 

--- a/clients/nemo/RabbitVCS.py
+++ b/clients/nemo/RabbitVCS.py
@@ -28,6 +28,33 @@ Our module for everything related to the Nemo extension.
 
 
 from __future__ import with_statement
+from rabbitvcs.util.contextmenuitems import *
+import copy
+from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
+import rabbitvcs.services.service
+from rabbitvcs.util.settings import SettingsManager
+from rabbitvcs import version as EXT_VERSION
+from rabbitvcs import gettext, get_icon_path
+from rabbitvcs.util.log import Log, reload_log_settings
+import rabbitvcs.ui.property_page
+import rabbitvcs.ui
+from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
+from rabbitvcs.util.decorators import timeit, disable
+from rabbitvcs.util.strings import S
+from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import get_home_folder
+from rabbitvcs.util.helper import get_file_extension, get_common_directory
+from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
+import rabbitvcs.vcs.status
+from rabbitvcs.vcs import VCS
+import pysvn
+from gi.repository import Nemo, GObject, Gtk, GdkPixbuf
+import gi
+from rabbitvcs.util import helper
+import datetime
+from os.path import isdir, isfile, realpath, basename
+import os.path
+import os
 
 from __future__ import absolute_import
 from six.moves import range
@@ -35,8 +62,10 @@ from six.moves import range
 import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+
 def log_all_exceptions(type, value, tb):
-    import sys, traceback
+    import sys
+    import traceback
     from rabbitvcs.util.log import Log
     log = Log("rabbitvcs.util.extensions.Nemo.RabbitVCS")
     log.exception_info("Error caught by master exception hook!",
@@ -59,53 +88,19 @@ def log_all_exceptions(type, value, tb):
 # import sys
 # sys.excepthook = log_all_exceptions
 
-import copy
 
-import os
-import os.path
-from os.path import isdir, isfile, realpath, basename
-import datetime
-
-from rabbitvcs.util import helper
-
-import gi
 gi.require_version('Nemo', '3.0')
 sa = helper.SanitizeArgv()
-from gi.repository import Nemo, GObject, Gtk, GdkPixbuf
 sa.restore()
 
-import pysvn
 
-from rabbitvcs.vcs import VCS
-import rabbitvcs.vcs.status
-
-from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
-from rabbitvcs.util.helper import get_file_extension, get_common_directory
-from rabbitvcs.util.helper import get_home_folder
-from rabbitvcs.util.helper import pretty_timedelta
-
-from rabbitvcs.util.strings import S
-
-from rabbitvcs.util.decorators import timeit, disable
-
-from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR, ContextMenuConditions
-
-import rabbitvcs.ui
-import rabbitvcs.ui.property_page
-
-from rabbitvcs.util.log import Log, reload_log_settings
 log = Log("rabbitvcs.util.extensions.Nemo.RabbitVCS")
 
-from rabbitvcs import gettext, get_icon_path
 _ = gettext.gettext
 
-from rabbitvcs import version as EXT_VERSION
 
-from rabbitvcs.util.settings import SettingsManager
 settings = SettingsManager()
 
-import rabbitvcs.services.service
-from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 
 class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
                 Nemo.ColumnProvider, Nemo.PropertyPageProvider, Nemo.NameAndDescProvider, GObject.GObject):
@@ -275,9 +270,11 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
         enable_emblems = bool(int(settings.get("general", "enable_emblems")))
         enable_attrs = bool(int(settings.get("general", "enable_attributes")))
 
-        if not (enable_emblems or enable_attrs): return Nemo.OperationResult.COMPLETE
+        if not (enable_emblems or enable_attrs):
+            return Nemo.OperationResult.COMPLETE
 
-        if not self.valid_uri(item.get_uri()): return Nemo.OperationResult.FAILED
+        if not self.valid_uri(item.get_uri()):
+            return Nemo.OperationResult.FAILED
 
         path = self.get_local_path(item)
 
@@ -296,8 +293,10 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
         # TODO: how come the statuses for a few directories are incorrect
         # when we remove this line (detected as working copies, even though
         # they are not)? That shouldn't happen.
-        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(path)
-        if not is_in_a_or_a_working_copy: return Nemo.OperationResult.COMPLETE
+        is_in_a_or_a_working_copy = self.vcs_client.is_in_a_or_a_working_copy(
+            path)
+        if not is_in_a_or_a_working_copy:
+            return Nemo.OperationResult.COMPLETE
 
         # Do our magic...
 
@@ -311,9 +310,10 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
         # Need to catch exception
         for idx in range(len(self.statuses_from_callback)):
             found = (self.statuses_from_callback[idx].path) == path
-            if found: break
+            if found:
+                break
 
-        if found: # We're here because we were triggered by a callback
+        if found:  # We're here because we were triggered by a callback
             status = self.statuses_from_callback[idx]
             del self.statuses_from_callback[idx]
 
@@ -327,8 +327,10 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
                                                  invalidate=invalidate)
 
         # FIXME: when did this get disabled?
-        if enable_attrs: self.update_columns(item, path, status)
-        if enable_emblems: self.update_status(item, path, status)
+        if enable_attrs:
+            self.update_columns(item, path, status)
+        if enable_emblems:
+            self.update_status(item, path, status)
 
         return Nemo.OperationResult.COMPLETE
 
@@ -369,7 +371,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
         if status.summary in rabbitvcs.ui.STATUS_EMBLEMS:
             item.add_emblem(rabbitvcs.ui.STATUS_EMBLEMS[status.summary])
 
-    #~ @disable
+    # ~ @disable
     # @timeit
     # FIXME: this is a bottleneck. See generate_statuses() in
     # MainContextMenuConditions.
@@ -400,7 +402,8 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
                 paths.append(path)
                 self.VFSFile_table[path] = item
 
-        if len(paths) == 0: return []
+        if len(paths) == 0:
+            return []
 
         # log.debug("get_file_items_full() called")
 
@@ -411,11 +414,13 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
             conditions_dict = self.items_cache[paths_str]
             if conditions_dict and conditions_dict != "in-progress" and hasattr(window, 'base_dir'):
                 conditions = NemoMenuConditions(conditions_dict)
-                menu = NemoMainContextMenu(self, window.base_dir, paths, conditions).get_menu()
+                menu = NemoMainContextMenu(
+                    self, window.base_dir, paths, conditions).get_menu()
                 return menu
 
         if conditions_dict != "in-progress" and hasattr(window, 'base_dir'):
-            self.status_checker.generate_menu_conditions_async(provider, window.base_dir, paths, self.update_file_items)
+            self.status_checker.generate_menu_conditions_async(
+                provider, window.base_dir, paths, self.update_file_items)
             self.items_cache[path] = "in-progress"
 
         return ()
@@ -428,7 +433,8 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
                 paths.append(path)
                 self.VFSFile_table[path] = item
 
-        if len(paths) == 0: return []
+        if len(paths) == 0:
+            return []
 
         # log.debug("get_file_items() called")
 
@@ -436,16 +442,17 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
 
     def update_file_items(self, provider, base_dir, paths, conditions_dict):
         paths_str = "-".join(paths)
-        self.items_cache[paths_str] =  conditions_dict
+        self.items_cache[paths_str] = conditions_dict
         Nemo.MenuProvider.emit_items_updated_signal(provider)
 
-    #~ @disable
+    # ~ @disable
     # This is useful for profiling. Rename it to "get_background_items" and then
     # rename the real function "get_background_items_real".
     def get_background_items_profile(self, window, item):
         import cProfile
 
-        path = S(gnomevfs.get_local_path_from_uri(item.get_uri())).replace("/", ":")
+        path = S(gnomevfs.get_local_path_from_uri(
+            item.get_uri())).replace("/", ":")
 
         profile_data_file = os.path.join(
             get_home_folder(),
@@ -485,19 +492,22 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
             conditions_dict = self.items_cache[path]
             if conditions_dict and conditions_dict != "in-progress":
                 conditions = NemoMenuConditions(conditions_dict)
-                menu = NemoMainContextMenu(self, path, [path], conditions).get_menu()
+                menu = NemoMainContextMenu(
+                    self, path, [path], conditions).get_menu()
                 return menu
 
         window.base_dir = path
 
         if conditions_dict != "in-progress":
-            self.status_checker.generate_menu_conditions_async(provider, path, [path], self.update_background_items)
+            self.status_checker.generate_menu_conditions_async(
+                provider, path, [path], self.update_background_items)
             self.items_cache[path] = "in-progress"
 
         return ()
 
     def get_background_items(self, window, item):
-        if not self.valid_uri(item.get_uri()): return
+        if not self.valid_uri(item.get_uri()):
+            return
         path = self.get_local_path(item)
         self.VFSFile_table[path] = item
 
@@ -510,7 +520,7 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
     def update_background_items(self, provider, base_dir, paths, conditions_dict):
         paths_str = "-".join(paths)
         conditions = NemoMenuConditions(conditions_dict)
-        self.items_cache[paths_str] =  conditions_dict
+        self.items_cache[paths_str] = conditions_dict
         Nemo.MenuProvider.emit_items_updated_signal(provider)
 
     #
@@ -526,7 +536,8 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
 
         """
 
-        if not uri.startswith("file://"): return False
+        if not uri.startswith("file://"):
+            return False
 
         return True
 
@@ -589,11 +600,11 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
 
         def do_reload_settings():
             globals()["settings"] = SettingsManager()
-            globals()["log"] = reload_log_settings()("rabbitvcs.util.extensions.nemo")
+            globals()["log"] = reload_log_settings()(
+                "rabbitvcs.util.extensions.nemo")
             log.debug("Re-scanning settings")
 
         self.execute_after_process_exit(proc, do_reload_settings)
-
 
     #
     # Callbacks
@@ -640,10 +651,13 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
                     paths.append(path)
                     self.VFSFile_table[path] = item
 
-        if len(paths) == 0: return []
+        if len(paths) == 0:
+            return []
 
-        label = rabbitvcs.ui.property_page.PropertyPageLabel(claim_domain=False).get_widget("rabbitvcs-title")
-        page = rabbitvcs.ui.property_page.PropertyPage(paths, claim_domain=False).get_widget()
+        label = rabbitvcs.ui.property_page.PropertyPageLabel(
+            claim_domain=False).get_widget("rabbitvcs-title")
+        page = rabbitvcs.ui.property_page.PropertyPage(
+            paths, claim_domain=False).get_widget()
 
         ppage = Nemo.PropertyPage(name='RabbitVCS::PropertyPage',
                                   label=label,
@@ -651,11 +665,9 @@ class RabbitVCS(Nemo.InfoProvider, Nemo.MenuProvider,
 
         return [ppage]
 
-
     def get_name_and_desc(self):
         return [("Nemo RabbitVCS:::Access RabbitVCS from the context menu")]
 
-from rabbitvcs.util.contextmenuitems import *
 
 class NemoContextMenu(MenuBuilder):
     """
@@ -682,9 +694,11 @@ class NemoContextMenu(MenuBuilder):
     def top_level_menu(self, items):
         return items
 
+
 class NemoMenuConditions(ContextMenuConditions):
     def __init__(self, path_dict):
         self.path_dict = path_dict
+
 
 class NemoMainContextMenu(MainContextMenu):
     def get_menu(self):

--- a/clients/pluma/rabbitvcs-plugin.py
+++ b/clients/pluma/rabbitvcs-plugin.py
@@ -1,11 +1,17 @@
 from __future__ import absolute_import
 from rabbitvcs.util.contextmenuitems import *
-from rabbitvcs.util.contextmenu import GtkFilesContextMenuConditions, \
-    GtkFilesContextMenuCallbacks, MainContextMenu, MainContextMenuCallbacks, \
-    MenuBuilder, GtkContextMenuCaller
+from rabbitvcs.util.contextmenu import (
+    GtkFilesContextMenuConditions,
+    GtkFilesContextMenuCallbacks,
+    MainContextMenu,
+    MainContextMenuCallbacks,
+    MenuBuilder,
+    GtkContextMenuCaller,
+)
 from rabbitvcs.vcs import create_vcs_instance
 from gi.repository import Pluma, GObject, Peas
 from gi.repository import Gtk
+
 #
 # This is a Pluma plugin to allow for RabbitVCS integration in the Pluma
 # text editor.
@@ -225,7 +231,7 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Git/RabbitVCS::Apply_Patch",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Git/RabbitVCS::Create_Patch",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::Settings",
-        "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::About"
+        "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::About",
     ]
 
     _default_base_dir = os.path.expanduser("~")
@@ -256,16 +262,18 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         # Get the GtkUIManager
         manager = self._window.get_ui_manager()
 
-        self._menubar_menu = PlumaMenu(self, self.vcs_client, self.base_dir, [
-                                       self._get_document_path()])
-        self._menu_action = Gtk.Action(name="RabbitVCSMenu",
-                                       label="RabbitVCS",
-                                       tooltip=_("Excellent Version Control"),
-                                       stock_id=None)
+        self._menubar_menu = PlumaMenu(
+            self, self.vcs_client, self.base_dir, [self._get_document_path()]
+        )
+        self._menu_action = Gtk.Action(
+            name="RabbitVCSMenu",
+            label="RabbitVCS",
+            tooltip=_("Excellent Version Control"),
+            stock_id=None,
+        )
 
         self._action_group = Gtk.ActionGroup("RabbitVCSActions")
-        self._action_group = self._menubar_menu.get_action_group(
-            self._action_group)
+        self._action_group = self._menubar_menu.get_action_group(self._action_group)
         self._action_group.add_action(self._menu_action)
 
         # Insert the action group
@@ -294,14 +302,12 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         self._action_group.set_sensitive(document != None)
         if document != None:
             manager = self._window.get_ui_manager()
-            manager.get_widget(
-                "/MenuBar/ExtraMenu_1/RabbitVCSMenu").set_sensitive(True)
+            manager.get_widget("/MenuBar/ExtraMenu_1/RabbitVCSMenu").set_sensitive(True)
             self._menubar_menu.set_paths([self._get_document_path()])
             self._determine_menu_sensitivity([self._get_document_path()])
 
     def connect_view(self, view, id_name):
-        handler_id = view.connect(
-            "populate-popup", self.on_view_populate_popup)
+        handler_id = view.connect("populate-popup", self.on_view_populate_popup)
         setattr(view, id_name, [handler_id])
 
     def disconnect_view(self, view, id_name):
@@ -312,8 +318,9 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         menu.append(separator)
         separator.show()
 
-        context_menu = PlumaMainContextMenu(self, self.vcs_client, self.base_dir, [
-                                            self._get_document_path()]).get_menu()
+        context_menu = PlumaMainContextMenu(
+            self, self.vcs_client, self.base_dir, [self._get_document_path()]
+        ).get_menu()
         for context_menu_item in context_menu:
             menu.append(context_menu_item)
 
@@ -375,8 +382,8 @@ class RabbitVCSPlumaPlugin(GObject.Object, Peas.Activatable):
         self._instances[self.object] = RabbitVCSWindowHelper(self, self.object)
 
         handler_ids = []
-        for signal in ('tab-added', 'tab-removed'):
-            method = getattr(self, 'on_window_' + signal.replace('-', '_'))
+        for signal in ("tab-added", "tab-removed"):
+            method = getattr(self, "on_window_" + signal.replace("-", "_"))
             handler_ids.append(self.object.connect(signal, method))
 
         setattr(self.object, self.id_name, handler_ids)
@@ -410,8 +417,7 @@ class RabbitVCSPlumaPlugin(GObject.Object, Peas.Activatable):
 
     def on_window_tab_removed(self, window, tab):
         if window in self._instances:
-            self._instances[window].disconnect_view(
-                tab.get_view(), self.id_name)
+            self._instances[window].disconnect_view(tab.get_view(), self.id_name)
 
 
 class MenuIgnoreByFilename(MenuItem):
@@ -477,16 +483,14 @@ class PlumaMenuBuilder(object):
             item = item_class(conditions, callbacks)
 
             default_name = MenuItem.make_default_name(item.identifier)
-            action = Gtk.Action(item.identifier, item.label,
-                                item.tooltip, item.icon)
+            action = Gtk.Action(item.identifier, item.label, item.tooltip, item.icon)
 
             if item.icon and hasattr(action, "set_icon_name"):
                 action.set_icon_name(item.icon)
 
             if item.callback:
                 if item.callback_args:
-                    action.connect("activate", item.callback,
-                                   item.callback_args)
+                    action.connect("activate", item.callback, item.callback_args)
                 else:
                     action.connect("activate", item.callback)
 
@@ -534,14 +538,10 @@ class PlumaMenu(object):
         self.base_dir = base_dir
         self.vcs_client = vcs_client
 
-        self.conditions = GtkFilesContextMenuConditions(
-            self.vcs_client, self.paths)
+        self.conditions = GtkFilesContextMenuConditions(self.vcs_client, self.paths)
 
         self.callbacks = GtkFilesContextMenuCallbacks(
-            self.caller,
-            self.base_dir,
-            self.vcs_client,
-            self.paths
+            self.caller, self.base_dir, self.vcs_client, self.paths
         )
 
         self.structure = [
@@ -598,7 +598,7 @@ class PlumaMenu(object):
             MenuSettings,
             MenuAbout,
             MenuIgnoreByFilename,
-            MenuIgnoreByFileExtension
+            MenuIgnoreByFileExtension,
         ]
 
     def set_paths(self, paths):
@@ -612,7 +612,9 @@ class PlumaMenu(object):
         self.conditions.base_dir = base_dir
 
     def get_action_group(self, action_group):
-        return PlumaMenuBuilder(self.structure, self.conditions, self.callbacks, action_group).action_group
+        return PlumaMenuBuilder(
+            self.structure, self.conditions, self.callbacks, action_group
+        ).action_group
 
     def update_conditions(self, paths):
         self.conditions.generate_statuses(paths)
@@ -642,8 +644,9 @@ class PlumaContextMenu(MenuBuilder):
 
 
 class PlumaMainContextMenu(MainContextMenu):
-    def __init__(self, caller, vcs_client, base_dir, paths=[],
-                 conditions=None, callbacks=None):
+    def __init__(
+        self, caller, vcs_client, base_dir, paths=[], conditions=None, callbacks=None
+    ):
         """
         @param  caller: The calling object
         @type   caller: RabbitVCS extension
@@ -671,16 +674,12 @@ class PlumaMainContextMenu(MainContextMenu):
 
         self.conditions = conditions
         if self.conditions is None:
-            self.conditions = GtkFilesContextMenuConditions(
-                self.vcs_client, paths)
+            self.conditions = GtkFilesContextMenuConditions(self.vcs_client, paths)
 
         self.callbacks = callbacks
         if self.callbacks is None:
             self.callbacks = MainContextMenuCallbacks(
-                self.caller,
-                self.base_dir,
-                self.vcs_client,
-                paths
+                self.caller, self.base_dir, self.vcs_client, paths
             )
 
         ignore_items = get_ignore_list_items(paths)
@@ -692,93 +691,105 @@ class PlumaMainContextMenu(MainContextMenu):
             (MenuUpdate, None),
             (MenuCommit, None),
             (MenuPush, None),
-            (MenuRabbitVCSSvn, [
-                (MenuCheckout, None),
-                (MenuDiffMenu, [
-                    (MenuDiff, None),
-                    (MenuDiffPrevRev, None),
-                    (MenuDiffMultiple, None),
-                    (MenuCompareTool, None),
-                    (MenuCompareToolPrevRev, None),
-                    (MenuCompareToolMultiple, None),
-                    (MenuShowChanges, None),
-                ]),
-                (MenuShowLog, None),
-                (MenuRepoBrowser, None),
-                (MenuCheckForModifications, None),
-                (MenuSeparator, None),
-                (MenuAdd, None),
-                (MenuAddToIgnoreList, ignore_items),
-                (MenuSeparator, None),
-                (MenuUpdateToRevision, None),
-                (MenuRename, None),
-                (MenuDelete, None),
-                (MenuRevert, None),
-                (MenuEditConflicts, None),
-                (MenuMarkResolved, None),
-                (MenuRelocate, None),
-                (MenuGetLock, None),
-                (MenuUnlock, None),
-                (MenuCleanup, None),
-                (MenuSeparator, None),
-                (MenuExport, None),
-                (MenuCreateRepository, None),
-                (MenuImport, None),
-                (MenuSeparator, None),
-                (MenuBranchTag, None),
-                (MenuSwitch, None),
-                (MenuMerge, None),
-                (MenuSeparator, None),
-                (MenuAnnotate, None),
-                (MenuSeparator, None),
-                (MenuCreatePatch, None),
-                (MenuApplyPatch, None),
-                (MenuProperties, None),
-                (MenuSeparator, None),
-                (MenuSettings, None),
-                (MenuAbout, None)
-            ]),
-            (MenuRabbitVCSGit, [
-                (MenuClone, None),
-                (MenuInitializeRepository, None),
-                (MenuSeparator, None),
-                (MenuDiffMenu, [
-                    (MenuDiff, None),
-                    (MenuDiffPrevRev, None),
-                    (MenuDiffMultiple, None),
-                    (MenuCompareTool, None),
-                    (MenuCompareToolPrevRev, None),
-                    (MenuCompareToolMultiple, None),
-                    (MenuShowChanges, None),
-                ]),
-                (MenuShowLog, None),
-                (MenuStage, None),
-                (MenuUnstage, None),
-                (MenuAddToIgnoreList, ignore_items),
-                (MenuSeparator, None),
-                (MenuRename, None),
-                (MenuDelete, None),
-                (MenuRevert, None),
-                (MenuEditConflicts, None),
-                (MenuClean, None),
-                (MenuReset, None),
-                (MenuCheckout, None),
-                (MenuSeparator, None),
-                (MenuBranches, None),
-                (MenuTags, None),
-                (MenuRemotes, None),
-                (MenuSeparator, None),
-                (MenuExport, None),
-                (MenuMerge, None),
-                (MenuSeparator, None),
-                (MenuAnnotate, None),
-                (MenuSeparator, None),
-                (MenuCreatePatch, None),
-                (MenuApplyPatch, None),
-                (MenuSeparator, None),
-                (MenuSettings, None),
-                (MenuAbout, None)
-            ])
+            (
+                MenuRabbitVCSSvn,
+                [
+                    (MenuCheckout, None),
+                    (
+                        MenuDiffMenu,
+                        [
+                            (MenuDiff, None),
+                            (MenuDiffPrevRev, None),
+                            (MenuDiffMultiple, None),
+                            (MenuCompareTool, None),
+                            (MenuCompareToolPrevRev, None),
+                            (MenuCompareToolMultiple, None),
+                            (MenuShowChanges, None),
+                        ],
+                    ),
+                    (MenuShowLog, None),
+                    (MenuRepoBrowser, None),
+                    (MenuCheckForModifications, None),
+                    (MenuSeparator, None),
+                    (MenuAdd, None),
+                    (MenuAddToIgnoreList, ignore_items),
+                    (MenuSeparator, None),
+                    (MenuUpdateToRevision, None),
+                    (MenuRename, None),
+                    (MenuDelete, None),
+                    (MenuRevert, None),
+                    (MenuEditConflicts, None),
+                    (MenuMarkResolved, None),
+                    (MenuRelocate, None),
+                    (MenuGetLock, None),
+                    (MenuUnlock, None),
+                    (MenuCleanup, None),
+                    (MenuSeparator, None),
+                    (MenuExport, None),
+                    (MenuCreateRepository, None),
+                    (MenuImport, None),
+                    (MenuSeparator, None),
+                    (MenuBranchTag, None),
+                    (MenuSwitch, None),
+                    (MenuMerge, None),
+                    (MenuSeparator, None),
+                    (MenuAnnotate, None),
+                    (MenuSeparator, None),
+                    (MenuCreatePatch, None),
+                    (MenuApplyPatch, None),
+                    (MenuProperties, None),
+                    (MenuSeparator, None),
+                    (MenuSettings, None),
+                    (MenuAbout, None),
+                ],
+            ),
+            (
+                MenuRabbitVCSGit,
+                [
+                    (MenuClone, None),
+                    (MenuInitializeRepository, None),
+                    (MenuSeparator, None),
+                    (
+                        MenuDiffMenu,
+                        [
+                            (MenuDiff, None),
+                            (MenuDiffPrevRev, None),
+                            (MenuDiffMultiple, None),
+                            (MenuCompareTool, None),
+                            (MenuCompareToolPrevRev, None),
+                            (MenuCompareToolMultiple, None),
+                            (MenuShowChanges, None),
+                        ],
+                    ),
+                    (MenuShowLog, None),
+                    (MenuStage, None),
+                    (MenuUnstage, None),
+                    (MenuAddToIgnoreList, ignore_items),
+                    (MenuSeparator, None),
+                    (MenuRename, None),
+                    (MenuDelete, None),
+                    (MenuRevert, None),
+                    (MenuEditConflicts, None),
+                    (MenuClean, None),
+                    (MenuReset, None),
+                    (MenuCheckout, None),
+                    (MenuSeparator, None),
+                    (MenuBranches, None),
+                    (MenuTags, None),
+                    (MenuRemotes, None),
+                    (MenuSeparator, None),
+                    (MenuExport, None),
+                    (MenuMerge, None),
+                    (MenuSeparator, None),
+                    (MenuAnnotate, None),
+                    (MenuSeparator, None),
+                    (MenuCreatePatch, None),
+                    (MenuApplyPatch, None),
+                    (MenuSeparator, None),
+                    (MenuSettings, None),
+                    (MenuAbout, None),
+                ],
+            ),
         ]
 
     def get_menu(self):

--- a/clients/pluma/rabbitvcs-plugin.py
+++ b/clients/pluma/rabbitvcs-plugin.py
@@ -1,4 +1,11 @@
 from __future__ import absolute_import
+from rabbitvcs.util.contextmenuitems import *
+from rabbitvcs.util.contextmenu import GtkFilesContextMenuConditions, \
+    GtkFilesContextMenuCallbacks, MainContextMenu, MainContextMenuCallbacks, \
+    MenuBuilder, GtkContextMenuCaller
+from rabbitvcs.vcs import create_vcs_instance
+from gi.repository import Pluma, GObject, Peas
+from gi.repository import Gtk
 #
 # This is a Pluma plugin to allow for RabbitVCS integration in the Pluma
 # text editor.
@@ -28,16 +35,8 @@ from rabbitvcs.util import helper
 
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk
 sa.restore()
-from gi.repository import Pluma, GObject, Peas
 
-
-from rabbitvcs.vcs import create_vcs_instance
-from rabbitvcs.util.contextmenu import GtkFilesContextMenuConditions, \
-    GtkFilesContextMenuCallbacks, MainContextMenu, MainContextMenuCallbacks, \
-    MenuBuilder, GtkContextMenuCaller
-from rabbitvcs.util.contextmenuitems import *
 
 # Menu item, insert a new item on the menu bar.
 ui_str = """<ui>
@@ -146,10 +145,12 @@ ui_str = """<ui>
   </menubar>
 </ui>
 """
+
+
 class RabbitVCSWindowHelper(GtkContextMenuCaller):
 
     _menu_paths = [
-#        "/MenuBar/RabbitVCSMenu",
+        #        "/MenuBar/RabbitVCSMenu",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Svn",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Svn/RabbitVCS::Commit",
         "/MenuBar/ExtraMenu_1/RabbitVCSMenu/RabbitVCS::RabbitVCS_Svn/RabbitVCS::Update",
@@ -255,15 +256,17 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         # Get the GtkUIManager
         manager = self._window.get_ui_manager()
 
-        self._menubar_menu = PlumaMenu(self, self.vcs_client, self.base_dir, [self._get_document_path()])
+        self._menubar_menu = PlumaMenu(self, self.vcs_client, self.base_dir, [
+                                       self._get_document_path()])
         self._menu_action = Gtk.Action(name="RabbitVCSMenu",
                                        label="RabbitVCS",
                                        tooltip=_("Excellent Version Control"),
                                        stock_id=None)
 
         self._action_group = Gtk.ActionGroup("RabbitVCSActions")
-        self._action_group = self._menubar_menu.get_action_group(self._action_group)
-        self._action_group.add_action( self._menu_action )
+        self._action_group = self._menubar_menu.get_action_group(
+            self._action_group)
+        self._action_group.add_action(self._menu_action)
 
         # Insert the action group
         manager.insert_action_group(self._action_group, 0)
@@ -291,12 +294,14 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         self._action_group.set_sensitive(document != None)
         if document != None:
             manager = self._window.get_ui_manager()
-            manager.get_widget("/MenuBar/ExtraMenu_1/RabbitVCSMenu").set_sensitive(True)
+            manager.get_widget(
+                "/MenuBar/ExtraMenu_1/RabbitVCSMenu").set_sensitive(True)
             self._menubar_menu.set_paths([self._get_document_path()])
             self._determine_menu_sensitivity([self._get_document_path()])
 
     def connect_view(self, view, id_name):
-        handler_id = view.connect("populate-popup", self.on_view_populate_popup)
+        handler_id = view.connect(
+            "populate-popup", self.on_view_populate_popup)
         setattr(view, id_name, [handler_id])
 
     def disconnect_view(self, view, id_name):
@@ -307,7 +312,8 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
         menu.append(separator)
         separator.show()
 
-        context_menu = PlumaMainContextMenu(self, self.vcs_client, self.base_dir, [self._get_document_path()]).get_menu()
+        context_menu = PlumaMainContextMenu(self, self.vcs_client, self.base_dir, [
+                                            self._get_document_path()]).get_menu()
         for context_menu_item in context_menu:
             menu.append(context_menu_item)
 
@@ -354,6 +360,7 @@ class RabbitVCSWindowHelper(GtkContextMenuCaller):
 
     def on_context_menu_command_finished(self):
         self.update_ui()
+
 
 class RabbitVCSPlumaPlugin(GObject.Object, Peas.Activatable):
     __gtype_name__ = "RabbitVCSPlumaPlugin"
@@ -403,17 +410,21 @@ class RabbitVCSPlumaPlugin(GObject.Object, Peas.Activatable):
 
     def on_window_tab_removed(self, window, tab):
         if window in self._instances:
-            self._instances[window].disconnect_view(tab.get_view(), self.id_name)
+            self._instances[window].disconnect_view(
+                tab.get_view(), self.id_name)
+
 
 class MenuIgnoreByFilename(MenuItem):
     identifier = "RabbitVCS::Ignore_By_Filename"
     label = _("Ignore by File Name")
     tooltip = _("Ignore item by filename")
 
+
 class MenuIgnoreByFileExtension(MenuItem):
     identifier = "RabbitVCS::Ignore_By_File_Extension"
     label = _("Ignore by File Extension")
     tooltip = _("Ignore item by extension")
+
 
 class PlumaMenuBuilder(object):
     """
@@ -466,14 +477,16 @@ class PlumaMenuBuilder(object):
             item = item_class(conditions, callbacks)
 
             default_name = MenuItem.make_default_name(item.identifier)
-            action = Gtk.Action(item.identifier, item.label, item.tooltip, item.icon)
+            action = Gtk.Action(item.identifier, item.label,
+                                item.tooltip, item.icon)
 
             if item.icon and hasattr(action, "set_icon_name"):
                 action.set_icon_name(item.icon)
 
             if item.callback:
                 if item.callback_args:
-                    action.connect("activate", item.callback, item.callback_args)
+                    action.connect("activate", item.callback,
+                                   item.callback_args)
                 else:
                     action.connect("activate", item.callback)
 
@@ -492,6 +505,7 @@ class PlumaMenuBuilder(object):
                 function = attr
 
         return function
+
 
 class PlumaMenu(object):
     def __init__(self, caller, vcs_client, base_dir, paths):
@@ -520,7 +534,8 @@ class PlumaMenu(object):
         self.base_dir = base_dir
         self.vcs_client = vcs_client
 
-        self.conditions = GtkFilesContextMenuConditions(self.vcs_client, self.paths)
+        self.conditions = GtkFilesContextMenuConditions(
+            self.vcs_client, self.paths)
 
         self.callbacks = GtkFilesContextMenuCallbacks(
             self.caller,
@@ -606,6 +621,7 @@ class PlumaMenu(object):
     def update_action(self, action):
         action.set_property("visible", action.item.show())
 
+
 class PlumaContextMenu(MenuBuilder):
     """
     Provides a standard Gtk context menu (ie. a list of Gtk.MenuItem"s).
@@ -624,9 +640,10 @@ class PlumaContextMenu(MenuBuilder):
     def top_level_menu(self, items):
         return items
 
+
 class PlumaMainContextMenu(MainContextMenu):
     def __init__(self, caller, vcs_client, base_dir, paths=[],
-            conditions=None, callbacks=None):
+                 conditions=None, callbacks=None):
         """
         @param  caller: The calling object
         @type   caller: RabbitVCS extension
@@ -654,7 +671,8 @@ class PlumaMainContextMenu(MainContextMenu):
 
         self.conditions = conditions
         if self.conditions is None:
-            self.conditions = GtkFilesContextMenuConditions(self.vcs_client, paths)
+            self.conditions = GtkFilesContextMenuConditions(
+                self.vcs_client, paths)
 
         self.callbacks = callbacks
         if self.callbacks is None:

--- a/clients/thunar/RabbitVCS.py
+++ b/clients/thunar/RabbitVCS.py
@@ -50,6 +50,7 @@ import threading
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -79,16 +80,10 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
         SVN.STATUS["deleted"],
         SVN.STATUS["replaced"],
         SVN.STATUS["modified"],
-        SVN.STATUS["missing"]
+        SVN.STATUS["missing"],
     ]
 
-    MODIFIED_TEXT_STATUSES = [
-        "added",
-        "deleted",
-        "replaced",
-        "modified",
-        "missing"
-    ]
+    MODIFIED_TEXT_STATUSES = ["added", "deleted", "replaced", "modified", "missing"]
 
     #: This is our lookup table for C{NautilusVFSFile}s which we need for attaching
     #: emblems. This is mostly a workaround for not being able to turn a path/uri
@@ -138,13 +133,15 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
     #: A list of statuses that we want to keep track of for when a process
     #: might have done something.
     STATUSES_TO_MONITOR = copy.copy(MODIFIED_TEXT_STATUSES)
-    STATUSES_TO_MONITOR.extend([
-        "unversioned",
-        # When doing a checkout Nautilus will notice a directory being
-        # added and call update_file_info, but at that stage the
-        # checkout likely hasn't completed yet and the status will be:
-        "incomplete"
-    ])
+    STATUSES_TO_MONITOR.extend(
+        [
+            "unversioned",
+            # When doing a checkout Nautilus will notice a directory being
+            # added and call update_file_info, but at that stage the
+            # checkout likely hasn't completed yet and the status will be:
+            "incomplete",
+        ]
+    )
 
     def __init__(self):
         threading.currentThread().setName("RabbitVCS extension thread")
@@ -263,15 +260,13 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
             #
             for path in paths:
                 # We're not interested in the result now, just the callback
-                self.status_checker.check_status(path,
-                                                 recurse=True,
-                                                 invalidate=True,
-                                                 summary=True)
+                self.status_checker.check_status(
+                    path, recurse=True, invalidate=True, summary=True
+                )
 
         self.execute_after_process_exit(proc, do_check)
 
     def execute_after_process_exit(self, proc, func=None):
-
         def is_process_still_alive():
             log.debug("is_process_still_alive() for pid: %i" % proc.pid)
             # First we need to see if the commit process is still running
@@ -280,7 +275,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
 
             log.debug("%s" % retval)
 
-            still_going = (retval is None)
+            still_going = retval is None
 
             if not still_going and callable(func):
                 func()
@@ -305,8 +300,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
 
         def do_reload_settings():
             globals()["settings"] = SettingsManager()
-            globals()["log"] = reload_log_settings()(
-                "rabbitvcs.util.extensions.thunar")
+            globals()["log"] = reload_log_settings()("rabbitvcs.util.extensions.thunar")
             log.debug("Re-scanning settings")
 
         self.execute_after_process_exit(proc, do_reload_settings)

--- a/clients/thunar/RabbitVCS.py
+++ b/clients/thunar/RabbitVCS.py
@@ -28,9 +28,7 @@ from __future__ import with_statement
 from __future__ import absolute_import
 import copy
 import os.path
-from os.path import isdir, isfile, realpath, basename
-import datetime
-import time
+from os.path import realpath
 import threading
 
 from rabbitvcs.util import helper
@@ -38,12 +36,10 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import GObject, Gtk, Thunarx
+from gi.repository import GObject, Thunarx
 sa.restore()
 
 from rabbitvcs.vcs.svn import SVN
-
-import os
 
 import rabbitvcs.ui
 import rabbitvcs.ui.property_page
@@ -51,8 +47,8 @@ from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
 from rabbitvcs.util.helper import get_file_extension, get_common_directory
 from rabbitvcs.util.helper import pretty_timedelta
 from rabbitvcs.util.strings import S
-from rabbitvcs.util.decorators import timeit, disable
-from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu, SEPARATOR
+from rabbitvcs.util.decorators import timeit
+from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu
 
 from rabbitvcs.util.log import Log, reload_log_settings
 log = Log("rabbitvcs.util.extensions.thunarx.RabbitVCS")

--- a/clients/thunar/RabbitVCS.py
+++ b/clients/thunar/RabbitVCS.py
@@ -25,6 +25,22 @@ Our module for everything related to the Thunar extension.
 """
 
 from __future__ import with_statement
+from rabbitvcs.util.contextmenuitems import *
+from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
+import rabbitvcs.services.service
+from rabbitvcs.util.settings import SettingsManager
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log, reload_log_settings
+from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu
+from rabbitvcs.util.decorators import timeit
+from rabbitvcs.util.strings import S
+from rabbitvcs.util.helper import pretty_timedelta
+from rabbitvcs.util.helper import get_file_extension, get_common_directory
+from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
+import rabbitvcs.ui.property_page
+import rabbitvcs.ui
+from rabbitvcs.vcs.svn import SVN
+from gi.repository import GObject, Thunarx
 from __future__ import absolute_import
 import copy
 import os.path
@@ -36,31 +52,15 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import GObject, Thunarx
 sa.restore()
 
-from rabbitvcs.vcs.svn import SVN
 
-import rabbitvcs.ui
-import rabbitvcs.ui.property_page
-from rabbitvcs.util.helper import launch_ui_window, launch_diff_tool
-from rabbitvcs.util.helper import get_file_extension, get_common_directory
-from rabbitvcs.util.helper import pretty_timedelta
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.decorators import timeit
-from rabbitvcs.util.contextmenu import MenuBuilder, MainContextMenu
-
-from rabbitvcs.util.log import Log, reload_log_settings
 log = Log("rabbitvcs.util.extensions.thunarx.RabbitVCS")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
-from rabbitvcs.util.settings import SettingsManager
 settings = SettingsManager()
 
-import rabbitvcs.services.service
-from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 
 class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvider):
     """
@@ -156,7 +156,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
             return None
         return item.get_location().get_path()
 
-    #~ @disable
+    # ~ @disable
     # @timeit
     def get_file_menu_items(self, window, items):
         """
@@ -185,11 +185,12 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
                 paths.append(path)
                 self.VFSFile_table[path] = item
 
-        if len(paths) == 0: return []
+        if len(paths) == 0:
+            return []
 
         return ThunarxMainContextMenu(self, window.base_dir, paths).get_menu()
 
-    #~ @disable
+    # ~ @disable
     @timeit
     def get_folder_menu_items(self, window, item):
         """
@@ -207,7 +208,8 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
 
         """
 
-        if not self.valid_uri(item.get_uri()): return
+        if not self.valid_uri(item.get_uri()):
+            return
         path = realpath(S(self.get_local_path(item)))
         self.VFSFile_table[path] = item
 
@@ -230,7 +232,8 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
 
         """
 
-        if not uri.startswith("file://"): return False
+        if not uri.startswith("file://"):
+            return False
 
         return True
 
@@ -302,7 +305,8 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
 
         def do_reload_settings():
             globals()["settings"] = SettingsManager()
-            globals()["log"] = reload_log_settings()("rabbitvcs.util.extensions.thunar")
+            globals()["log"] = reload_log_settings()(
+                "rabbitvcs.util.extensions.thunar")
             log.debug("Re-scanning settings")
 
         self.execute_after_process_exit(proc, do_reload_settings)
@@ -316,7 +320,8 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
                 paths.append(path)
                 self.VFSFile_table[path] = item
 
-        if len(paths) == 0: return []
+        if len(paths) == 0:
+            return []
 
         label = rabbitvcs.ui.property_page.PropertyPageLabel().get_widget()
         page = rabbitvcs.ui.property_page.PropertyPage(paths).get_widget()
@@ -327,7 +332,6 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
 
         return [ppage]
 
-from rabbitvcs.util.contextmenuitems import *
 
 class ThunarxContextMenu(MenuBuilder):
     """
@@ -347,6 +351,7 @@ class ThunarxContextMenu(MenuBuilder):
 
     def top_level_menu(self, items):
         return items
+
 
 class ThunarxMainContextMenu(MainContextMenu):
     def get_menu(self):

--- a/rabbitvcs/__init__.py
+++ b/rabbitvcs/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,6 +29,7 @@ from locale import getdefaultlocale
 # Hack to make RabbitVCS win in the battle against TortoiseHg
 try:
     import mercurial.demandimport
+
     mercurial.demandimport.enable = lambda: None
 except Exception as e:
     pass
@@ -35,15 +37,14 @@ except Exception as e:
 version = "0.18"
 APP_NAME = "RabbitVCS"
 TEMP_DIR_PREFIX = "rabbitvcs-"
-LOCALE_DIR = "%s/locale" % os.path.dirname(
-    os.path.dirname(os.path.realpath(__file__)))
+LOCALE_DIR = "%s/locale" % os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 if not os.path.exists(LOCALE_DIR):
     LOCALE_DIR = "/usr/share/locale"
 
 WEBSITE = "http://www.rabbitvcs.org/"
 
 langs = []
-language = os.environ.get('LANGUAGE', None)
+language = os.environ.get("LANGUAGE", None)
 if language:
     langs += language.split(":")
 if getdefaultlocale()[0] != None:
@@ -58,10 +59,9 @@ class gettext(object):
     @staticmethod
     def set_language(langs):
         global current_translation
-        current_translation = _gettext.translation(APP_NAME,
-                                                   LOCALE_DIR,
-                                                   languages=langs,
-                                                   fallback=True)
+        current_translation = _gettext.translation(
+            APP_NAME, LOCALE_DIR, languages=langs, fallback=True
+        )
 
     @staticmethod
     def gettext(message):
@@ -92,7 +92,7 @@ def package_version():
     extensions.
 
     """
-    app_version = version.split('-')[0]
+    app_version = version.split("-")[0]
     # TODO: sanity-check app_version: make sure it's just digits and dots
     return app_version
 
@@ -113,6 +113,7 @@ def package_prefix():
 
     try:
         from rabbitvcs.buildinfo import rabbitvcs_prefix
+
         return rabbitvcs_prefix
     except ImportError as e:
         return ""
@@ -126,6 +127,9 @@ def get_icon_path():
 
     try:
         from rabbitvcs.buildinfo import icon_path
+
         return icon_path
     except ImportError as e:
-        return "%s/data/icons/hicolor" % os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+        return "%s/data/icons/hicolor" % os.path.dirname(
+            os.path.dirname(os.path.realpath(__file__))
+        )

--- a/rabbitvcs/__init__.py
+++ b/rabbitvcs/__init__.py
@@ -35,7 +35,8 @@ except Exception as e:
 version = "0.18"
 APP_NAME = "RabbitVCS"
 TEMP_DIR_PREFIX = "rabbitvcs-"
-LOCALE_DIR = "%s/locale" % os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+LOCALE_DIR = "%s/locale" % os.path.dirname(
+    os.path.dirname(os.path.realpath(__file__)))
 if not os.path.exists(LOCALE_DIR):
     LOCALE_DIR = "/usr/share/locale"
 
@@ -52,14 +53,16 @@ _gettext.bindtextdomain(APP_NAME, LOCALE_DIR)
 _gettext.textdomain(APP_NAME)
 current_translation = None
 
+
 class gettext(object):
     @staticmethod
     def set_language(langs):
         global current_translation
         current_translation = _gettext.translation(APP_NAME,
                                                    LOCALE_DIR,
-                                                   languages = langs,
-                                                   fallback = True)
+                                                   languages=langs,
+                                                   fallback=True)
+
     @staticmethod
     def gettext(message):
         if not current_translation:
@@ -70,7 +73,9 @@ class gettext(object):
     def ngettext(msgid1, msgid2, n):
         return gettext.gettext(msgid1 if n == 1 else msgid2)
 
+
 gettext.set_language(langs)
+
 
 def package_name():
     """
@@ -99,6 +104,7 @@ def package_identifier():
     """
     return "%s-%s" % (package_name(), package_version())
 
+
 def package_prefix():
     """
     Return the prefix of the local RabbitVCS installation
@@ -110,6 +116,7 @@ def package_prefix():
         return rabbitvcs_prefix
     except ImportError as e:
         return ""
+
 
 def get_icon_path():
     """

--- a/rabbitvcs/debug/pythonconsole.py
+++ b/rabbitvcs/debug/pythonconsole.py
@@ -36,6 +36,7 @@ import re
 import traceback
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 
 
@@ -105,8 +106,7 @@ class PythonConsole(Gtk.ScrolledWindow):
         if keyname == "d" and event_state == Gdk.ModifierType.CONTROL_MASK:
             self.exit()
 
-        elif (keyname == "Return" and
-              event_state == Gdk.ModifierType.CONTROL_MASK):
+        elif keyname == "Return" and event_state == Gdk.ModifierType.CONTROL_MASK:
             # Get the command
             buffer = view.get_buffer()
             inp_mark = buffer.get_mark("input")
@@ -125,7 +125,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             # Keep indentation of precendent line
             spaces = self._RE_SPACES.match(line)
             if spaces is not None:
-                buffer.insert(cur, line[spaces.start():spaces.end()])
+                buffer.insert(cur, line[spaces.start() : spaces.end()])
                 cur = buffer.get_end_iter()
 
             buffer.place_cursor(cur)
@@ -147,8 +147,9 @@ class PythonConsole(Gtk.ScrolledWindow):
             buffer.insert(cur, "\n")
 
             cur_strip = self.current_command.rstrip()
-            if cur_strip.endswith(":") \
-                    or (self.current_command[-2:] != "\n\n" and self.block_command):
+            if cur_strip.endswith(":") or (
+                self.current_command[-2:] != "\n\n" and self.block_command
+            ):
                 # Unfinished block command
                 self.block_command = True
                 com_mark = "... "
@@ -185,8 +186,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             GLib.idle_add(self.scroll_to_end)
             return True
 
-        elif keyname == "KP_Left" or keyname == "Left" or \
-                keyname == "BackSpace":
+        elif keyname == "KP_Left" or keyname == "Left" or keyname == "BackSpace":
             buffer = view.get_buffer()
             inp = buffer.get_iter_at_mark(buffer.get_mark("input"))
             cur = buffer.get_iter_at_mark(buffer.get_insert())
@@ -199,8 +199,11 @@ class PythonConsole(Gtk.ScrolledWindow):
         # For the console we enable smart/home end behavior inconditionally
         # since it is useful when editing python
 
-        elif ((keyname == "KP_Home" or keyname == "Home") and
-              event_state == event_state & (Gdk.ModifierType.SHIFT_MASK | Gdk.ModifierType.CONTROL_MASK)):
+        elif (
+            keyname == "KP_Home" or keyname == "Home"
+        ) and event_state == event_state & (
+            Gdk.ModifierType.SHIFT_MASK | Gdk.ModifierType.CONTROL_MASK
+        ):
             # Go to the begin of the command instead of the begin of the line
             buffer = view.get_buffer()
             iter = buffer.get_iter_at_mark(buffer.get_mark("input"))
@@ -218,8 +221,11 @@ class PythonConsole(Gtk.ScrolledWindow):
                 buffer.place_cursor(iter)
             return True
 
-        elif ((keyname == "KP_End" or keyname == "End") and
-              event_state == event_state & (Gdk.ModifierType.SHIFT_MASK | Gdk.ModifierType.CONTROL_MASK)):
+        elif (
+            keyname == "KP_End" or keyname == "End"
+        ) and event_state == event_state & (
+            Gdk.ModifierType.SHIFT_MASK | Gdk.ModifierType.CONTROL_MASK
+        ):
             buffer = view.get_buffer()
             iter = buffer.get_end_iter()
             ins = buffer.get_iter_at_mark(buffer.get_insert())
@@ -348,15 +354,37 @@ class OutFile:
         self.fn = fn
         self.console = console
 
-    def close(self): pass
-    def flush(self): pass
-    def fileno(self): return self.fn
-    def isatty(self): return 0
-    def read(self, a): return ""
-    def readline(self): return ""
-    def readlines(self): return []
-    def write(self, s):      self.console.write(s)
-    def writelines(self, l): self.console.write(l)
-    def seek(self, a): raise IOError(29, "Illegal seek")
-    def tell(self): raise IOError(29, "Illegal seek")
+    def close(self):
+        pass
+
+    def flush(self):
+        pass
+
+    def fileno(self):
+        return self.fn
+
+    def isatty(self):
+        return 0
+
+    def read(self, a):
+        return ""
+
+    def readline(self):
+        return ""
+
+    def readlines(self):
+        return []
+
+    def write(self, s):
+        self.console.write(s)
+
+    def writelines(self, l):
+        self.console.write(l)
+
+    def seek(self, a):
+        raise IOError(29, "Illegal seek")
+
+    def tell(self):
+        raise IOError(29, "Illegal seek")
+
     truncate = tell

--- a/rabbitvcs/debug/pythonconsole.py
+++ b/rabbitvcs/debug/pythonconsole.py
@@ -28,6 +28,8 @@
 #   Copyright (C), 2005 Adam Hooper <adamh@densi.com>
 #   Copyright (C) 2006 - Steve Frécinaux
 
+from rabbitvcs.util.strings import S
+from gi.repository import GLib, Gtk, Gdk, Pango
 import string
 import sys
 import re
@@ -35,15 +37,12 @@ import traceback
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import GLib, Gtk, Gdk, Pango
-
-from rabbitvcs.util.strings import S
 
 
 class PythonConsole(Gtk.ScrolledWindow):
 
     __gsignals__ = {
-        "grab-focus" : "override",
+        "grab-focus": "override",
     }
 
     DEFAULT_FONT = "Monospace"
@@ -149,7 +148,7 @@ class PythonConsole(Gtk.ScrolledWindow):
 
             cur_strip = self.current_command.rstrip()
             if cur_strip.endswith(":") \
-            or (self.current_command[-2:] != "\n\n" and self.block_command):
+                    or (self.current_command[-2:] != "\n\n" and self.block_command):
                 # Unfinished block command
                 self.block_command = True
                 com_mark = "... "
@@ -187,7 +186,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             return True
 
         elif keyname == "KP_Left" or keyname == "Left" or \
-             keyname == "BackSpace":
+                keyname == "BackSpace":
             buffer = view.get_buffer()
             inp = buffer.get_iter_at_mark(buffer.get_mark("input"))
             cur = buffer.get_iter_at_mark(buffer.get_insert())
@@ -201,7 +200,7 @@ class PythonConsole(Gtk.ScrolledWindow):
         # since it is useful when editing python
 
         elif ((keyname == "KP_Home" or keyname == "Home") and
-             event_state == event_state & (Gdk.ModifierType.SHIFT_MASK|Gdk.ModifierType.CONTROL_MASK)):
+              event_state == event_state & (Gdk.ModifierType.SHIFT_MASK | Gdk.ModifierType.CONTROL_MASK)):
             # Go to the begin of the command instead of the begin of the line
             buffer = view.get_buffer()
             iter = buffer.get_iter_at_mark(buffer.get_mark("input"))
@@ -220,7 +219,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             return True
 
         elif ((keyname == "KP_End" or keyname == "End") and
-             event_state == event_state & (Gdk.ModifierType.SHIFT_MASK|Gdk.ModifierType.CONTROL_MASK)):
+              event_state == event_state & (Gdk.ModifierType.SHIFT_MASK | Gdk.ModifierType.CONTROL_MASK)):
             buffer = view.get_buffer()
             iter = buffer.get_end_iter()
             ins = buffer.get_iter_at_mark(buffer.get_insert())
@@ -339,22 +338,25 @@ class PythonConsole(Gtk.ScrolledWindow):
         sys.stdout, self.stdout = self.stdout, sys.stdout
         sys.stderr, self.stderr = self.stderr, sys.stderr
 
+
 class OutFile:
     """
     A fake output file object.
     """
+
     def __init__(self, console, fn):
         self.fn = fn
         self.console = console
-    def close(self):         pass
-    def flush(self):         pass
-    def fileno(self):        return self.fn
-    def isatty(self):        return 0
-    def read(self, a):       return ""
-    def readline(self):      return ""
-    def readlines(self):     return []
+
+    def close(self): pass
+    def flush(self): pass
+    def fileno(self): return self.fn
+    def isatty(self): return 0
+    def read(self, a): return ""
+    def readline(self): return ""
+    def readlines(self): return []
     def write(self, s):      self.console.write(s)
     def writelines(self, l): self.console.write(l)
-    def seek(self, a):       raise IOError(29, "Illegal seek")
-    def tell(self):          raise IOError(29, "Illegal seek")
+    def seek(self, a): raise IOError(29, "Illegal seek")
+    def tell(self): raise IOError(29, "Illegal seek")
     truncate = tell

--- a/rabbitvcs/services/checkerservice.py
+++ b/rabbitvcs/services/checkerservice.py
@@ -67,18 +67,18 @@ from rabbitvcs.services.statuschecker import StatusChecker
 import rabbitvcs.vcs.status
 
 from rabbitvcs.util.log import Log
+
 log = Log("rabbitvcs.services.checkerservice")
 
 
 INTERFACE = "org.google.code.rabbitvcs.StatusChecker"
 OBJECT_PATH = "/org/google/code/rabbitvcs/StatusChecker"
 SERVICE = "org.google.code.rabbitvcs.RabbitVCS.Checker"
-TIMEOUT = 60*15*100  # seconds
+TIMEOUT = 60 * 15 * 100  # seconds
 
 
 def find_class(module, name):
-    """ Given a module name and a class name, return the actual type object.
-    """
+    """Given a module name and a class name, return the actual type object."""
     # From Python stdlib pickle module source
     __import__(module)
     mod = sys.modules[module]
@@ -87,26 +87,25 @@ def find_class(module, name):
 
 
 def encode_status(status):
-    """ Before encoding a status object to JSON, we need to turn it into
+    """Before encoding a status object to JSON, we need to turn it into
     something simpler.
     """
     return status.__getstate__()
 
 
 def decode_status(json_dict):
-    """ Once we get a JSON encoded string out the other side of DBUS, we need to
+    """Once we get a JSON encoded string out the other side of DBUS, we need to
     reconstitute the original object. This method is based on the pickle module
     in the Python stdlib.
     """
-    cl = find_class(json_dict['__module__'], json_dict['__type__'])
+    cl = find_class(json_dict["__module__"], json_dict["__type__"])
     st = None
     if cl in rabbitvcs.vcs.status.STATUS_TYPES:
         st = cl.__new__(cl)
         st.__setstate__(json_dict)
-    elif 'path' in json_dict:
-        log.warning("Could not deduce status class: %s" %
-                    json_dict['__type__'])
-        st = rabbitvcs.vcs.status.Status.status_error(json_dict['path'])
+    elif "path" in json_dict:
+        log.warning("Could not deduce status class: %s" % json_dict["__type__"])
+        st = rabbitvcs.vcs.status.Status.status_error(json_dict["path"])
     else:
         raise TypeError("RabbitVCS status object has no path")
     return st
@@ -119,7 +118,7 @@ def output_and_flush(*args):
 
 
 class StatusCheckerService(dbus.service.Object):
-    """ StatusCheckerService objects wrap a StatusCheckerPlus instance,
+    """StatusCheckerService objects wrap a StatusCheckerPlus instance,
     exporting methods that can be called via DBUS.
 
     There should only be a single such object running in a separate process from
@@ -128,7 +127,7 @@ class StatusCheckerService(dbus.service.Object):
     """
 
     def __init__(self, connection, mainloop):
-        """ Creates a new status checker wrapper service, with the given DBUS
+        """Creates a new status checker wrapper service, with the given DBUS
         connection.
 
         The mainloop argument is needed for process management (eg. calling
@@ -142,8 +141,7 @@ class StatusCheckerService(dbus.service.Object):
         """
         dbus.service.Object.__init__(self, connection, OBJECT_PATH)
 
-        self.encoder = json.JSONEncoder(default=encode_status,
-                                        separators=(',', ':'))
+        self.encoder = json.JSONEncoder(default=encode_status, separators=(",", ":"))
 
         self.mainloop = mainloop
 
@@ -162,7 +160,7 @@ class StatusCheckerService(dbus.service.Object):
         return own_mem + checker_mem
 
     @dbus.service.method(INTERFACE)
-    def SetLocale(self, language='', encoding=''):
+    def SetLocale(self, language="", encoding=""):
         return rabbitvcs.util._locale.set_locale(language, encoding)
 
     @dbus.service.method(INTERFACE)
@@ -173,21 +171,19 @@ class StatusCheckerService(dbus.service.Object):
     def CheckerType(self):
         return self.status_checker.CHECKER_NAME
 
-    @dbus.service.method(INTERFACE, in_signature='aybbb', out_signature='s')
-    def CheckStatus(self, path, recurse=False, invalidate=False,
-                    summary=False):
-        """ Requests a status check from the underlying status checker.
-            Path is given as an array of bytes instead of a string because
-            dbus does not support strings with invalid characters.
+    @dbus.service.method(INTERFACE, in_signature="aybbb", out_signature="s")
+    def CheckStatus(self, path, recurse=False, invalidate=False, summary=False):
+        """Requests a status check from the underlying status checker.
+        Path is given as an array of bytes instead of a string because
+        dbus does not support strings with invalid characters.
         """
-        status = self.status_checker.check_status(S(bytearray(path)),
-                                                  recurse=recurse,
-                                                  summary=summary,
-                                                  invalidate=invalidate)
+        status = self.status_checker.check_status(
+            S(bytearray(path)), recurse=recurse, summary=summary, invalidate=invalidate
+        )
 
         return self.encoder.encode(status)
 
-    @dbus.service.method(INTERFACE, in_signature='aay', out_signature='s')
+    @dbus.service.method(INTERFACE, in_signature="aay", out_signature="s")
     def GenerateMenuConditions(self, paths):
         upaths = []
         for path in paths:
@@ -205,9 +201,10 @@ class StatusCheckerService(dbus.service.Object):
         waiting for the process to exit).
         """
         if not self.CheckVersion(version):
-            log.warning("Version mismatch, quitting checker service "
-                        "(service: %s, extension: %s)"
-                        % (SERVICE_VERSION, version))
+            log.warning(
+                "Version mismatch, quitting checker service "
+                "(service: %s, extension: %s)" % (SERVICE_VERSION, version)
+            )
             return self.Quit()
 
         return None
@@ -241,7 +238,7 @@ class StatusCheckerService(dbus.service.Object):
 
 
 class StatusCheckerStub(object):
-    """ StatusCheckerStub objects contain methods that call an actual status
+    """StatusCheckerStub objects contain methods that call an actual status
     checker running in another process.
 
     These objects should be created by the GUI as needed (eg. the nautilus
@@ -251,7 +248,7 @@ class StatusCheckerStub(object):
     """
 
     def __init__(self):
-        """ Creates an object that can call the VCS status checker via DBUS.
+        """Creates an object that can call the VCS status checker via DBUS.
 
         If there is not already a DBUS object with the path "OBJECT_PATH", we
         create one by starting a new Python process that runs this file.
@@ -270,8 +267,7 @@ class StatusCheckerStub(object):
 
         # Try to get a new checker
         try:
-            self.status_checker = self.session_bus.get_object(SERVICE,
-                                                              OBJECT_PATH)
+            self.status_checker = self.session_bus.get_object(SERVICE, OBJECT_PATH)
             # Sets the checker locale.
             self.status_checker.SetLocale(*rabbitvcs.util._locale.get_locale())
         except dbus.DBusException as ex:
@@ -309,17 +305,19 @@ class StatusCheckerStub(object):
                     log.exception(ex)
                     self._connect_to_checker()
 
-    def check_status_now(self, path, recurse=False, invalidate=False,
-                         summary=False):
+    def check_status_now(self, path, recurse=False, invalidate=False, summary=False):
 
         status = None
 
         try:
-            json_status = self.status_checker.CheckStatus(bytearray(S(path).bytes()),
-                                                          recurse, invalidate,
-                                                          summary,
-                                                          dbus_interface=INTERFACE,
-                                                          timeout=TIMEOUT)
+            json_status = self.status_checker.CheckStatus(
+                bytearray(S(path).bytes()),
+                recurse,
+                invalidate,
+                summary,
+                dbus_interface=INTERFACE,
+                timeout=TIMEOUT,
+            )
             status = self.decoder.decode(json_status)
             # Test client error problems :)
             # raise dbus.DBusException("Test")
@@ -333,18 +331,19 @@ class StatusCheckerStub(object):
 
         return status
 
-    def check_status_later(self, path, callback, recurse=False,
-                           invalidate=False, summary=False):
-
+    def check_status_later(
+        self, path, callback, recurse=False, invalidate=False, summary=False
+    ):
         def real_reply_handler(json_status):
             # Note that this a closure referring to the outer functions callback
             # parameter
             status = self.decoder.decode(json_status)
             path1 = S(path)
             path2 = S(status.path)
-            assert path1 == path2, "Status check returned the wrong path "\
-                "(asked about %s, got back %s)" % \
-                (path1.display(), path2.display())
+            assert path1 == path2, (
+                "Status check returned the wrong path "
+                "(asked about %s, got back %s)" % (path1.display(), path2.display())
+            )
             callback(status)
 
         def reply_handler(*args, **kwargs):
@@ -358,13 +357,16 @@ class StatusCheckerStub(object):
             callback(rabbitvcs.vcs.status.Status.status_error(path))
 
         try:
-            self.status_checker.CheckStatus(bytearray(S(path).bytes()),
-                                            recurse, invalidate,
-                                            summary,
-                                            dbus_interface=INTERFACE,
-                                            timeout=TIMEOUT,
-                                            reply_handler=reply_handler,
-                                            error_handler=error_handler)
+            self.status_checker.CheckStatus(
+                bytearray(S(path).bytes()),
+                recurse,
+                invalidate,
+                summary,
+                dbus_interface=INTERFACE,
+                timeout=TIMEOUT,
+                reply_handler=reply_handler,
+                error_handler=error_handler,
+            )
         except dbus.DBusException as ex:
             log.exception(ex)
             callback(rabbitvcs.vcs.status.Status.status_error(path))
@@ -373,22 +375,23 @@ class StatusCheckerStub(object):
 
     # @rabbitvcs.util.decorators.deprecated
     # Can't decide whether this should be deprecated or not... -JH
-    def check_status(self, path, recurse=False, invalidate=False,
-                     summary=False, callback=None):
-        """ Check the VCS status of the given path.
+    def check_status(
+        self, path, recurse=False, invalidate=False, summary=False, callback=None
+    ):
+        """Check the VCS status of the given path.
 
         This is a pass-through method to the check_status method of the DBUS
         service (which is, in turn, a wrapper around the real status checker).
         """
         if callback:
-            GLib.idle_add(self.check_status_later,
-                          path, callback, recurse, invalidate, summary)
+            GLib.idle_add(
+                self.check_status_later, path, callback, recurse, invalidate, summary
+            )
             return rabbitvcs.vcs.status.Status.status_calc(path)
         else:
             return self.check_status_now(path, recurse, invalidate, summary)
 
     def generate_menu_conditions(self, provider, base_dir, paths, callback):
-
         def real_reply_handler(obj):
             # Note that this a closure referring to the outer functions callback
             # parameter
@@ -407,11 +410,13 @@ class StatusCheckerStub(object):
 
         bpaths = [bytearray(S(p).bytes()) for p in paths]
         try:
-            self.status_checker.GenerateMenuConditions(bpaths,
-                                                       dbus_interface=INTERFACE,
-                                                       timeout=TIMEOUT,
-                                                       reply_handler=reply_handler,
-                                                       error_handler=error_handler)
+            self.status_checker.GenerateMenuConditions(
+                bpaths,
+                dbus_interface=INTERFACE,
+                timeout=TIMEOUT,
+                reply_handler=reply_handler,
+                error_handler=error_handler,
+            )
         except dbus.DBusException as ex:
             log.exception(ex)
             callback(provider, base_dir, paths, {})
@@ -419,27 +424,28 @@ class StatusCheckerStub(object):
             self._connect_to_checker()
 
     def generate_menu_conditions_async(self, provider, base_dir, paths, callback):
-        GLib.idle_add(self.generate_menu_conditions,
-                      provider, base_dir, paths, callback)
+        GLib.idle_add(
+            self.generate_menu_conditions, provider, base_dir, paths, callback
+        )
         return {}
 
 
 def start():
-    """ Starts the checker service, via the utility method in "service.py". """
-    rabbitvcs.services.service.start_service(os.path.abspath(__file__), SERVICE,
-                                             OBJECT_PATH)
+    """Starts the checker service, via the utility method in "service.py"."""
+    rabbitvcs.services.service.start_service(
+        os.path.abspath(__file__), SERVICE, OBJECT_PATH
+    )
 
 
 def Main():
-    """ The main point of entry for the checker service.
+    """The main point of entry for the checker service.
 
     This will set up the DBUS and glib extensions, the gobject/glib main loop,
     and start the service.
     """
     global log
     log = Log("rabbitvcs.services.checkerservice:main")
-    log.debug("Checker: starting service: %s (%s)" %
-              (OBJECT_PATH, os.getpid()))
+    log.debug("Checker: starting service: %s (%s)" % (OBJECT_PATH, os.getpid()))
 
     # We need this to for the client to be able to do asynchronous calls
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)

--- a/rabbitvcs/services/service.py
+++ b/rabbitvcs/services/service.py
@@ -30,6 +30,7 @@ import subprocess
 import dbus
 
 from rabbitvcs.util.log import Log
+
 log = Log("rabbitvcs.services.service")
 
 
@@ -72,9 +73,9 @@ def start_service(script_file, dbus_service_name, dbus_object_path):
         obj = session_bus.get_object(dbus_service_name, dbus_object_path)
         object_exists = True
     except dbus.DBusException:
-        proc = subprocess.Popen([sys.executable, script_file],
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE)
+        proc = subprocess.Popen(
+            [sys.executable, script_file], stdin=subprocess.PIPE, stdout=subprocess.PIPE
+        )
         pid = proc.pid
         log.debug("Started process: %i" % pid)
 

--- a/rabbitvcs/services/service.py
+++ b/rabbitvcs/services/service.py
@@ -32,6 +32,7 @@ import dbus
 from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.services.service")
 
+
 def start_service(script_file, dbus_service_name, dbus_object_path):
     """
     This function is used to start a service that exports a DBUS object. If the
@@ -72,14 +73,13 @@ def start_service(script_file, dbus_service_name, dbus_object_path):
         object_exists = True
     except dbus.DBusException:
         proc = subprocess.Popen([sys.executable, script_file],
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE)
+                                stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE)
         pid = proc.pid
         log.debug("Started process: %i" % pid)
 
         # Wait for subprocess to send a newline, to tell us it's ready
-        proc.stdout.readline() # We don't care what the message is
+        proc.stdout.readline()  # We don't care what the message is
         object_exists = True
 
     return object_exists
-

--- a/rabbitvcs/services/statuschecker.py
+++ b/rabbitvcs/services/statuschecker.py
@@ -26,26 +26,26 @@ import rabbitvcs.vcs
 import rabbitvcs.vcs.status
 
 from rabbitvcs import gettext
+
 _ = gettext.gettext
 
 log = Log("rabbitvcs.services.statuschecker")
 
 
 class StatusChecker(object):
-    """ A class for performing status checks. """
+    """A class for performing status checks."""
 
     # All subclasses should override this! This is to be displayed in the
     # settings dialog
     CHECKER_NAME = _("Simple status checker")
 
     def __init__(self):
-        """ Initialises status checker. Obviously. """
+        """Initialises status checker. Obviously."""
         self.vcs_client = rabbitvcs.vcs.create_vcs_instance()
         self.conditions_dict_cache = {}
 
     def check_status(self, path, recurse, summary, invalidate):
-        """ Performs a status check, blocking until the check is done.
-        """
+        """Performs a status check, blocking until the check is done."""
         path_status = self.vcs_client.status(path, summary, invalidate)
         return path_status
 
@@ -59,7 +59,7 @@ class StatusChecker(object):
         return None
 
     def get_memory_usage(self):
-        """ Returns any additional memory of any subprocesses used by this
+        """Returns any additional memory of any subprocesses used by this
         checker. In other words, DO NOT return the memory usage of THIS process!
         """
         return 0

--- a/rabbitvcs/services/statuschecker.py
+++ b/rabbitvcs/services/statuschecker.py
@@ -20,6 +20,7 @@ Very simple status checking class. Useful when you can't get any of the others
 to work, or you need to prototype things.
 """
 from __future__ import absolute_import
+from rabbitvcs.util.log import Log
 
 import rabbitvcs.vcs
 import rabbitvcs.vcs.status
@@ -27,8 +28,8 @@ import rabbitvcs.vcs.status
 from rabbitvcs import gettext
 _ = gettext.gettext
 
-from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.services.statuschecker")
+
 
 class StatusChecker(object):
     """ A class for performing status checks. """

--- a/rabbitvcs/test.py
+++ b/rabbitvcs/test.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.

--- a/rabbitvcs/tests/nautilus.py
+++ b/rabbitvcs/tests/nautilus.py
@@ -4,11 +4,14 @@ to get the RabbitVCS extension to load properly.
 
 """
 
+
 class InfoProvider(object):
     pass
 
+
 class MenuProvider(object):
     pass
+
 
 class ColumnProvider(object):
     pass

--- a/rabbitvcs/tests/test_rabbitvcs.py
+++ b/rabbitvcs/tests/test_rabbitvcs.py
@@ -35,7 +35,8 @@ from unittest import TestCase, main
 # make sure the current working copy is in sys.path before anything else
 from os.path import abspath, dirname, join, normpath
 import sys
-toplevel = normpath(join(dirname(abspath(__file__)), '..', '..'))
+
+toplevel = normpath(join(dirname(abspath(__file__)), "..", ".."))
 sys.path.insert(0, toplevel)
 
 
@@ -54,9 +55,11 @@ class RabbitVCSTest(TestCase):
         """Make sure the package version is reported properly."""
         result = rabbitvcs.package_version()
         for character in result:
-            if not (character.isdigit() or character == '.'):
-                self.fail("Not all characters in package version "
-                          "'%s' were digits or dots." % result)
+            if not (character.isdigit() or character == "."):
+                self.fail(
+                    "Not all characters in package version "
+                    "'%s' were digits or dots." % result
+                )
 
     def test_package_identifier(self):
         """Make sure the package identifier is reported properly."""
@@ -82,12 +85,13 @@ class FakeInfo(object):
     """
 
     def __init__(self):
-        self.data = {'text_status': pysvn.wc_status_kind.none,
-                     'commit_revision': FakeVersion(1234),
-                     'commit_author': None,
-                     'commit_time': 0.0,
-                     'url': None,
-                     }
+        self.data = {
+            "text_status": pysvn.wc_status_kind.none,
+            "commit_revision": FakeVersion(1234),
+            "commit_author": None,
+            "commit_time": 0.0,
+            "url": None,
+        }
 
 
 class FakeClient(object):
@@ -95,6 +99,7 @@ class FakeClient(object):
     Fake pysvn.Client that can have its behavior controlled.
 
     """
+
     instance_count = 0
     send_empty_info = True
 
@@ -166,9 +171,10 @@ class RabbitVCSPySvnTest(TestCase):
         self.assertEqual(FakeClient.instance_count, 2)
         self.assertEqual(len(self.logger.messages), 1)
         last_message = self.logger.messages[-1]
-        self.assertEqual(str(last_message[1]),
-                         "The path 'awesomepath' does not "
-                         "appear to be under source control.")
+        self.assertEqual(
+            str(last_message[1]),
+            "The path 'awesomepath' does not " "appear to be under source control.",
+        )
 
     def test_update_columns_correct_info(self):
         """

--- a/rabbitvcs/tests/test_rabbitvcs.py
+++ b/rabbitvcs/tests/test_rabbitvcs.py
@@ -25,6 +25,12 @@ Unit tests for the top-level rabbitvcs package.
 
 """
 from __future__ import absolute_import
+from rabbitvcs.util.extensions.nautilus import RabbitVCS
+import rabbitvcs
+import pysvn
+from . import nautilus
+import traceback
+from unittest import TestCase, main
 
 # make sure the current working copy is in sys.path before anything else
 from os.path import abspath, dirname, join, normpath
@@ -32,20 +38,13 @@ import sys
 toplevel = normpath(join(dirname(abspath(__file__)), '..', '..'))
 sys.path.insert(0, toplevel)
 
-from unittest import TestCase, main
-import traceback
-
-from . import nautilus
-import pysvn
-import rabbitvcs
-from rabbitvcs.util.extensions.nautilus import RabbitVCS
-
 
 class RabbitVCSTest(TestCase):
     """
     Main RabbitVCS tests.
 
     """
+
     def test_package_name(self):
         """Make sure the package name is reported properly."""
         result = rabbitvcs.package_name()
@@ -71,6 +70,7 @@ class FakeVersion(object):
     Fake revision info for FakeInfo, below.
 
     """
+
     def __init__(self, number):
         self.number = number
 
@@ -80,6 +80,7 @@ class FakeInfo(object):
     Fake pysvn.Client.info() response.
 
     """
+
     def __init__(self):
         self.data = {'text_status': pysvn.wc_status_kind.none,
                      'commit_revision': FakeVersion(1234),
@@ -117,6 +118,7 @@ class FakeLog(object):
     within unit tests.
 
     """
+
     def __init__(self, prefix):
         self.prefix = prefix
         self.messages = []
@@ -137,6 +139,7 @@ class RabbitVCSPySvnTest(TestCase):
     fiddle with pysvn stuff for the tests to work.
 
     """
+
     def setUp(self):
         self.oldClient = pysvn.Client
         pysvn.Client = FakeClient
@@ -179,7 +182,7 @@ class RabbitVCSPySvnTest(TestCase):
         self.nsvn.update_columns(item, path)
         self.assertEqual(FakeClient.instance_count, 2)
         if len(self.logger.messages) > 0:
-            for e,m,t in self.logger.messages:
+            for e, m, t in self.logger.messages:
                 traceback.print_exception(e, m, t)
             self.fail()
 

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -26,6 +26,9 @@ UI layer.
 
 """
 from __future__ import absolute_import
+import rabbitvcs.vcs.status
+from rabbitvcs import APP_NAME, LOCALE_DIR, gettext
+from gi.repository import Gtk, Gdk, GLib
 
 import os
 from six.moves import range
@@ -35,47 +38,46 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, Gdk, GLib
 sa.restore()
 
-from rabbitvcs import APP_NAME, LOCALE_DIR, gettext
 _ = gettext.gettext
 
-import rabbitvcs.vcs.status
 
-REVISION_OPT = (["-r", "--revision"], {"help":"specify the revision number"})
+REVISION_OPT = (["-r", "--revision"], {"help": "specify the revision number"})
 BASEDIR_OPT = (["-b", "--base-dir"], {})
 QUIET_OPT = (["-q", "--quiet"], {
     "help":     "Run the add command quietly, with no UI.",
     "action":   "store_true",
     "default":  False
 })
-VCS_OPT = (["--vcs"], {"help":"specify the version control system"})
+VCS_OPT = (["--vcs"], {"help": "specify the version control system"})
 
-VCS_OPT_ERROR = _("You must specify a version control system using the --vcs [svn|git] option")
+VCS_OPT_ERROR = _(
+    "You must specify a version control system using the --vcs [svn|git] option")
 
 #: Maps statuses to emblems.
 STATUS_EMBLEMS = {
-    rabbitvcs.vcs.status.status_normal : "rabbitvcs-normal",
-    rabbitvcs.vcs.status.status_modified : "rabbitvcs-modified",
-    rabbitvcs.vcs.status.status_added : "rabbitvcs-added",
-    rabbitvcs.vcs.status.status_deleted : "rabbitvcs-deleted",
-    rabbitvcs.vcs.status.status_ignored :"rabbitvcs-ignored",
-    rabbitvcs.vcs.status.status_read_only : "rabbitvcs-locked",
-    rabbitvcs.vcs.status.status_locked : "rabbitvcs-locked",
-    rabbitvcs.vcs.status.status_unknown : "rabbitvcs-unknown",
-    rabbitvcs.vcs.status.status_missing : "rabbitvcs-complicated",
-    rabbitvcs.vcs.status.status_replaced : "rabbitvcs-modified",
-    rabbitvcs.vcs.status.status_complicated : "rabbitvcs-complicated",
-    rabbitvcs.vcs.status.status_calculating : "rabbitvcs-calculating",
-    rabbitvcs.vcs.status.status_error : "rabbitvcs-error",
-    rabbitvcs.vcs.status.status_unversioned : "rabbitvcs-unversioned"
+    rabbitvcs.vcs.status.status_normal: "rabbitvcs-normal",
+    rabbitvcs.vcs.status.status_modified: "rabbitvcs-modified",
+    rabbitvcs.vcs.status.status_added: "rabbitvcs-added",
+    rabbitvcs.vcs.status.status_deleted: "rabbitvcs-deleted",
+    rabbitvcs.vcs.status.status_ignored: "rabbitvcs-ignored",
+    rabbitvcs.vcs.status.status_read_only: "rabbitvcs-locked",
+    rabbitvcs.vcs.status.status_locked: "rabbitvcs-locked",
+    rabbitvcs.vcs.status.status_unknown: "rabbitvcs-unknown",
+    rabbitvcs.vcs.status.status_missing: "rabbitvcs-complicated",
+    rabbitvcs.vcs.status.status_replaced: "rabbitvcs-modified",
+    rabbitvcs.vcs.status.status_complicated: "rabbitvcs-complicated",
+    rabbitvcs.vcs.status.status_calculating: "rabbitvcs-calculating",
+    rabbitvcs.vcs.status.status_error: "rabbitvcs-error",
+    rabbitvcs.vcs.status.status_unversioned: "rabbitvcs-unversioned"
 }
+
 
 class GtkBuilderWidgetWrapper(object):
 
-    def __init__(self, gtkbuilder_filename = None,
-                 gtkbuilder_id = None, claim_domain=True):
+    def __init__(self, gtkbuilder_filename=None,
+                 gtkbuilder_id=None, claim_domain=True):
         if gtkbuilder_filename:
             self.gtkbuilder_filename = gtkbuilder_filename
 
@@ -101,11 +103,12 @@ class GtkBuilderWidgetWrapper(object):
 
         return tree
 
-    def get_widget(self, id = None):
+    def get_widget(self, id=None):
         if not id:
             id = self.gtkbuilder_id
 
         return self.tree.get_object(id)
+
 
 class InterfaceView(GtkBuilderWidgetWrapper):
     """
@@ -130,10 +133,10 @@ class InterfaceView(GtkBuilderWidgetWrapper):
         if platform.system() == 'Darwin':
             try:
                 import subprocess
-                subprocess.Popen('osascript -e "tell application \\"Python\\" to activate"', shell=True)
+                subprocess.Popen(
+                    'osascript -e "tell application \\"Python\\" to activate"', shell=True)
             except:
                 pass
-
 
     def hide(self):
         window = self.get_widget(self.gtkbuilder_id)
@@ -202,7 +205,7 @@ class InterfaceView(GtkBuilderWidgetWrapper):
             self.on_refresh_clicked(widget)
             return True
 
-    def change_button(self, id, label = None, icon = None):
+    def change_button(self, id, label=None, icon=None):
         """
          Replace label and/or icon of the named button.
         """
@@ -213,6 +216,7 @@ class InterfaceView(GtkBuilderWidgetWrapper):
         if icon:
             image = Gtk.Image.new_from_icon_name(icon, Gtk.IconSize.BUTTON)
             button.set_image(image)
+
 
 class InterfaceNonView(object):
     """
@@ -240,6 +244,7 @@ class InterfaceNonView(object):
 
     def gtk_quit_is_set(self):
         return self.do_gtk_quit
+
 
 class VCSNotSupportedError(Exception):
     """Indicates the desired VCS is not valid for a given action"""

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -36,6 +36,7 @@ from six.moves import range
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -45,15 +46,19 @@ _ = gettext.gettext
 
 REVISION_OPT = (["-r", "--revision"], {"help": "specify the revision number"})
 BASEDIR_OPT = (["-b", "--base-dir"], {})
-QUIET_OPT = (["-q", "--quiet"], {
-    "help":     "Run the add command quietly, with no UI.",
-    "action":   "store_true",
-    "default":  False
-})
+QUIET_OPT = (
+    ["-q", "--quiet"],
+    {
+        "help": "Run the add command quietly, with no UI.",
+        "action": "store_true",
+        "default": False,
+    },
+)
 VCS_OPT = (["--vcs"], {"help": "specify the version control system"})
 
 VCS_OPT_ERROR = _(
-    "You must specify a version control system using the --vcs [svn|git] option")
+    "You must specify a version control system using the --vcs [svn|git] option"
+)
 
 #: Maps statuses to emblems.
 STATUS_EMBLEMS = {
@@ -70,14 +75,12 @@ STATUS_EMBLEMS = {
     rabbitvcs.vcs.status.status_complicated: "rabbitvcs-complicated",
     rabbitvcs.vcs.status.status_calculating: "rabbitvcs-calculating",
     rabbitvcs.vcs.status.status_error: "rabbitvcs-error",
-    rabbitvcs.vcs.status.status_unversioned: "rabbitvcs-unversioned"
+    rabbitvcs.vcs.status.status_unversioned: "rabbitvcs-unversioned",
 }
 
 
 class GtkBuilderWidgetWrapper(object):
-
-    def __init__(self, gtkbuilder_filename=None,
-                 gtkbuilder_id=None, claim_domain=True):
+    def __init__(self, gtkbuilder_filename=None, gtkbuilder_id=None, claim_domain=True):
         if gtkbuilder_filename:
             self.gtkbuilder_filename = gtkbuilder_filename
 
@@ -92,7 +95,7 @@ class GtkBuilderWidgetWrapper(object):
     def get_tree(self):
         path = "%s/xml/%s.xml" % (
             os.path.dirname(os.path.realpath(__file__)),
-            self.gtkbuilder_filename
+            self.gtkbuilder_filename,
         )
 
         tree = Gtk.Builder()
@@ -130,23 +133,27 @@ class InterfaceView(GtkBuilderWidgetWrapper):
         # when a launched (and methods like 'present()' don't appear to work correctly).
         # So until GTK on OSX is fixed let's work around this issue...
         import platform
-        if platform.system() == 'Darwin':
+
+        if platform.system() == "Darwin":
             try:
                 import subprocess
+
                 subprocess.Popen(
-                    'osascript -e "tell application \\"Python\\" to activate"', shell=True)
+                    'osascript -e "tell application \\"Python\\" to activate"',
+                    shell=True,
+                )
             except:
                 pass
 
     def hide(self):
         window = self.get_widget(self.gtkbuilder_id)
         if window:
-            window.set_property('visible', False)
+            window.set_property("visible", False)
 
     def show(self):
         window = self.get_widget(self.gtkbuilder_id)
         if window:
-            window.set_property('visible', True)
+            window.set_property("visible", True)
 
     def destroy(self):
         self.close()
@@ -186,28 +193,34 @@ class InterfaceView(GtkBuilderWidgetWrapper):
         return True
 
     def on_key_pressed(self, widget, event, *args):
-        if event.keyval == Gdk.keyval_from_name('Escape'):
+        if event.keyval == Gdk.keyval_from_name("Escape"):
             self.on_cancel_clicked(widget)
             return True
 
-        if (event.state & Gdk.ModifierType.CONTROL_MASK and
-                Gdk.keyval_name(event.keyval).lower() == "w"):
+        if (
+            event.state & Gdk.ModifierType.CONTROL_MASK
+            and Gdk.keyval_name(event.keyval).lower() == "w"
+        ):
             self.on_cancel_clicked(widget)
             return True
 
-        if (event.state & Gdk.ModifierType.CONTROL_MASK and
-                Gdk.keyval_name(event.keyval).lower() == "q"):
+        if (
+            event.state & Gdk.ModifierType.CONTROL_MASK
+            and Gdk.keyval_name(event.keyval).lower() == "q"
+        ):
             self.on_cancel_clicked(widget)
             return True
 
-        if (event.state & Gdk.ModifierType.CONTROL_MASK and
-                Gdk.keyval_name(event.keyval).lower() == "r"):
+        if (
+            event.state & Gdk.ModifierType.CONTROL_MASK
+            and Gdk.keyval_name(event.keyval).lower() == "r"
+        ):
             self.on_refresh_clicked(widget)
             return True
 
     def change_button(self, id, label=None, icon=None):
         """
-         Replace label and/or icon of the named button.
+        Replace label and/or icon of the named button.
         """
 
         button = self.get_widget(id)

--- a/rabbitvcs/ui/about.py
+++ b/rabbitvcs/ui/about.py
@@ -1,4 +1,17 @@
 from __future__ import absolute_import
+from six.moves import map
+from rabbitvcs import gettext
+import configobj
+import pysvn
+import rabbitvcs.ui.widget
+from rabbitvcs.ui import InterfaceView
+import rabbitvcs
+from gi.repository import Gtk, GObject, GdkPixbuf
+import gi
+from rabbitvcs.util import helper
+import re
+import string
+import os.path
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -22,27 +35,13 @@ You should have received a copy of the GNU General Public License
 along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.  """
 
 
-import os.path
-import string
-import re
-
-from rabbitvcs.util import helper
-
-import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, GdkPixbuf
 sa.restore()
 
-import rabbitvcs
-from rabbitvcs.ui import InterfaceView
-import rabbitvcs.ui.widget
-import pysvn
-import configobj
 
-from rabbitvcs import gettext
-from six.moves import map
 _ = gettext.gettext
+
 
 class About(object):
     """
@@ -86,8 +85,9 @@ class About(object):
         self.about.set_logo(pixbuf)
 
         versions = []
-        versions.append("Subversion - %s" % ".".join(list(map(str,pysvn.svn_version))))
-        versions.append("Pysvn - %s" % ".".join(list(map(str,pysvn.version))))
+        versions.append("Subversion - %s" %
+                        ".".join(list(map(str, pysvn.svn_version))))
+        versions.append("Pysvn - %s" % ".".join(list(map(str, pysvn.version))))
         versions.append("ConfigObj - %s" % str(configobj.__version__))
 
         self.about.set_comments("\n".join(versions))

--- a/rabbitvcs/ui/about.py
+++ b/rabbitvcs/ui/about.py
@@ -12,6 +12,7 @@ from rabbitvcs.util import helper
 import re
 import string
 import os.path
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -72,21 +73,21 @@ class About(object):
         if not authors_path:
             # Assumes the user is running RabbitVCS through an svn checkout
             # and the doc files are two directories up (from rabbitvcs/ui).
-            doc_path = os.path.dirname(os.path.realpath(__file__)).split('/')
-            doc_path = '/'.join(doc_path[:-2])
+            doc_path = os.path.dirname(os.path.realpath(__file__)).split("/")
+            doc_path = "/".join(doc_path[:-2])
             authors_path = os.path.join(doc_path, "AUTHORS")
 
         authors = open(authors_path, "r").read()
 
         self.about.set_authors(authors.split("\n"))
 
-        pixbuf = GdkPixbuf.Pixbuf.new_from_file(rabbitvcs.get_icon_path() +
-                                                "/scalable/apps/rabbitvcs.svg")
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file(
+            rabbitvcs.get_icon_path() + "/scalable/apps/rabbitvcs.svg"
+        )
         self.about.set_logo(pixbuf)
 
         versions = []
-        versions.append("Subversion - %s" %
-                        ".".join(list(map(str, pysvn.svn_version))))
+        versions.append("Subversion - %s" % ".".join(list(map(str, pysvn.svn_version))))
         versions.append("Pysvn - %s" % ".".join(list(map(str, pysvn.version))))
         versions.append("ConfigObj - %s" % str(configobj.__version__))
 

--- a/rabbitvcs/ui/action.py
+++ b/rabbitvcs/ui/action.py
@@ -40,6 +40,7 @@ from os.path import basename
 
 import shutil
 import gi
+
 gi.require_version("Gtk", "3.0")
 
 
@@ -121,12 +122,10 @@ class MessageCallbackNotifier(VCSNotifier):
         self.table = rabbitvcs.ui.widget.Table(
             self.get_widget("table"),
             [GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
-            [_("Action"), _("Path"), _("Mime Type")]
+            [_("Action"), _("Path"), _("Mime Type")],
         )
 
-        self.pbar = rabbitvcs.ui.widget.ProgressBar(
-            self.get_widget("pbar")
-        )
+        self.pbar = rabbitvcs.ui.widget.ProgressBar(self.get_widget("pbar"))
         self.pbar.start_pulsate()
         self.finished = False
 
@@ -173,7 +172,7 @@ class MessageCallbackNotifier(VCSNotifier):
         self.set_title(header)
 
         self.get_widget("action").set_markup(
-            "<span size=\"xx-large\"><b>%s</b></span>" % header
+            '<span size="xx-large"><b>%s</b></span>' % header
         )
 
     @gtk_unsafe
@@ -197,6 +196,7 @@ class MessageCallbackNotifier(VCSNotifier):
     def saveas(self, path=None):
         if path is None:
             from rabbitvcs.ui.dialog import FileSaveAs
+
             dialog = FileSaveAs()
             path = dialog.run()
 
@@ -215,9 +215,7 @@ class LoadingNotifier(VCSNotifier):
 
         VCSNotifier.__init__(self, callback_cancel, visible)
 
-        self.pbar = rabbitvcs.ui.widget.ProgressBar(
-            self.get_widget("pbar")
-        )
+        self.pbar = rabbitvcs.ui.widget.ProgressBar(self.get_widget("pbar"))
         self.pbar.start_pulsate()
 
     def on_destroy(self, widget):
@@ -254,8 +252,9 @@ class VCSAction(threading.Thread):
 
     """
 
-    def __init__(self, client, register_gtk_quit=False, notification=True,
-                 run_in_thread=True):
+    def __init__(
+        self, client, register_gtk_quit=False, notification=True, run_in_thread=True
+    ):
 
         self.run_in_thread = run_in_thread
 
@@ -276,13 +275,12 @@ class VCSAction(threading.Thread):
             self.notification = MessageCallbackNotifier(
                 self.set_cancel,
                 notification,
-                client_in_same_thread=self.client_in_same_thread
+                client_in_same_thread=self.client_in_same_thread,
             )
             self.has_notifier = True
         elif run_in_thread:
             visible = run_in_thread
-            self.notification = LoadingNotifier(
-                self.set_cancel, visible=visible)
+            self.notification = LoadingNotifier(self.set_cancel, visible=visible)
             self.has_loader = True
         else:
             self.notification = DummyNotifier()
@@ -363,9 +361,7 @@ class VCSAction(threading.Thread):
         """
 
         if self.has_notifier:
-            self.notification.append(
-                ["", _("Finished"), ""]
-            )
+            self.notification.append(["", _("Finished"), ""])
             self.notification.focus_on_ok_button()
             title = self.notification.get_title()
             self.notification.set_title(_("%s - Finished") % title)
@@ -393,11 +389,11 @@ class VCSAction(threading.Thread):
         message = self.message
         if message is None:
             settings = rabbitvcs.util.settings.SettingsManager()
-            message = settings.get_multiline(
-                "general", "default_commit_message")
+            message = settings.get_multiline("general", "default_commit_message")
             result = helper.run_in_main_thread(
-                lambda: rabbitvcs.ui.dialog.TextChange(_("Log Message"), message).run())
-            should_continue = (result[0] == Gtk.ResponseType.OK)
+                lambda: rabbitvcs.ui.dialog.TextChange(_("Log Message"), message).run()
+            )
+            should_continue = result[0] == Gtk.ResponseType.OK
             message = result[1]
         if isinstance(message, bytes):
             message = message.decode()
@@ -434,7 +430,8 @@ class VCSAction(threading.Thread):
             return (False, "", "", False)
 
         result = helper.run_in_main_thread(
-            lambda: rabbitvcs.ui.dialog.Authentication(realm, may_save).run())
+            lambda: rabbitvcs.ui.dialog.Authentication(realm, may_save).run()
+        )
 
         if result is not None:
             self.login_tries += 1
@@ -460,14 +457,16 @@ class VCSAction(threading.Thread):
 
         result = 0
         if data:
-            result = helper.run_in_main_thread(lambda: rabbitvcs.ui.dialog.Certificate(
-                data["realm"],
-                data["hostname"],
-                data["issuer_dname"],
-                data["valid_from"],
-                data["valid_until"],
-                data["finger_print"]
-            ).run())
+            result = helper.run_in_main_thread(
+                lambda: rabbitvcs.ui.dialog.Certificate(
+                    data["realm"],
+                    data["hostname"],
+                    data["issuer_dname"],
+                    data["valid_from"],
+                    data["valid_until"],
+                    data["finger_print"],
+                ).run()
+            )
 
         if result == 0:
             # Deny
@@ -496,10 +495,9 @@ class VCSAction(threading.Thread):
         @return:            (True=continue/False=cancel, password, may save)
         """
 
-        return helper.run_in_main_thread(lambda: rabbitvcs.ui.dialog.CertAuthentication(
-            realm,
-            may_save
-        ).run())
+        return helper.run_in_main_thread(
+            lambda: rabbitvcs.ui.dialog.CertAuthentication(realm, may_save).run()
+        )
 
     def get_client_cert(self, realm, may_save):
         """
@@ -518,10 +516,9 @@ class VCSAction(threading.Thread):
         @return:            (True=continue/False=cancel, password, may save)
         """
 
-        return helper.run_in_main_thread(lambda: rabbitvcs.ui.dialog.SSLClientCertPrompt(
-            realm,
-            may_save
-        ).run())
+        return helper.run_in_main_thread(
+            lambda: rabbitvcs.ui.dialog.SSLClientCertPrompt(realm, may_save).run()
+        )
 
     def set_log_message(self, message):
         """
@@ -548,8 +545,7 @@ class VCSAction(threading.Thread):
         """
 
         if message is not None:
-            self.notification.get_widget(
-                "status").set_text(S(message).display())
+            self.notification.get_widget("status").set_text(S(message).display())
 
     def append(self, func, *args, **kwargs):
         """
@@ -620,8 +616,9 @@ class VCSAction(threading.Thread):
 
 
 class SVNAction(VCSAction):
-    def __init__(self, client, register_gtk_quit=False, notification=True,
-                 run_in_thread=True):
+    def __init__(
+        self, client, register_gtk_quit=False, notification=True, run_in_thread=True
+    ):
 
         self.client_in_same_thread = False
 
@@ -631,12 +628,10 @@ class SVNAction(VCSAction):
         self.client.set_callback_get_log_message(self.get_log_message)
         self.client.set_callback_get_login(self.get_login)
         self.client.set_callback_ssl_server_trust_prompt(self.get_ssl_trust)
-        self.client.set_callback_ssl_client_cert_password_prompt(
-            self.get_ssl_password)
+        self.client.set_callback_ssl_client_cert_password_prompt(self.get_ssl_password)
         self.client.set_callback_ssl_client_cert_prompt(self.get_client_cert)
 
-        VCSAction.__init__(self, client, register_gtk_quit, notification,
-                           run_in_thread)
+        VCSAction.__init__(self, client, register_gtk_quit, notification, run_in_thread)
 
     def notify(self, data):
         """
@@ -675,39 +670,37 @@ class SVNAction(VCSAction):
                     is_complete_action = True
                     break
 
-            if (is_known_action
-                    and is_complete_action
-                    and "revision" in data
-                    and data["revision"]):
+            if (
+                is_known_action
+                and is_complete_action
+                and "revision" in data
+                and data["revision"]
+            ):
                 self.notification.append(
                     ["", "Revision %s" % data["revision"].number, ""]
                 )
             elif "path" in data:
-                self.notification.append([
-                    action,
-                    data["path"],
-                    data["mime_type"]
-                ])
+                self.notification.append([action, data["path"], data["mime_type"]])
 
     def conflict_filter(self, data):
         if "content_state" in data and str(data["content_state"]) == "conflicted":
             position = self.queue.get_position()
-            self.queue.insert(position+1, self.edit_conflict, data)
+            self.queue.insert(position + 1, self.edit_conflict, data)
 
     def edit_conflict(self, data):
         helper.launch_ui_window("editconflicts", [data["path"]], block=True)
 
 
 class GitAction(VCSAction):
-    def __init__(self, client, register_gtk_quit=False, notification=True,
-                 run_in_thread=True):
+    def __init__(
+        self, client, register_gtk_quit=False, notification=True, run_in_thread=True
+    ):
 
         self.client_in_same_thread = True
 
         self.client = client
 
-        VCSAction.__init__(self, client, register_gtk_quit, notification,
-                           run_in_thread)
+        VCSAction.__init__(self, client, register_gtk_quit, notification, run_in_thread)
 
         self.client.set_callback_notify(self.notify)
         self.client.set_callback_progress_update(self.set_progress_fraction)
@@ -719,16 +712,16 @@ class GitAction(VCSAction):
             if data:
                 self.conflict_filter(data)
                 if isinstance(data, dict):
-                    self.notification.append([
-                        data["action"],
-                        data["path"],
-                        data["mime_type"]
-                    ])
+                    self.notification.append(
+                        [data["action"], data["path"], data["mime_type"]]
+                    )
                 else:
                     self.notification.append(["", data, ""])
 
     def get_user(self):
-        return helper.run_in_main_thread(lambda: rabbitvcs.ui.dialog.NameEmailPrompt().run())
+        return helper.run_in_main_thread(
+            lambda: rabbitvcs.ui.dialog.NameEmailPrompt().run()
+        )
 
     def conflict_filter(self, data):
         if str(data).startswith("ERROR:"):
@@ -737,8 +730,9 @@ class GitAction(VCSAction):
 
 
 class MercurialAction(VCSAction):
-    def __init__(self, client, register_gtk_quit=False, notification=True,
-                 run_in_thread=True):
+    def __init__(
+        self, client, register_gtk_quit=False, notification=True, run_in_thread=True
+    ):
 
         self.client_in_same_thread = True
 
@@ -747,24 +741,23 @@ class MercurialAction(VCSAction):
         self.client.set_callback_get_user(self.get_user)
         self.client.set_callback_get_cancel(self.cancel)
 
-        VCSAction.__init__(self, client, register_gtk_quit, notification,
-                           run_in_thread)
+        VCSAction.__init__(self, client, register_gtk_quit, notification, run_in_thread)
 
     def notify(self, data):
         if self.has_notifier:
             if data:
                 self.conflict_filter(data)
                 if isinstance(data, dict):
-                    self.notification.append([
-                        data["action"],
-                        data["path"],
-                        data["mime_type"]
-                    ])
+                    self.notification.append(
+                        [data["action"], data["path"], data["mime_type"]]
+                    )
                 else:
                     self.notification.append(["", data, ""])
 
     def get_user(self):
-        return helper.run_in_main_thread(lambda: rabbitvcs.ui.dialog.NameEmailPrompt().run())
+        return helper.run_in_main_thread(
+            lambda: rabbitvcs.ui.dialog.NameEmailPrompt().run()
+        )
 
     def conflict_filter(self, data):
         if str(data).startswith("ERROR:"):
@@ -772,12 +765,11 @@ class MercurialAction(VCSAction):
             helper.launch_ui_window("editconflicts", [path], block=True)
 
 
-def vcs_action_factory(client, register_gtk_quit=False, notification=True,
-                       run_in_thread=True):
+def vcs_action_factory(
+    client, register_gtk_quit=False, notification=True, run_in_thread=True
+):
 
     if client.vcs == rabbitvcs.vcs.VCS_GIT:
-        return GitAction(client, register_gtk_quit, notification,
-                         run_in_thread)
+        return GitAction(client, register_gtk_quit, notification, run_in_thread)
     else:
-        return SVNAction(client, register_gtk_quit, notification,
-                         run_in_thread)
+        return SVNAction(client, register_gtk_quit, notification, run_in_thread)

--- a/rabbitvcs/ui/add.py
+++ b/rabbitvcs/ui/add.py
@@ -10,6 +10,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -38,6 +39,7 @@ from time import sleep
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -73,15 +75,18 @@ class Add(InterfaceView, GtkContextMenuCaller):
 
         # TODO Remove this when there is svn support
         for path in paths:
-            if rabbitvcs.vcs.guess(path)['vcs'] == rabbitvcs.vcs.VCS_SVN:
+            if rabbitvcs.vcs.guess(path)["vcs"] == rabbitvcs.vcs.VCS_SVN:
                 self.get_widget("show_ignored").set_sensitive(False)
 
-        columns = [[GObject.TYPE_BOOLEAN,
-                    rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
-                    rabbitvcs.ui.widget.TYPE_PATH,
-                    GObject.TYPE_STRING],
-                   [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"),
-                    _("Extension")]]
+        columns = [
+            [
+                GObject.TYPE_BOOLEAN,
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH,
+                GObject.TYPE_STRING,
+            ],
+            [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"), _("Extension")],
+        ]
 
         self.setup(self.get_widget("Add"), columns)
 
@@ -89,18 +94,17 @@ class Add(InterfaceView, GtkContextMenuCaller):
             self.get_widget("files_table"),
             columns[0],
             columns[1],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 2
+            filters=[
+                {
+                    "callback": rabbitvcs.ui.widget.path_filter,
+                    "user_data": {"base_dir": base_dir, "column": 2},
                 }
-            }],
+            ],
             callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event,
-                "key-event":     self.on_files_table_key_event
-            }
+                "row-activated": self.on_files_table_row_activated,
+                "mouse-event": self.on_files_table_mouse_event,
+                "key-event": self.on_files_table_key_event,
+            },
         )
 
         self.initialize_items()
@@ -122,7 +126,7 @@ class Add(InterfaceView, GtkContextMenuCaller):
                 # TODO Refactor
                 # TODO SVN support
                 # TODO Further fix ignore patterns
-                if rabbitvcs.vcs.guess(path)['vcs'] == rabbitvcs.vcs.VCS_GIT:
+                if rabbitvcs.vcs.guess(path)["vcs"] == rabbitvcs.vcs.VCS_GIT:
                     git = self.vcs.git(path)
                     for ignored_path in git.client.get_all_ignore_file_paths(path):
                         should_add = True
@@ -132,21 +136,20 @@ class Add(InterfaceView, GtkContextMenuCaller):
 
                         if should_add:
                             self.items.append(
-                                Status(os.path.realpath(ignored_path), 'unversioned'))
+                                Status(os.path.realpath(ignored_path), "unversioned")
+                            )
 
         self.populate_files_table()
-        helper.run_in_main_thread(status.set_text, _(
-            "Found %d item(s)") % len(self.items))
+        helper.run_in_main_thread(
+            status.set_text, _("Found %d item(s)") % len(self.items)
+        )
 
     def populate_files_table(self):
         self.files_table.clear()
         for item in self.items:
-            self.files_table.append([
-                True,
-                S(item.path),
-                item.path,
-                helper.get_file_extension(item.path)
-            ])
+            self.files_table.append(
+                [True, S(item.path), item.path, helper.get_file_extension(item.path)]
+            )
 
     def toggle_ignored(self):
         self.show_ignored = not self.show_ignored
@@ -216,8 +219,7 @@ class SVNAdd(Add):
         self.hide()
 
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Add"))
         self.action.append(self.action.set_status, _("Running Add Command..."))
@@ -242,8 +244,7 @@ class GitAdd(Add):
         self.hide()
 
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Add"))
         self.action.append(self.action.set_status, _("Running Add Command..."))
@@ -253,10 +254,7 @@ class GitAdd(Add):
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNAdd,
-    rabbitvcs.vcs.VCS_GIT: GitAdd
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNAdd, rabbitvcs.vcs.VCS_GIT: GitAdd}
 
 
 def add_factory(paths, base_dir):
@@ -268,9 +266,7 @@ class AddQuiet(object):
     def __init__(self, paths):
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn
-        )
+        self.action = rabbitvcs.ui.action.SVNAction(self.svn)
 
         self.action.append(self.svn.add, paths)
         self.action.schedule()
@@ -278,9 +274,9 @@ class AddQuiet(object):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT, QUIET_OPT],
-        usage="Usage: rabbitvcs add [path1] [path2] ..."
+        [BASEDIR_OPT, QUIET_OPT], usage="Usage: rabbitvcs add [path1] [path2] ..."
     )
 
     if options.quiet:

--- a/rabbitvcs/ui/add.py
+++ b/rabbitvcs/ui/add.py
@@ -1,4 +1,15 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.vcs.status import Status
+from rabbitvcs.util.log import Log
+import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -29,26 +40,15 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util import helper
-from rabbitvcs.util.strings import S
-import rabbitvcs.vcs
-from rabbitvcs.util.log import Log
-from rabbitvcs.vcs.status import Status
 
 log = Log("rabbitvcs.ui.add")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
 helper.gobject_threads_init()
+
 
 class Add(InterfaceView, GtkContextMenuCaller):
     """
@@ -131,12 +131,12 @@ class Add(InterfaceView, GtkContextMenuCaller):
                                 should_add = False
 
                         if should_add:
-                            self.items.append(Status(os.path.realpath(ignored_path), 'unversioned'))
-
-
+                            self.items.append(
+                                Status(os.path.realpath(ignored_path), 'unversioned'))
 
         self.populate_files_table()
-        helper.run_in_main_thread(status.set_text, _("Found %d item(s)") % len(self.items))
+        helper.run_in_main_thread(status.set_text, _(
+            "Found %d item(s)") % len(self.items))
 
     def populate_files_table(self):
         self.files_table.clear()
@@ -226,6 +226,7 @@ class SVNAdd(Add):
         self.action.append(self.action.finish)
         self.action.schedule()
 
+
 class GitAdd(Add):
     def __init__(self, paths, base_dir=None):
         Add.__init__(self, paths, base_dir)
@@ -251,14 +252,17 @@ class GitAdd(Add):
         self.action.append(self.action.finish)
         self.action.schedule()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNAdd,
     rabbitvcs.vcs.VCS_GIT: GitAdd
 }
 
+
 def add_factory(paths, base_dir):
-    guess = rabbitvcs.vcs.guess (paths[0])
-    return classes_map[guess["vcs"]](paths,base_dir)
+    guess = rabbitvcs.vcs.guess(paths[0])
+    return classes_map[guess["vcs"]](paths, base_dir)
+
 
 class AddQuiet(object):
     def __init__(self, paths):
@@ -282,6 +286,7 @@ if __name__ == "__main__":
     if options.quiet:
         AddQuiet(paths)
     else:
-        window = add_factory(paths,options.base_dir)#Add(paths, options.base_dir)
+        # Add(paths, options.base_dir)
+        window = add_factory(paths, options.base_dir)
         window.register_gtk_quit()
         Gtk.main()

--- a/rabbitvcs/ui/annotate.py
+++ b/rabbitvcs/ui/annotate.py
@@ -1,4 +1,19 @@
 from __future__ import absolute_import
+from rabbitvcs.util.log import Log
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.util.settings import SettingsManager
+from rabbitvcs.util.highlighter import highlight
+from rabbitvcs.util.decorators import gtk_unsafe
+from rabbitvcs.util.strings import S
+from rabbitvcs.util.contextmenuitems import *
+from rabbitvcs.util.contextmenu import GtkContextMenu
+from rabbitvcs.ui.dialog import MessageBox, Loading
+from rabbitvcs.ui.widget import Clickable, Table, TYPE_MARKUP, TYPE_HIDDEN
+from rabbitvcs.ui.action import SVNAction, GitAction
+from rabbitvcs.ui.log import log_dialog_factory
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk, GLib
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -31,26 +46,11 @@ from rabbitvcs.util import helper
 from gi import require_version
 require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk, GLib
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.log import log_dialog_factory
-from rabbitvcs.ui.action import SVNAction, GitAction
-from rabbitvcs.ui.widget import Clickable, Table, TYPE_MARKUP, TYPE_HIDDEN
-from rabbitvcs.ui.dialog import MessageBox, Loading
-from rabbitvcs.util.contextmenu import GtkContextMenu
-from rabbitvcs.util.contextmenuitems import *
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.decorators import gtk_unsafe
-from rabbitvcs.util.highlighter import highlight
-from rabbitvcs.util.settings import SettingsManager
-import rabbitvcs.vcs
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
-from rabbitvcs.util.log import Log
 logger = Log("rabbitvcs.ui.annotate")
 
 
@@ -110,13 +110,14 @@ class Annotate(InterfaceView):
                 GObject.TYPE_STRING, TYPE_MARKUP, TYPE_HIDDEN, TYPE_HIDDEN],
             [_("Revision"), _("Author"), _("Date"), _("Line"), _("Text"),
                 "revision color", "author color"],
-            callbacks = {
+            callbacks={
                 "mouse-event":   self.on_annotate_table_mouse_event
             }
         )
         table.allow_multiple()
         table.get_column(3).get_cells()[0].set_property("xalign", 1.0)
-        treeview.connect("query-tooltip", self.on_query_tooltip, (0, (0, 1, 2)))
+        treeview.connect(
+            "query-tooltip", self.on_query_tooltip, (0, (0, 1, 2)))
         treeview.set_has_tooltip(True)
 
         if self.colorize:
@@ -176,7 +177,7 @@ class Annotate(InterfaceView):
         path, column, cellx, celly = t
         columns = treeview.get_columns()
         try:
-                pos = columns.index(column)
+            pos = columns.index(column)
         except ValueError:
             return False
         if not pos in enabled_columns:
@@ -416,11 +417,11 @@ class SVNAnnotate(Annotate):
         #   so this workaround is required for now
         datestr = item["date"][0:-8]
         try:
-            date = datetime(*time.strptime(datestr,"%Y-%m-%dT%H:%M:%S")[:-2])
+            date = datetime(*time.strptime(datestr, "%Y-%m-%dT%H:%M:%S")[:-2])
             date = helper.format_datetime(date, self.datetime_format)
         except:
             date = ""
- 
+
         return revision, date, S(item["author"].strip())
 
     def populate_table(self):
@@ -608,6 +609,7 @@ class MenuDiffRevisions(MenuItem):
     tooltip = _("View diff between selected revisions")
     icon = "rabbitvcs-diff"
 
+
 class MenuCompareRevisions(MenuItem):
     identifier = "RabbitVCS::Compare_Revisions"
     label = _("Compare revisions")
@@ -631,7 +633,7 @@ class AnnotateContextMenuConditions(object):
 
     def show_next_revision(self, data=None):
         return (len(self.revisions) == 1 and
-            not self.caller.next_revision(self.revisions[0]) is None)
+                not self.caller.next_revision(self.revisions[0]) is None)
 
     def diff_working_copy(self, data=None):
         return (self.vcs.is_in_a_or_a_working_copy(self.path) and
@@ -751,6 +753,7 @@ class AnnotateContextMenu(object):
     Defines context menu items for a table's rows
 
     """
+
     def __init__(self, caller, event, path, revisions=[]):
         """
         @param  caller: The calling object
@@ -814,6 +817,7 @@ classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNAnnotate,
     rabbitvcs.vcs.VCS_GIT: GitAnnotate
 }
+
 
 def annotate_factory(vcs, path, revision=None):
     if not vcs:

--- a/rabbitvcs/ui/annotate.py
+++ b/rabbitvcs/ui/annotate.py
@@ -14,6 +14,7 @@ from rabbitvcs.ui.action import SVNAction, GitAction
 from rabbitvcs.ui.log import log_dialog_factory
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk, GLib
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -44,6 +45,7 @@ from random import random, uniform
 from rabbitvcs.util import helper
 
 from gi import require_version
+
 require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -106,18 +108,29 @@ class Annotate(InterfaceView):
         treeview = self.get_widget("table")
         table = Table(
             treeview,
-            [GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING,
-                GObject.TYPE_STRING, TYPE_MARKUP, TYPE_HIDDEN, TYPE_HIDDEN],
-            [_("Revision"), _("Author"), _("Date"), _("Line"), _("Text"),
-                "revision color", "author color"],
-            callbacks={
-                "mouse-event":   self.on_annotate_table_mouse_event
-            }
+            [
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                TYPE_MARKUP,
+                TYPE_HIDDEN,
+                TYPE_HIDDEN,
+            ],
+            [
+                _("Revision"),
+                _("Author"),
+                _("Date"),
+                _("Line"),
+                _("Text"),
+                "revision color",
+                "author color",
+            ],
+            callbacks={"mouse-event": self.on_annotate_table_mouse_event},
         )
         table.allow_multiple()
         table.get_column(3).get_cells()[0].set_property("xalign", 1.0)
-        treeview.connect(
-            "query-tooltip", self.on_query_tooltip, (0, (0, 1, 2)))
+        treeview.connect("query-tooltip", self.on_query_tooltip, (0, (0, 1, 2)))
         treeview.set_has_tooltip(True)
 
         if self.colorize:
@@ -206,14 +219,16 @@ class Annotate(InterfaceView):
         self.show_revision(forceload=forceload)
 
     def on_history_prev(self, clickable, widget, event, *args):
-        forceload = (self.history[self.history_index] !=
-                     self.history[self.history_index - 1])
+        forceload = (
+            self.history[self.history_index] != self.history[self.history_index - 1]
+        )
         self.history_index -= 1
         self.show_revision(forceload=forceload)
 
     def on_history_next(self, clickable, widget, event, *args):
-        forceload = (self.history[self.history_index] !=
-                     self.history[self.history_index + 1])
+        forceload = (
+            self.history[self.history_index] != self.history[self.history_index + 1]
+        )
         self.history_index += 1
         self.show_revision(forceload=forceload)
 
@@ -225,13 +240,14 @@ class Annotate(InterfaceView):
     def history_popup_menu(self, clickable, widget, event, *args):
         menu = Gtk.Menu()
         width = 0
-        for i, revision in list(enumerate(self.history))[:self.history_index + 6][-11:]:
+        for i, revision in list(enumerate(self.history))[: self.history_index + 6][
+            -11:
+        ]:
             message = ""
             revision = self.short_revision(revision)
             if revision in self.log_by_revision:
                 log = self.log_by_revision[revision]
-                message = helper.format_long_text(log.message,
-                                                  cols=32, line1only=True)
+                message = helper.format_long_text(log.message, cols=32, line1only=True)
             revision = helper.html_escape(revision)
             message = helper.html_escape(message)
             if i == self.history_index:
@@ -239,11 +255,11 @@ class Annotate(InterfaceView):
                 message = "<b>" + message + "</b>"
             row = Gtk.Grid()
             cell1 = Gtk.Label()
-            cell1.set_properties(xalign=0, yalign=.5)
+            cell1.set_properties(xalign=0, yalign=0.5)
             cell1.set_markup(revision)
             row.attach(cell1, 0, 0, 1, 1)
             cell2 = Gtk.Label()
-            cell2.set_properties(xalign=0, yalign=.5)
+            cell2.set_properties(xalign=0, yalign=0.5)
             cell2.set_markup(message)
             row.attach(cell2, 1, 0, 1, 1)
             menuitem = Gtk.MenuItem()
@@ -280,7 +296,7 @@ class Annotate(InterfaceView):
         if revision.lower() != self.history[self.history_index].lower():
             forceload = True
             self.history_index += 1
-            self.history = self.history[:self.history_index] + [revision]
+            self.history = self.history[: self.history_index] + [revision]
         self.set_history_sensitive()
         if forceload:
             self.load(revision)
@@ -294,6 +310,7 @@ class Annotate(InterfaceView):
     def save(self, path=None):
         if path is None:
             from rabbitvcs.ui.dialog import FileSaveAs
+
             dialog = FileSaveAs()
             path = dialog.run()
 
@@ -379,16 +396,9 @@ class SVNAnnotate(Annotate):
 
         self.launch_loading()
 
-        self.action = SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.action = SVNAction(self.svn, notification=False)
 
-        self.action.append(
-            self.svn.annotate,
-            self.path,
-            to_revision=rev
-        )
+        self.action.append(self.svn.annotate, self.path, to_revision=rev)
 
         if not self.log_by_order:
             self.action.append(self.svn.log, self.path)
@@ -437,15 +447,17 @@ class SVNAnnotate(Annotate):
             except KeyError:
                 revision_color = "#FFFFFF"
 
-            self.table.append([
-                revision,
-                author,
-                date,
-                str(int(item["number"]) + 1),
-                lines[i],
-                revision_color,
-                author_color
-            ])
+            self.table.append(
+                [
+                    revision,
+                    author,
+                    date,
+                    str(int(item["number"]) + 1),
+                    lines[i],
+                    revision_color,
+                    author_color,
+                ]
+            )
 
     def generate_string_from_result(self):
         blamedict = self.action.get_result(0)
@@ -459,7 +471,7 @@ class SVNAnnotate(Annotate):
                 revision,
                 author,
                 date,
-                item["line"]
+                item["line"],
             )
 
         return text
@@ -490,16 +502,9 @@ class GitAnnotate(Annotate):
     def load(self, revision):
         self.launch_loading()
 
-        self.action = GitAction(
-            self.git,
-            notification=False
-        )
+        self.action = GitAction(self.git, notification=False)
 
-        self.action.append(
-            self.git.annotate,
-            self.path,
-            self.git.revision(revision)
-        )
+        self.action.append(self.git.annotate, self.path, self.git.revision(revision))
 
         if not self.log_by_order:
             self.action.append(self.git.log, self.path)
@@ -524,15 +529,17 @@ class GitAnnotate(Annotate):
             except KeyError:
                 revision_color = "#FFFFFF"
 
-            self.table.append([
-                revision,
-                author,
-                helper.format_datetime(item["date"], self.datetime_format),
-                str(item["number"]),
-                lines[i],
-                revision_color,
-                author_color
-            ])
+            self.table.append(
+                [
+                    revision,
+                    author,
+                    helper.format_datetime(item["date"], self.datetime_format),
+                    str(item["number"]),
+                    lines[i],
+                    revision_color,
+                    author_color,
+                ]
+            )
 
     def generate_string_from_result(self):
         blamedict = self.action.get_result(0)
@@ -544,7 +551,7 @@ class GitAnnotate(Annotate):
                 item["revision"][:7],
                 item["author"],
                 helper.format_datetime(item["date"], self.datetime_format),
-                item["line"]
+                item["line"],
             )
 
         return text
@@ -632,34 +639,44 @@ class AnnotateContextMenuConditions(object):
         return len(self.revisions) == 1
 
     def show_next_revision(self, data=None):
-        return (len(self.revisions) == 1 and
-                not self.caller.next_revision(self.revisions[0]) is None)
+        return (
+            len(self.revisions) == 1
+            and not self.caller.next_revision(self.revisions[0]) is None
+        )
 
     def diff_working_copy(self, data=None):
-        return (self.vcs.is_in_a_or_a_working_copy(self.path) and
-                len(self.revisions) == 1)
+        return (
+            self.vcs.is_in_a_or_a_working_copy(self.path) and len(self.revisions) == 1
+        )
 
     def compare_working_copy(self, data=None):
-        return (self.vcs.is_in_a_or_a_working_copy(self.path) and
-                len(self.revisions) == 1)
+        return (
+            self.vcs.is_in_a_or_a_working_copy(self.path) and len(self.revisions) == 1
+        )
 
     def diff_previous_revision(self, data=None):
-        return (self.vcs.is_in_a_or_a_working_copy(self.path) and
-                len(self.revisions) == 1 and
-                not self.caller.previous_revision(self.revisions[0]) is None)
+        return (
+            self.vcs.is_in_a_or_a_working_copy(self.path)
+            and len(self.revisions) == 1
+            and not self.caller.previous_revision(self.revisions[0]) is None
+        )
 
     def compare_previous_revision(self, data=None):
-        return (self.vcs.is_in_a_or_a_working_copy(self.path) and
-                len(self.revisions) == 1 and
-                not self.caller.previous_revision(self.revisions[0]) is None)
+        return (
+            self.vcs.is_in_a_or_a_working_copy(self.path)
+            and len(self.revisions) == 1
+            and not self.caller.previous_revision(self.revisions[0]) is None
+        )
 
     def diff_revisions(self, data=None):
-        return (self.vcs.is_in_a_or_a_working_copy(self.path) and
-                len(self.revisions) == 2)
+        return (
+            self.vcs.is_in_a_or_a_working_copy(self.path) and len(self.revisions) == 2
+        )
 
     def compare_revisions(self, data=None):
-        return (self.vcs.is_in_a_or_a_working_copy(self.path) and
-                len(self.revisions) == 2)
+        return (
+            self.vcs.is_in_a_or_a_working_copy(self.path) and len(self.revisions) == 2
+        )
 
 
 class AnnotateContextMenuCallbacks(object):
@@ -674,39 +691,53 @@ class AnnotateContextMenuCallbacks(object):
         self.caller.show_revision(self.revisions[0])
 
     def view_revision(self, widget, data=None):
-        helper.launch_ui_window("annotate", [
-            self.path,
-            "--vcs=%s" % self.caller.get_vcs_name(),
-            "-r", self.revisions[0]])
+        helper.launch_ui_window(
+            "annotate",
+            [
+                self.path,
+                "--vcs=%s" % self.caller.get_vcs_name(),
+                "-r",
+                self.revisions[0],
+            ],
+        )
 
     def show_next_revision(self, widget, data=None):
         self.caller.show_revision(self.caller.next_revision(self.revisions[0]))
 
     def diff_working_copy(self, widget, data=None):
-        helper.launch_ui_window("diff", [
-            "%s@%s" % (self.path, S(self.revisions[0])),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "%s@%s" % (self.path, S(self.revisions[0])),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def compare_working_copy(self, widget, data=None):
         path_older = self.path
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path_older = self.vcs.svn().get_repo_url(self.path)
 
-        helper.launch_ui_window("diff", [
-            "-s",
-            "%s@%s" % (path_older, S(self.revisions[0])),
-            self.path,
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "-s",
+                "%s@%s" % (path_older, S(self.revisions[0])),
+                self.path,
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def diff_previous_revision(self, widget, data=None):
         prev = self.caller.previous_revision(self.revisions[0])
-        helper.launch_ui_window("diff", [
-            "%s@%s" % (self.path, S(prev)),
-            "%s@%s" % (self.path, S(self.revisions[0])),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "%s@%s" % (self.path, S(prev)),
+                "%s@%s" % (self.path, S(self.revisions[0])),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def compare_previous_revision(self, widget, data=None):
         prev = self.caller.previous_revision(self.revisions[0])
@@ -714,23 +745,29 @@ class AnnotateContextMenuCallbacks(object):
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path_older = self.vcs.svn().get_repo_url(self.path)
 
-        helper.launch_ui_window("diff", [
-            "-s",
-            "%s@%s" % (path_older, S(prev)),
-            "%s@%s" % (self.path, S(self.revisions[0])),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "-s",
+                "%s@%s" % (path_older, S(prev)),
+                "%s@%s" % (self.path, S(self.revisions[0])),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def diff_revisions(self, widget, data=None):
         rev1 = self.revisions[0]
         rev2 = self.revisions[-1]
         if self.caller.compare_revision_order(rev1, rev2) > 0:
             rev1, rev2 = rev2, rev1
-        helper.launch_ui_window("diff", [
-            "%s@%s" % (self.path, S(rev1)),
-            "%s@%s" % (self.path, S(rev2)),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "%s@%s" % (self.path, S(rev1)),
+                "%s@%s" % (self.path, S(rev2)),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def compare_revisions(self, widget, data=None):
         rev1 = self.revisions[0]
@@ -740,12 +777,15 @@ class AnnotateContextMenuCallbacks(object):
         path_older = self.path
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path_older = self.vcs.svn().get_repo_url(self.path)
-        helper.launch_ui_window("diff", [
-            "-s",
-            "%s@%s" % (path_older, S(rev1)),
-            "%s@%s" % (self.path, S(rev2)),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "-s",
+                "%s@%s" % (path_older, S(rev1)),
+                "%s@%s" % (self.path, S(rev2)),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
 
 class AnnotateContextMenu(object):
@@ -776,17 +816,11 @@ class AnnotateContextMenu(object):
         self.vcs = rabbitvcs.vcs.VCS()
 
         self.conditions = AnnotateContextMenuConditions(
-            self.caller,
-            self.vcs,
-            self.path,
-            self.revisions
+            self.caller, self.vcs, self.path, self.revisions
         )
 
         self.callbacks = AnnotateContextMenuCallbacks(
-            self.caller,
-            self.vcs,
-            self.path,
-            self.revisions
+            self.caller, self.vcs, self.path, self.revisions
         )
 
         # The first element of each tuple is a key that matches a
@@ -808,15 +842,11 @@ class AnnotateContextMenu(object):
         if len(self.revisions) == 0:
             return
 
-        context_menu = GtkContextMenu(self.structure,
-                                      self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNAnnotate,
-    rabbitvcs.vcs.VCS_GIT: GitAnnotate
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNAnnotate, rabbitvcs.vcs.VCS_GIT: GitAnnotate}
 
 
 def annotate_factory(vcs, path, revision=None):
@@ -829,9 +859,9 @@ def annotate_factory(vcs, path, revision=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT
+
     (options, paths) = main(
-        [REVISION_OPT, VCS_OPT],
-        usage="Usage: rabbitvcs annotate url [-r REVISION]"
+        [REVISION_OPT, VCS_OPT], usage="Usage: rabbitvcs annotate url [-r REVISION]"
     )
 
     window = annotate_factory(options.vcs, paths[0], options.revision)

--- a/rabbitvcs/ui/applypatch.py
+++ b/rabbitvcs/ui/applypatch.py
@@ -5,6 +5,7 @@ import rabbitvcs.vcs
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui import InterfaceNonView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -32,6 +33,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -58,9 +60,8 @@ class ApplyPatch(InterfaceNonView):
         path = None
 
         dialog = Gtk.FileChooserDialog(
-            title=_("Apply Patch"),
-            parent=None,
-            action=Gtk.FileChooserAction.OPEN)
+            title=_("Apply Patch"), parent=None, action=Gtk.FileChooserAction.OPEN
+        )
         dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("_Open"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
@@ -81,7 +82,8 @@ class ApplyPatch(InterfaceNonView):
         dialog = Gtk.FileChooserDialog(
             title=_("Apply Patch To Directory..."),
             parent=None,
-            action=Gtk.FileChooserAction.SELECT_FOLDER)
+            action=Gtk.FileChooserAction.SELECT_FOLDER,
+        )
         dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("_Select"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
@@ -115,8 +117,7 @@ class SVNApplyPatch(ApplyPatch):
 
         ticks = 2
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.set_pbar_ticks(ticks)
         self.action.append(self.action.set_header, _("Apply Patch"))
@@ -146,8 +147,7 @@ class GitApplyPatch(ApplyPatch):
 
         ticks = 2
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.set_pbar_ticks(ticks)
         self.action.append(self.action.set_header, _("Apply Patch"))
@@ -160,7 +160,7 @@ class GitApplyPatch(ApplyPatch):
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNApplyPatch,
-    rabbitvcs.vcs.VCS_GIT: GitApplyPatch
+    rabbitvcs.vcs.VCS_GIT: GitApplyPatch,
 }
 
 
@@ -171,8 +171,8 @@ def applypatch_factory(paths):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
-    (options, paths) = main(
-        usage="Usage: rabbitvcs applypatch [path1] [path2] ...")
+
+    (options, paths) = main(usage="Usage: rabbitvcs applypatch [path1] [path2] ...")
 
     window = applypatch_factory(paths)
     window.register_gtk_quit()

--- a/rabbitvcs/ui/applypatch.py
+++ b/rabbitvcs/ui/applypatch.py
@@ -1,4 +1,10 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+import rabbitvcs.vcs
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui import InterfaceNonView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,18 +34,13 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceNonView
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.vcs
-from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.applypatch")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class ApplyPatch(InterfaceNonView):
     """
@@ -57,9 +58,9 @@ class ApplyPatch(InterfaceNonView):
         path = None
 
         dialog = Gtk.FileChooserDialog(
-            title = _("Apply Patch"),
-            parent = None,
-            action = Gtk.FileChooserAction.OPEN)
+            title=_("Apply Patch"),
+            parent=None,
+            action=Gtk.FileChooserAction.OPEN)
         dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("_Open"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
@@ -78,9 +79,9 @@ class ApplyPatch(InterfaceNonView):
         dir = None
 
         dialog = Gtk.FileChooserDialog(
-                title = _("Apply Patch To Directory..."),
-                parent = None,
-                action = Gtk.FileChooserAction.SELECT_FOLDER)
+            title=_("Apply Patch To Directory..."),
+            parent=None,
+            action=Gtk.FileChooserAction.SELECT_FOLDER)
         dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("_Select"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
@@ -93,6 +94,7 @@ class ApplyPatch(InterfaceNonView):
         dialog.destroy()
 
         return dir
+
 
 class SVNApplyPatch(ApplyPatch):
     def __init__(self, paths):
@@ -124,6 +126,7 @@ class SVNApplyPatch(ApplyPatch):
         self.action.append(self.action.finish)
         self.action.schedule()
 
+
 class GitApplyPatch(ApplyPatch):
     def __init__(self, paths):
         ApplyPatch.__init__(self, paths)
@@ -154,10 +157,12 @@ class GitApplyPatch(ApplyPatch):
         self.action.append(self.action.finish)
         self.action.schedule()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNApplyPatch,
     rabbitvcs.vcs.VCS_GIT: GitApplyPatch
 }
+
 
 def applypatch_factory(paths):
     guess = rabbitvcs.vcs.guess(paths[0])
@@ -166,10 +171,10 @@ def applypatch_factory(paths):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
-    (options, paths) = main(usage="Usage: rabbitvcs applypatch [path1] [path2] ...")
+    (options, paths) = main(
+        usage="Usage: rabbitvcs applypatch [path1] [path2] ...")
 
     window = applypatch_factory(paths)
     window.register_gtk_quit()
     window.start()
     Gtk.main()
-

--- a/rabbitvcs/ui/branch.py
+++ b/rabbitvcs/ui/branch.py
@@ -8,6 +8,7 @@ import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -33,6 +34,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -49,6 +51,7 @@ class SVNBranch(InterfaceView):
     Pass a single path to the class when initializing
 
     """
+
     SETTINGS = rabbitvcs.util.settings.SettingsManager()
 
     SWITCH_AFTER = SETTINGS.get("general", "switch_after_branch")
@@ -66,33 +69,28 @@ class SVNBranch(InterfaceView):
 
         repo_paths = helper.get_repository_paths()
         self.from_urls = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("from_urls"),
-            repo_paths
+            self.get_widget("from_urls"), repo_paths
         )
         self.to_urls = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("to_urls"),
-            helper.get_repository_paths()
+            self.get_widget("to_urls"), helper.get_repository_paths()
         )
 
         repository_url = self.svn.get_repo_url(path)
         self.from_urls.set_child_text(repository_url)
         self.to_urls.set_child_text(repository_url)
 
-        self.message = rabbitvcs.ui.widget.TextView(
-            self.get_widget("message")
-        )
-        self.get_widget("toggle_switch_after_branch").set_active(
-            self.SWITCH_AFTER)
+        self.message = rabbitvcs.ui.widget.TextView(self.get_widget("message"))
+        self.get_widget("toggle_switch_after_branch").set_active(self.SWITCH_AFTER)
 
         self.revision_selector = rabbitvcs.ui.widget.RevisionSelector(
             self.get_widget("revision_container"),
             self.svn,
             revision=revision,
             url_combobox=self.from_urls,
-            expand=True
+            expand=True,
         )
 
-        if (self.revision is None and status.has_modified()):
+        if self.revision is None and status.has_modified():
             self.revision_selector.set_kind_working()
 
     def on_ok_clicked(self, widget):
@@ -100,37 +98,27 @@ class SVNBranch(InterfaceView):
         dest = self.to_urls.get_active_text()
 
         if dest == "":
-            rabbitvcs.ui.dialog.MessageBox(
-                _("You must supply a destination path."))
+            rabbitvcs.ui.dialog.MessageBox(_("You must supply a destination path."))
             return
 
         revision = self.revision_selector.get_revision_object()
         self.hide()
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.set_log_message(self.message.get_text())
 
-        self.action.append(
-            helper.save_log_message,
-            self.message.get_text()
-        )
+        self.action.append(helper.save_log_message, self.message.get_text())
 
         self.action.append(self.action.set_header, _("Branch/tag"))
-        self.action.append(self.action.set_status, _(
-            "Running Branch/tag Command..."))
+        self.action.append(self.action.set_status, _("Running Branch/tag Command..."))
         self.action.append(self.svn.copy, src, dest, revision)
         self.action.append(self.action.set_status, _("Completed Branch/tag"))
         if self.SWITCH_AFTER:
-            self.action.append(self.action.set_status,
-                               _("Running Switch Command..."))
+            self.action.append(self.action.set_status, _("Running Switch Command..."))
             self.action.append(helper.save_repository_path, dest)
             self.action.append(
-                self.svn.switch,
-                self.path,
-                helper.quote_url(dest),
-                revision=revision
+                self.svn.switch, self.path, helper.quote_url(dest), revision=revision
             )
             self.action.append(self.action.set_status, _("Completed Switch"))
 
@@ -145,8 +133,10 @@ class SVNBranch(InterfaceView):
 
     def on_repo_browser_clicked(self, widget, data=None):
         from rabbitvcs.ui.browser import SVNBrowserDialog
-        SVNBrowserDialog(self.from_urls.get_active_text(),
-                         callback=self.on_repo_browser_closed)
+
+        SVNBrowserDialog(
+            self.from_urls.get_active_text(), callback=self.on_repo_browser_closed
+        )
 
     def on_repo_browser_closed(self, new_url):
         self.from_urls.set_child_text(new_url)
@@ -156,16 +146,11 @@ class SVNBranch(InterfaceView):
 
         # Save this preference for future commits.
         if self.SETTINGS.get("general", "switch_after_branch") != self.SWITCH_AFTER:
-            self.SETTINGS.set(
-                "general", "switch_after_branch",
-                self.SWITCH_AFTER
-            )
+            self.SETTINGS.set("general", "switch_after_branch", self.SWITCH_AFTER)
             self.SETTINGS.write()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNBranch
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNBranch}
 
 
 def branch_factory(vcs, path, revision=None):
@@ -178,9 +163,9 @@ def branch_factory(vcs, path, revision=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT
+
     (options, args) = main(
-        [REVISION_OPT, VCS_OPT],
-        usage="Usage: rabbitvcs branch [url_or_path]"
+        [REVISION_OPT, VCS_OPT], usage="Usage: rabbitvcs branch [url_or_path]"
     )
 
     window = branch_factory(options.vcs, args[0], options.revision)

--- a/rabbitvcs/ui/branch.py
+++ b/rabbitvcs/ui/branch.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs.status
+import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,19 +35,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util.strings import S
-import rabbitvcs.vcs
-import rabbitvcs.vcs.status
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNBranch(InterfaceView):
     """
@@ -80,7 +81,8 @@ class SVNBranch(InterfaceView):
         self.message = rabbitvcs.ui.widget.TextView(
             self.get_widget("message")
         )
-        self.get_widget("toggle_switch_after_branch").set_active(self.SWITCH_AFTER)
+        self.get_widget("toggle_switch_after_branch").set_active(
+            self.SWITCH_AFTER)
 
         self.revision_selector = rabbitvcs.ui.widget.RevisionSelector(
             self.get_widget("revision_container"),
@@ -98,7 +100,8 @@ class SVNBranch(InterfaceView):
         dest = self.to_urls.get_active_text()
 
         if dest == "":
-            rabbitvcs.ui.dialog.MessageBox(_("You must supply a destination path."))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("You must supply a destination path."))
             return
 
         revision = self.revision_selector.get_revision_object()
@@ -115,11 +118,13 @@ class SVNBranch(InterfaceView):
         )
 
         self.action.append(self.action.set_header, _("Branch/tag"))
-        self.action.append(self.action.set_status, _("Running Branch/tag Command..."))
+        self.action.append(self.action.set_status, _(
+            "Running Branch/tag Command..."))
         self.action.append(self.svn.copy, src, dest, revision)
         self.action.append(self.action.set_status, _("Completed Branch/tag"))
         if self.SWITCH_AFTER:
-            self.action.append(self.action.set_status, _("Running Switch Command..."))
+            self.action.append(self.action.set_status,
+                               _("Running Switch Command..."))
             self.action.append(helper.save_repository_path, dest)
             self.action.append(
                 self.svn.switch,
@@ -141,7 +146,7 @@ class SVNBranch(InterfaceView):
     def on_repo_browser_clicked(self, widget, data=None):
         from rabbitvcs.ui.browser import SVNBrowserDialog
         SVNBrowserDialog(self.from_urls.get_active_text(),
-            callback=self.on_repo_browser_closed)
+                         callback=self.on_repo_browser_closed)
 
     def on_repo_browser_closed(self, new_url):
         self.from_urls.set_child_text(new_url)
@@ -157,9 +162,11 @@ class SVNBranch(InterfaceView):
             )
             self.SETTINGS.write()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNBranch
 }
+
 
 def branch_factory(vcs, path, revision=None):
     if not vcs:

--- a/rabbitvcs/ui/branches.py
+++ b/rabbitvcs/ui/branches.py
@@ -1,4 +1,16 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from xml.sax import saxutils
+import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
+from rabbitvcs.ui.dialog import DeleteConfirmation
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.log import log_dialog_factory
+from rabbitvcs.ui.action import GitAction
+from rabbitvcs.ui import InterfaceView
+import time
+from datetime import datetime
+from gi.repository import Gtk, GObject, Gdk, Pango
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,27 +40,14 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk, Pango
 sa.restore()
 
-from datetime import datetime
-import time
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import GitAction
-from rabbitvcs.ui.log import log_dialog_factory
-import rabbitvcs.ui.widget
-from rabbitvcs.ui.dialog import DeleteConfirmation
-from rabbitvcs.util.strings import S
-import rabbitvcs.vcs
-
-from xml.sax import saxutils
-
-from rabbitvcs import gettext
 _ = gettext.gettext
 
 STATE_ADD = 0
 STATE_EDIT = 1
+
 
 class GitBranchManager(InterfaceView):
     """
@@ -104,7 +103,7 @@ class GitBranchManager(InterfaceView):
         row = 0
 
         # Set up the Branch line
-        label = Gtk.Label(label = _("Name:"))
+        label = Gtk.Label(label=_("Name:"))
         label.set_properties(xalign=0, yalign=.5)
         self.branch_entry = Gtk.Entry()
         self.branch_entry.set_hexpand(True)
@@ -114,15 +113,17 @@ class GitBranchManager(InterfaceView):
         row = row + 1
 
         # Set up the Commit-sha line
-        label = Gtk.Label(label = _("Start Point:"))
+        label = Gtk.Label(label=_("Start Point:"))
         label.set_properties(xalign=0, yalign=.5)
         self.start_point_entry = Gtk.Entry()
         self.start_point_entry.set_size_request(300, -1)
         self.start_point_entry.set_hexpand(True)
         self.log_dialog_button = Gtk.Button()
-        self.log_dialog_button.connect("clicked", self.on_log_dialog_button_clicked)
+        self.log_dialog_button.connect(
+            "clicked", self.on_log_dialog_button_clicked)
         image = Gtk.Image()
-        image.set_from_icon_name("rabbitvcs-show_log", Gtk.IconSize.SMALL_TOOLBAR)
+        image.set_from_icon_name("rabbitvcs-show_log",
+                                 Gtk.IconSize.SMALL_TOOLBAR)
         self.log_dialog_button.set_image(image)
         self.detail_grid.attach(label, 0, row, 1, 1)
         self.detail_grid.attach(self.start_point_entry, 1, row, 1, 1)
@@ -131,13 +132,15 @@ class GitBranchManager(InterfaceView):
         row = row + 1
 
         # Set up the Track line
-        self.track_checkbox = Gtk.CheckButton(label = _("Keep old branch's history"))
+        self.track_checkbox = Gtk.CheckButton(
+            label=_("Keep old branch's history"))
         self.detail_grid.attach(self.track_checkbox, 1, row, 2, 1)
         track_row = row
         row = row + 1
 
         # Set up the checkout line
-        self.checkout_checkbox = Gtk.CheckButton(label = _("Set as active branch"))
+        self.checkout_checkbox = Gtk.CheckButton(
+            label=_("Set as active branch"))
         self.detail_grid.attach(self.checkout_checkbox, 1, row, 2, 1)
         checkout_row = row
         row = row + 1
@@ -151,9 +154,9 @@ class GitBranchManager(InterfaceView):
         row = row + 1
 
         # Set up the Revision line
-        label = Gtk.Label(label = _("Revision:"))
-        label.set_properties(xalign=0,yalign=0)
-        self.revision_label = Gtk.Label(label = "")
+        label = Gtk.Label(label=_("Revision:"))
+        label.set_properties(xalign=0, yalign=0)
+        self.revision_label = Gtk.Label(label="")
         self.revision_label.set_properties(xalign=0, selectable=True)
         self.revision_label.set_line_wrap(True)
         self.revision_label.set_hexpand(True)
@@ -163,9 +166,9 @@ class GitBranchManager(InterfaceView):
         row = row + 1
 
         # Set up the Log Message line
-        label = Gtk.Label(label = _("Message:"))
+        label = Gtk.Label(label=_("Message:"))
         label.set_properties(xalign=0, yalign=0)
-        self.message_label = Gtk.Label(label = "")
+        self.message_label = Gtk.Label(label="")
         self.message_label.set_properties(xalign=0, yalign=0, selectable=True)
         self.message_label.set_line_wrap(True)
         self.message_label.set_hexpand(True)
@@ -175,10 +178,10 @@ class GitBranchManager(InterfaceView):
         row = row + 1
 
         self.add_rows = [branch_name_row, track_row, save_row, start_point_row,
-            checkout_row]
+                         checkout_row]
 
         self.view_rows = [branch_name_row, revision_row, message_row, save_row,
-             checkout_row]
+                          checkout_row]
 
         self.detail_grid.show()
         self.detail_container.add(self.detail_grid)
@@ -201,9 +204,11 @@ class GitBranchManager(InterfaceView):
 
         selected = []
         for branch in items:
-            selected.append(saxutils.unescape(branch).replace("<b>", "").replace("</b>", ""))
+            selected.append(saxutils.unescape(branch).replace(
+                "<b>", "").replace("</b>", ""))
 
-        confirm = rabbitvcs.ui.dialog.Confirmation(_("Are you sure you want to delete %s?" % ", ".join(selected)))
+        confirm = rabbitvcs.ui.dialog.Confirmation(
+            _("Are you sure you want to delete %s?" % ", ".join(selected)))
         result = confirm.run()
 
         if result == Gtk.ResponseType.OK or result == True:
@@ -294,8 +299,10 @@ class GitBranchManager(InterfaceView):
 
         if self.selected_branch:
             self.branch_entry.set_text(S(self.selected_branch.name).display())
-            self.revision_label.set_text(S(self.selected_branch.revision).display())
-            self.message_label.set_text(S(self.selected_branch.message.rstrip("\n")).display())
+            self.revision_label.set_text(
+                S(self.selected_branch.revision).display())
+            self.message_label.set_text(
+                S(self.selected_branch.message.rstrip("\n")).display())
             if self.selected_branch.tracking:
                 self.checkout_checkbox.set_active(True)
                 self.checkout_checkbox.set_sensitive(False)

--- a/rabbitvcs/ui/branches.py
+++ b/rabbitvcs/ui/branches.py
@@ -11,6 +11,7 @@ from rabbitvcs.ui import InterfaceView
 import time
 from datetime import datetime
 from gi.repository import Gtk, GObject, Gdk, Pango
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -38,6 +39,7 @@ import os
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -77,9 +79,9 @@ class GitBranchManager(InterfaceView):
             [rabbitvcs.ui.widget.TYPE_MARKUP],
             [_("Branch")],
             callbacks={
-                "mouse-event":   self.on_treeview_mouse_event,
-                "key-event":     self.on_treeview_key_event
-            }
+                "mouse-event": self.on_treeview_mouse_event,
+                "key-event": self.on_treeview_key_event,
+            },
         )
         self.initialize_detail()
         self.load()
@@ -104,7 +106,7 @@ class GitBranchManager(InterfaceView):
 
         # Set up the Branch line
         label = Gtk.Label(label=_("Name:"))
-        label.set_properties(xalign=0, yalign=.5)
+        label.set_properties(xalign=0, yalign=0.5)
         self.branch_entry = Gtk.Entry()
         self.branch_entry.set_hexpand(True)
         self.detail_grid.attach(label, 0, row, 1, 1)
@@ -114,16 +116,14 @@ class GitBranchManager(InterfaceView):
 
         # Set up the Commit-sha line
         label = Gtk.Label(label=_("Start Point:"))
-        label.set_properties(xalign=0, yalign=.5)
+        label.set_properties(xalign=0, yalign=0.5)
         self.start_point_entry = Gtk.Entry()
         self.start_point_entry.set_size_request(300, -1)
         self.start_point_entry.set_hexpand(True)
         self.log_dialog_button = Gtk.Button()
-        self.log_dialog_button.connect(
-            "clicked", self.on_log_dialog_button_clicked)
+        self.log_dialog_button.connect("clicked", self.on_log_dialog_button_clicked)
         image = Gtk.Image()
-        image.set_from_icon_name("rabbitvcs-show_log",
-                                 Gtk.IconSize.SMALL_TOOLBAR)
+        image.set_from_icon_name("rabbitvcs-show_log", Gtk.IconSize.SMALL_TOOLBAR)
         self.log_dialog_button.set_image(image)
         self.detail_grid.attach(label, 0, row, 1, 1)
         self.detail_grid.attach(self.start_point_entry, 1, row, 1, 1)
@@ -132,15 +132,13 @@ class GitBranchManager(InterfaceView):
         row = row + 1
 
         # Set up the Track line
-        self.track_checkbox = Gtk.CheckButton(
-            label=_("Keep old branch's history"))
+        self.track_checkbox = Gtk.CheckButton(label=_("Keep old branch's history"))
         self.detail_grid.attach(self.track_checkbox, 1, row, 2, 1)
         track_row = row
         row = row + 1
 
         # Set up the checkout line
-        self.checkout_checkbox = Gtk.CheckButton(
-            label=_("Set as active branch"))
+        self.checkout_checkbox = Gtk.CheckButton(label=_("Set as active branch"))
         self.detail_grid.attach(self.checkout_checkbox, 1, row, 2, 1)
         checkout_row = row
         row = row + 1
@@ -177,11 +175,21 @@ class GitBranchManager(InterfaceView):
         message_row = row
         row = row + 1
 
-        self.add_rows = [branch_name_row, track_row, save_row, start_point_row,
-                         checkout_row]
+        self.add_rows = [
+            branch_name_row,
+            track_row,
+            save_row,
+            start_point_row,
+            checkout_row,
+        ]
 
-        self.view_rows = [branch_name_row, revision_row, message_row, save_row,
-                          checkout_row]
+        self.view_rows = [
+            branch_name_row,
+            revision_row,
+            message_row,
+            save_row,
+            checkout_row,
+        ]
 
         self.detail_grid.show()
         self.detail_container.add(self.detail_grid)
@@ -204,11 +212,13 @@ class GitBranchManager(InterfaceView):
 
         selected = []
         for branch in items:
-            selected.append(saxutils.unescape(branch).replace(
-                "<b>", "").replace("</b>", ""))
+            selected.append(
+                saxutils.unescape(branch).replace("<b>", "").replace("</b>", "")
+            )
 
         confirm = rabbitvcs.ui.dialog.Confirmation(
-            _("Are you sure you want to delete %s?" % ", ".join(selected)))
+            _("Are you sure you want to delete %s?" % ", ".join(selected))
+        )
         result = confirm.run()
 
         if result == Gtk.ResponseType.OK or result == True:
@@ -299,10 +309,10 @@ class GitBranchManager(InterfaceView):
 
         if self.selected_branch:
             self.branch_entry.set_text(S(self.selected_branch.name).display())
-            self.revision_label.set_text(
-                S(self.selected_branch.revision).display())
+            self.revision_label.set_text(S(self.selected_branch.revision).display())
             self.message_label.set_text(
-                S(self.selected_branch.message.rstrip("\n")).display())
+                S(self.selected_branch.message.rstrip("\n")).display()
+            )
             if self.selected_branch.tracking:
                 self.checkout_checkbox.set_active(True)
                 self.checkout_checkbox.set_sensitive(False)
@@ -314,10 +324,7 @@ class GitBranchManager(InterfaceView):
         self.get_widget("detail_label").set_markup(_("<b>Branch Detail</b>"))
 
     def on_log_dialog_button_clicked(self, widget):
-        log_dialog_factory(
-            self.path,
-            ok_callback=self.on_log_dialog_closed
-        )
+        log_dialog_factory(self.path, ok_callback=self.on_log_dialog_closed)
 
     def on_log_dialog_closed(self, data):
         if data:
@@ -326,9 +333,10 @@ class GitBranchManager(InterfaceView):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT
+
     (options, paths) = main(
         [REVISION_OPT, VCS_OPT],
-        usage="Usage: rabbitvcs branch-manager path [-r revision]"
+        usage="Usage: rabbitvcs branch-manager path [-r revision]",
     )
 
     window = GitBranchManager(paths[0], revision=options.revision)

--- a/rabbitvcs/ui/browser.py
+++ b/rabbitvcs/ui/browser.py
@@ -9,10 +9,14 @@ import rabbitvcs.ui.action
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget
 from rabbitvcs.util.contextmenuitems import *
-from rabbitvcs.util.contextmenu import GtkContextMenu, GtkContextMenuCaller, \
-    GtkFilesContextMenuConditions
+from rabbitvcs.util.contextmenu import (
+    GtkContextMenu,
+    GtkContextMenuCaller,
+    GtkFilesContextMenuConditions,
+)
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -43,6 +47,7 @@ from datetime import datetime
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -68,71 +73,61 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         self.url = ""
         if self.svn.is_in_a_or_a_working_copy(url):
             action = rabbitvcs.ui.action.SVNAction(
-                self.svn, notification=False, run_in_thread=False)
+                self.svn, notification=False, run_in_thread=False
+            )
             self.url = S(action.run_single(self.svn.get_repo_url, url))
         elif self.svn.is_path_repository_url(url):
             self.url = S(url)
 
         self.urls = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("urls"),
-            helper.get_repository_paths()
+            self.get_widget("urls"), helper.get_repository_paths()
         )
         if self.url:
             self.urls.set_child_text(helper.unquote_url(self.url))
 
         # We must set a signal handler for the Gtk.Entry inside the combobox
         # Because glade will not retain that information
-        self.urls.set_child_signal(
-            "key-release-event",
-            self.on_urls_key_released
-        )
+        self.urls.set_child_signal("key-release-event", self.on_urls_key_released)
 
         self.revision_selector = rabbitvcs.ui.widget.RevisionSelector(
             self.get_widget("revision_container"),
             self.svn,
             url_combobox=self.urls,
-            expand=True
+            expand=True,
         )
 
         self.items = []
         self.list_table = rabbitvcs.ui.widget.Table(
             self.get_widget("list"),
-            [rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
-                rabbitvcs.ui.widget.TYPE_PATH, GObject.TYPE_INT,
-                GObject.TYPE_INT, GObject.TYPE_STRING, GObject.TYPE_FLOAT],
+            [
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH,
+                GObject.TYPE_INT,
+                GObject.TYPE_INT,
+                GObject.TYPE_STRING,
+                GObject.TYPE_FLOAT,
+            ],
             ["", _("Path"), _("Revision"), _("Size"), _("Author"), _("Date")],
-            filters=[{
-                "callback": self.file_filter,
-                "user_data": {
-                    "column": 1
-                }
-            }, {
-                "callback": self.revision_filter,
-                "user_data": {
-                    "column": 2
-                }
-            }, {
-                "callback": self.size_filter,
-                "user_data": {
-                    "column": 3
-                }
-            }, {
-                "callback": self.date_filter,
-                "user_data": {
-                    "column": 5
-                }
-            }],
-            filter_types=[GObject.TYPE_STRING, GObject.TYPE_STRING,
-                          GObject.TYPE_STRING, GObject.TYPE_STRING,
-                          GObject.TYPE_STRING, GObject.TYPE_STRING],
+            filters=[
+                {"callback": self.file_filter, "user_data": {"column": 1}},
+                {"callback": self.revision_filter, "user_data": {"column": 2}},
+                {"callback": self.size_filter, "user_data": {"column": 3}},
+                {"callback": self.date_filter, "user_data": {"column": 5}},
+            ],
+            filter_types=[
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+            ],
             callbacks={
                 "file-column-callback": self.file_column_callback,
                 "row-activated": self.on_row_activated,
-                "mouse-event":   self.on_list_table_mouse_event
+                "mouse-event": self.on_list_table_mouse_event,
             },
-            flags={
-                "sortable": True
-            }
+            flags={"sortable": True},
         )
 
         self.url_clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
@@ -144,15 +139,11 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
 
     def load(self):
         self.url = self.urls.get_active_text()
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
         revision = self.revision_selector.get_revision_object()
         self.action.append(
-            self.svn.list,
-            helper.quote_url(self.url),
-            revision=revision, recurse=False)
+            self.svn.list, helper.quote_url(self.url), revision=revision, recurse=False
+        )
         self.action.append(self.init_repo_root_url)
         self.action.append(self.populate_table, 0)
         self.action.schedule()
@@ -165,21 +156,23 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
 
         self.list_table.append([S(".."), "..", 0, 0, "", 0])
         for item, locked in self.items[1:]:
-            self.list_table.append([
-                S(item.path),
-                item.path,
-                item.created_rev.number,
-                item.size,
-                item.last_author,
-                item.time
-            ])
+            self.list_table.append(
+                [
+                    S(item.path),
+                    item.path,
+                    item.created_rev.number,
+                    item.size,
+                    item.last_author,
+                    item.time,
+                ]
+            )
 
     def init_repo_root_url(self):
         if self.repo_root_url is None and self.svn.is_in_a_or_a_working_copy(self.url):
             action = rabbitvcs.ui.action.SVNAction(
-                self.svn, notification=False, run_in_thread=False)
-            self.repo_root_url = action.run_single(
-                self.svn.get_repo_root_url, self.url)
+                self.svn, notification=False, run_in_thread=False
+            )
+            self.repo_root_url = action.run_single(self.svn.get_repo_root_url, self.url)
 
     def on_refresh_clicked(self, widget):
         helper.save_repository_path(self.urls.get_active_text())
@@ -187,6 +180,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
 
     def create_folder(self, where):
         from rabbitvcs.ui.dialog import NewFolder
+
         dialog = NewFolder()
         result = dialog.run()
         if result is None:
@@ -195,10 +189,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         (folder_name, log_message) = result
         new_url = where.rstrip("/") + "/" + folder_name
 
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
         self.action.append(self.svn.mkdir, new_url, log_message)
         self.action.append(self.svn.list, where, recurse=False)
         self.action.append(self.populate_table, 1)
@@ -313,17 +304,18 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         return self.urls.get_active_text()
 
     def _open(self, paths):
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
 
         exported_paths = []
         for path in paths:
             export_path = helper.get_tmp_path(os.path.basename(paths[0]))
             exported_paths.append(export_path)
-            self.action.append(self.svn.export, paths[0],
-                               export_path, revision=self.revision_selector.get_revision_object())
+            self.action.append(
+                self.svn.export,
+                paths[0],
+                export_path,
+                revision=self.revision_selector.get_revision_object(),
+            )
 
         for path in exported_paths:
             self.action.append(helper.open_item, path)
@@ -401,7 +393,7 @@ class BrowserContextMenuConditions(GtkFilesContextMenuConditions):
 
     def annotate(self, data1=None, data2=None):
         if self.path_dict["length"] == 1:
-            return (self.caller.file_column_callback(self.paths[0]) == "file")
+            return self.caller.file_column_callback(self.paths[0]) == "file"
 
         return False
 
@@ -423,15 +415,15 @@ class BrowserContextMenuConditions(GtkFilesContextMenuConditions):
 
     def create_repository_folder(self, data1=None):
         if self.path_dict["length"] == 1 and not self.is_parent_selected():
-            return (self.caller.file_column_callback(self.paths[0]) == "dir")
+            return self.caller.file_column_callback(self.paths[0]) == "dir"
 
-        return (self.path_dict["length"] == 0)
+        return self.path_dict["length"] == 0
 
     def browser_copy_to(self, data1=None, data2=None):
         return not self.is_parent_selected()
 
     def browser_copy_url_to_clipboard(self, data1=None, data2=None):
-        return (self.path_dict["length"] == 1)
+        return self.path_dict["length"] == 1
 
     def browser_move_to(self, data1=None, data2=None):
         revision = self.caller.revision_selector.get_revision_object()
@@ -469,8 +461,7 @@ class BrowserContextMenuCallbacks(object):
         self.caller._open(self.paths)
 
     def show_log(self, data=None, user_data=None):
-        helper.launch_ui_window(
-            "log", ["--vcs=%s" % self.guess, self.paths[0]])
+        helper.launch_ui_window("log", ["--vcs=%s" % self.guess, self.paths[0]])
 
     def annotate(self, data=None, user_data=None):
         urlrev = self.paths[0]
@@ -497,6 +488,7 @@ class BrowserContextMenuCallbacks(object):
         (base, filename) = os.path.split(self.paths[0])
 
         from rabbitvcs.ui.dialog import OneLineTextChange
+
         dialog = OneLineTextChange(_("Rename"), _("New Name:"), filename)
         (result, new_name) = dialog.run()
 
@@ -509,13 +501,9 @@ class BrowserContextMenuCallbacks(object):
             path_to_refresh = new_url
             self.__update_browser_url(path_to_refresh)
 
-        self.caller.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.caller.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
         self.caller.action.append(self.svn.move, self.paths[0], new_url)
-        self.caller.action.append(
-            self.svn.list, path_to_refresh, recurse=False)
+        self.caller.action.append(self.svn.list, path_to_refresh, recurse=False)
         self.caller.action.append(self.caller.populate_table, 1)
         self.caller.action.schedule()
 
@@ -528,13 +516,9 @@ class BrowserContextMenuCallbacks(object):
 
             self.__update_browser_url(path_to_refresh)
 
-        self.caller.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.caller.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
         self.caller.action.append(self.svn.remove, self.paths)
-        self.caller.action.append(
-            self.svn.list, path_to_refresh, recurse=False)
+        self.caller.action.append(self.svn.list, path_to_refresh, recurse=False)
         self.caller.action.append(self.caller.populate_table, 1)
         self.caller.action.schedule()
 
@@ -543,10 +527,11 @@ class BrowserContextMenuCallbacks(object):
 
     def browser_copy_to(self, data=None, user_data=None):
         from rabbitvcs.ui.dialog import OneLineTextChange
+
         dialog = OneLineTextChange(
             _("Where do you want to copy the selection?"),
             _("New Location:"),
-            self.caller.get_url()
+            self.caller.get_url(),
         )
         result = dialog.run()
         if result is None:
@@ -558,14 +543,11 @@ class BrowserContextMenuCallbacks(object):
 
         sources = self.__generate_sources_list()
 
-        self.caller.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
+        self.caller.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
+        self.caller.action.append(
+            self.svn.copy_all, sources, new_url, copy_as_child=True
         )
-        self.caller.action.append(
-            self.svn.copy_all, sources, new_url, copy_as_child=True)
-        self.caller.action.append(
-            self.svn.list, self.caller.get_url(), recurse=False)
+        self.caller.action.append(self.svn.list, self.caller.get_url(), recurse=False)
         self.caller.action.append(self.caller.populate_table, 1)
         self.caller.action.schedule()
 
@@ -574,10 +556,11 @@ class BrowserContextMenuCallbacks(object):
 
     def browser_move_to(self, data=None, user_data=None):
         from rabbitvcs.ui.dialog import OneLineTextChange
+
         dialog = OneLineTextChange(
             _("Where do you want to move the selection?"),
             _("New Location:"),
-            self.caller.get_url()
+            self.caller.get_url(),
         )
         result = dialog.run()
         if result is None:
@@ -587,14 +570,11 @@ class BrowserContextMenuCallbacks(object):
         if response == Gtk.ResponseType.CANCEL:
             return
 
-        self.caller.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
+        self.caller.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
+        self.caller.action.append(
+            self.svn.move_all, self.paths, new_url, move_as_child=True
         )
-        self.caller.action.append(
-            self.svn.move_all, self.paths, new_url, move_as_child=True)
-        self.caller.action.append(
-            self.svn.list, self.caller.get_url(), recurse=False)
+        self.caller.action.append(self.svn.list, self.caller.get_url(), recurse=False)
         self.caller.action.append(self.caller.populate_table, 1)
         self.caller.action.schedule()
 
@@ -609,16 +589,9 @@ class BrowserContextMenu(object):
         self.vcs = vcs
         self.svn = self.vcs.svn()
 
-        self.conditions = BrowserContextMenuConditions(
-            self.vcs,
-            paths,
-            self.caller
-        )
+        self.conditions = BrowserContextMenuConditions(self.vcs, paths, self.caller)
         self.callbacks = BrowserContextMenuCallbacks(
-            self.caller,
-            self.base_dir,
-            self.vcs,
-            paths
+            self.caller, self.base_dir, self.vcs, paths
         )
 
         self.structure = [
@@ -635,22 +608,18 @@ class BrowserContextMenu(object):
             (MenuDelete, None),
             (MenuBrowserCopyTo, None),
             (MenuBrowserCopyUrlToClipboard, None),
-            (MenuBrowserMoveTo, None)
+            (MenuBrowserMoveTo, None),
         ]
 
     def show(self):
         if len(self.paths) == 0:
             return
 
-        context_menu = GtkContextMenu(
-            self.structure, self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNBrowser,
-    rabbitvcs.vcs.VCS_DUMMY: SVNBrowser
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNBrowser, rabbitvcs.vcs.VCS_DUMMY: SVNBrowser}
 
 
 def browser_factory(path):
@@ -660,9 +629,8 @@ def browser_factory(path):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
-    (options, url) = main(
-        usage="Usage: rabbitvcs browser [url]"
-    )
+
+    (options, url) = main(usage="Usage: rabbitvcs browser [url]")
 
     window = browser_factory(url[0])
     window.register_gtk_quit()

--- a/rabbitvcs/ui/changes.py
+++ b/rabbitvcs/ui/changes.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.ui.dialog import MessageBox
+import rabbitvcs.ui.action
+from rabbitvcs.util.strings import S
+from rabbitvcs.util.contextmenuitems import *
+from rabbitvcs.util.contextmenu import GtkContextMenu
+import rabbitvcs.ui.widget
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,19 +37,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-import rabbitvcs.ui.widget
-from rabbitvcs.util.contextmenu import GtkContextMenu
-from rabbitvcs.util.contextmenuitems import *
-from rabbitvcs.util.strings import S
-import rabbitvcs.ui.action
-from rabbitvcs.ui.dialog import MessageBox
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class Changes(InterfaceView):
     """
@@ -199,7 +200,6 @@ class Changes(InterfaceView):
         can_browse_urls = self.can_second_browse_urls()
         self.second_urls_browse.set_sensitive(can_browse_urls)
 
-
     def enable_more_actions(self):
         self.more_actions.set_sensitive(True)
 
@@ -226,7 +226,6 @@ class Changes(InterfaceView):
                 "--vcs=%s" % self.get_vcs_name()
             ])
 
-
     #
     # More Actions callbacks
     #
@@ -251,6 +250,7 @@ class Changes(InterfaceView):
             vcs = rabbitvcs.vcs.VCS_GIT
 
         return vcs
+
 
 class SVNChanges(Changes):
     def __init__(self, path1=None, revision1=None, path2=None, revision2=None):
@@ -346,12 +346,13 @@ class SVNChanges(Changes):
     def on_first_urls_browse_clicked(self, widget, data=None):
         from rabbitvcs.ui.browser import SVNBrowserDialog
         SVNBrowserDialog(self.first_urls.get_active_text(),
-            callback=self.on_first_repo_chooser_closed)
+                         callback=self.on_first_repo_chooser_closed)
 
     def on_second_urls_browse_clicked(self, widget, data=None):
         from rabbitvcs.ui.browser import SVNBrowserDialog
         SVNBrowserDialog(self.second_urls.get_active_text(),
-            callback=self.on_second_repo_chooser_closed)
+                         callback=self.on_second_repo_chooser_closed)
+
 
 class GitChanges(Changes):
     def __init__(self, path1=None, revision1=None, path2=None, revision2=None):
@@ -438,20 +439,24 @@ class MenuOpenFirst(MenuItem):
     label = _("Open from first revision")
     icon = "document-open"
 
+
 class MenuOpenSecond(MenuItem):
     identifier = "RabbitVCS::Open_Second"
     label = _("Open from second revision")
     icon = "document-open"
+
 
 class MenuViewDiff(MenuItem):
     identifier = "RabbitVCS::View_Diff"
     label = _("View unified diff(s)")
     icon = "rabbitvcs-diff"
 
+
 class MenuCompare(MenuItem):
     identifier = "RabbitVCS::Compare"
     label = _("Compare side by side")
     icon = "rabbitvcs-compare"
+
 
 class ChangesContextMenuConditions(object):
     def __init__(self, caller, vcs):
@@ -467,7 +472,8 @@ class ChangesContextMenuConditions(object):
         return (
             len(self.caller.selected_rows) == 1
             and (
-                str(self.caller.get_first_revision()) != str(self.caller.get_second_revision())
+                str(self.caller.get_first_revision()) != str(
+                    self.caller.get_second_revision())
                 or self.caller.first_urls.get_active_text() != self.caller.second_urls.get_active_text()
             )
         )
@@ -482,13 +488,15 @@ class ChangesContextMenuConditions(object):
             len(self.caller.selected_rows) > 0
         )
 
+
 class ChangesContextMenuCallbacks(object):
     def __init__(self, caller, vcs):
         self.caller = caller
         self.vcs = vcs
 
     def open_first(self, widget, data=None):
-        path = self.caller.changes_table.get_row(self.caller.selected_rows[0])[0]
+        path = self.caller.changes_table.get_row(
+            self.caller.selected_rows[0])[0]
         if path == ".":
             path = ""
 
@@ -502,7 +510,8 @@ class ChangesContextMenuCallbacks(object):
         ])
 
     def open_second(self, widget, data=None):
-        path = self.caller.changes_table.get_row(self.caller.selected_rows[0])[0]
+        path = self.caller.changes_table.get_row(
+            self.caller.selected_rows[0])[0]
         if path == ".":
             path = ""
 
@@ -525,8 +534,10 @@ class ChangesContextMenuCallbacks(object):
                 url1 = ""
                 url2 = ""
 
-            url1 = helper.url_join(self.caller.first_urls.get_active_text(), url1)
-            url2 = helper.url_join(self.caller.second_urls.get_active_text(), url2)
+            url1 = helper.url_join(
+                self.caller.first_urls.get_active_text(), url1)
+            url2 = helper.url_join(
+                self.caller.second_urls.get_active_text(), url2)
             rev1 = self.caller.get_first_revision()
             rev2 = self.caller.get_second_revision()
 
@@ -537,11 +548,13 @@ class ChangesContextMenuCallbacks(object):
                 "--vcs=%s" % self.caller.get_vcs_name()
             ])
 
+
 class ChangesContextMenu(object):
     """
     Defines context menu items for a table with files
 
     """
+
     def __init__(self, caller, event):
         """
         @param  caller: The calling object
@@ -577,13 +590,16 @@ class ChangesContextMenu(object):
         if len(self.caller.selected_rows) == 0:
             return
 
-        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(
+            self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
+
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNChanges,
     rabbitvcs.vcs.VCS_GIT: GitChanges
 }
+
 
 def changes_factory(vcs, path1=None, revision1=None, path2=None, revision2=None):
     if not vcs:
@@ -605,6 +621,7 @@ if __name__ == "__main__":
     if len(args) > 0:
         pathrev2 = helper.parse_path_revision_string(args.pop(0))
 
-    window = changes_factory(options.vcs, pathrev1[0], pathrev1[1], pathrev2[0], pathrev2[1])
+    window = changes_factory(
+        options.vcs, pathrev1[0], pathrev1[1], pathrev2[0], pathrev2[1])
     window.register_gtk_quit()
     Gtk.main()

--- a/rabbitvcs/ui/changes.py
+++ b/rabbitvcs/ui/changes.py
@@ -8,6 +8,7 @@ from rabbitvcs.util.contextmenu import GtkContextMenu
 import rabbitvcs.ui.widget
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -35,6 +36,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -52,38 +54,30 @@ class Changes(InterfaceView):
                 in revisions like HEAD.  Currently, if a revision is passed it
                 assumes it is a number
     """
+
     selected_rows = []
-    MORE_ACTIONS_ITEMS = [
-        _("More Actions..."),
-        _("View unified diff")
-    ]
+    MORE_ACTIONS_ITEMS = [_("More Actions..."), _("View unified diff")]
 
     def __init__(self, path1=None, revision1=None, path2=None, revision2=None):
         InterfaceView.__init__(self, "changes", "Changes")
 
         self.vcs = rabbitvcs.vcs.VCS()
 
-        self.MORE_ACTIONS_CALLBACKS = [
-            None,
-            self.on_more_actions_view_unified_diff
-        ]
+        self.MORE_ACTIONS_CALLBACKS = [None, self.on_more_actions_view_unified_diff]
 
         self.more_actions = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("more_actions"),
-            self.MORE_ACTIONS_ITEMS
+            self.get_widget("more_actions"), self.MORE_ACTIONS_ITEMS
         )
         self.more_actions.set_active(0)
 
         repo_paths = helper.get_repository_paths()
         self.first_urls = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("first_urls"),
-            repo_paths
+            self.get_widget("first_urls"), repo_paths
         )
         self.first_urls_browse = self.get_widget("first_urls_browse")
 
         self.second_urls = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("second_urls"),
-            repo_paths
+            self.get_widget("second_urls"), repo_paths
         )
         self.second_urls_browse = self.get_widget("second_urls_browse")
 
@@ -179,15 +173,14 @@ class Changes(InterfaceView):
         self.check_refresh_button()
 
     def can_first_browse_urls(self):
-        return (self.first_urls.get_active_text() != "")
+        return self.first_urls.get_active_text() != ""
 
     def can_second_browse_urls(self):
-        return (self.second_urls.get_active_text() != "")
+        return self.second_urls.get_active_text() != ""
 
     def check_refresh_button(self):
         can_click_refresh = (
-            self.can_first_browse_urls()
-            and self.can_second_browse_urls()
+            self.can_first_browse_urls() and self.can_second_browse_urls()
         )
 
         self.get_widget("refresh").set_sensitive(can_click_refresh)
@@ -219,12 +212,15 @@ class Changes(InterfaceView):
             rev1 = self.get_first_revision()
             rev2 = self.get_second_revision()
 
-            helper.launch_ui_window("diff", [
-                "%s@%s" % (url1, S(rev1)),
-                "%s@%s" % (url2, S(rev2)),
-                "%s" % (sidebyside and "-s" or ""),
-                "--vcs=%s" % self.get_vcs_name()
-            ])
+            helper.launch_ui_window(
+                "diff",
+                [
+                    "%s@%s" % (url1, S(rev1)),
+                    "%s@%s" % (url2, S(rev2)),
+                    "%s" % (sidebyside and "-s" or ""),
+                    "--vcs=%s" % self.get_vcs_name(),
+                ],
+            )
 
     #
     # More Actions callbacks
@@ -236,11 +232,14 @@ class Changes(InterfaceView):
         rev2 = self.get_second_revision()
         url2 = self.second_urls.get_active_text()
 
-        helper.launch_ui_window("diff", [
-            "%s@%s" % (url1, S(rev1)),
-            "%s@%s" % (url2, S(rev2)),
-            "--vcs=%s" % self.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "%s@%s" % (url1, S(rev1)),
+                "%s@%s" % (url2, S(rev2)),
+                "--vcs=%s" % self.get_vcs_name(),
+            ],
+        )
 
     def get_vcs_name(self):
         vcs = rabbitvcs.vcs.VCS_DUMMY
@@ -271,7 +270,7 @@ class SVNChanges(Changes):
             self.svn,
             revision=revision1,
             url_combobox=self.first_urls,
-            expand=True
+            expand=True,
         )
 
         self.second_revision_selector = rabbitvcs.ui.widget.RevisionSelector(
@@ -279,21 +278,15 @@ class SVNChanges(Changes):
             self.svn,
             revision=revision2,
             url_combobox=self.second_urls,
-            expand=True
+            expand=True,
         )
 
         self.changes_table = rabbitvcs.ui.widget.Table(
             self.get_widget("changes_table"),
-            [GObject.TYPE_STRING, GObject.TYPE_STRING,
-                GObject.TYPE_STRING],
+            [GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
             [_("Path"), _("Change"), _("Property Change")],
-            flags={
-                "sortable": True,
-                "sort_on": 1
-            },
-            callbacks={
-                "mouse-event":   self.on_changes_table_button_released
-            }
+            flags={"sortable": True, "sort_on": 1},
+            callbacks={"mouse-event": self.on_changes_table_button_released},
         )
 
         self.check_ui()
@@ -307,17 +300,10 @@ class SVNChanges(Changes):
         second_rev = self.get_second_revision()
         second_url = self.second_urls.get_active_text()
 
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
         self.action.append(self.disable_more_actions)
         self.action.append(
-            self.svn.diff_summarize,
-            first_url,
-            first_rev,
-            second_url,
-            second_rev
+            self.svn.diff_summarize, first_url, first_rev, second_url, second_rev
         )
         self.action.append(helper.save_repository_path, first_url)
         self.action.append(helper.save_repository_path, second_url)
@@ -331,27 +317,29 @@ class SVNChanges(Changes):
 
         self.changes_table.clear()
         for item in summary:
-            prop_changed = (item["prop_changed"] == 1 and _("Yes") or _("No"))
+            prop_changed = item["prop_changed"] == 1 and _("Yes") or _("No")
 
             path = item["path"]
             if path == "":
                 path = "."
 
-            self.changes_table.append([
-                path,
-                str(item["summarize_kind"]),
-                prop_changed
-            ])
+            self.changes_table.append([path, str(item["summarize_kind"]), prop_changed])
 
     def on_first_urls_browse_clicked(self, widget, data=None):
         from rabbitvcs.ui.browser import SVNBrowserDialog
-        SVNBrowserDialog(self.first_urls.get_active_text(),
-                         callback=self.on_first_repo_chooser_closed)
+
+        SVNBrowserDialog(
+            self.first_urls.get_active_text(),
+            callback=self.on_first_repo_chooser_closed,
+        )
 
     def on_second_urls_browse_clicked(self, widget, data=None):
         from rabbitvcs.ui.browser import SVNBrowserDialog
-        SVNBrowserDialog(self.second_urls.get_active_text(),
-                         callback=self.on_second_repo_chooser_closed)
+
+        SVNBrowserDialog(
+            self.second_urls.get_active_text(),
+            callback=self.on_second_repo_chooser_closed,
+        )
 
 
 class GitChanges(Changes):
@@ -376,7 +364,7 @@ class GitChanges(Changes):
             self.git,
             revision=revision1,
             url_combobox=self.first_urls,
-            expand=True
+            expand=True,
         )
 
         self.second_revision_selector = rabbitvcs.ui.widget.RevisionSelector(
@@ -384,13 +372,13 @@ class GitChanges(Changes):
             self.git,
             revision=revision2,
             url_combobox=self.second_urls,
-            expand=True
+            expand=True,
         )
 
         self.changes_table = rabbitvcs.ui.widget.Table(
             self.get_widget("changes_table"),
             [GObject.TYPE_STRING, GObject.TYPE_STRING],
-            [_("Path"), _("Change")]
+            [_("Path"), _("Change")],
         )
 
         self.check_ui()
@@ -404,17 +392,10 @@ class GitChanges(Changes):
         second_rev = self.get_second_revision()
         second_url = self.second_urls.get_active_text()
 
-        self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            notification=False
-        )
+        self.action = rabbitvcs.ui.action.GitAction(self.git, notification=False)
         self.action.append(self.disable_more_actions)
         self.action.append(
-            self.git.diff_summarize,
-            first_url,
-            first_rev,
-            second_url,
-            second_rev
+            self.git.diff_summarize, first_url, first_rev, second_url, second_rev
         )
         self.action.append(helper.save_repository_path, first_url)
         self.action.append(helper.save_repository_path, second_url)
@@ -428,10 +409,7 @@ class GitChanges(Changes):
 
         self.changes_table.clear()
         for item in summary:
-            self.changes_table.append([
-                item.path,
-                item.action
-            ])
+            self.changes_table.append([item.path, item.action])
 
 
 class MenuOpenFirst(MenuItem):
@@ -464,29 +442,21 @@ class ChangesContextMenuConditions(object):
         self.vcs = vcs
 
     def open_first(self):
-        return (
-            len(self.caller.selected_rows) == 1
-        )
+        return len(self.caller.selected_rows) == 1
 
     def open_second(self):
-        return (
-            len(self.caller.selected_rows) == 1
-            and (
-                str(self.caller.get_first_revision()) != str(
-                    self.caller.get_second_revision())
-                or self.caller.first_urls.get_active_text() != self.caller.second_urls.get_active_text()
-            )
+        return len(self.caller.selected_rows) == 1 and (
+            str(self.caller.get_first_revision())
+            != str(self.caller.get_second_revision())
+            or self.caller.first_urls.get_active_text()
+            != self.caller.second_urls.get_active_text()
         )
 
     def view_diff(self):
-        return (
-            len(self.caller.selected_rows) > 0
-        )
+        return len(self.caller.selected_rows) > 0
 
     def compare(self):
-        return (
-            len(self.caller.selected_rows) > 0
-        )
+        return len(self.caller.selected_rows) > 0
 
 
 class ChangesContextMenuCallbacks(object):
@@ -495,33 +465,27 @@ class ChangesContextMenuCallbacks(object):
         self.vcs = vcs
 
     def open_first(self, widget, data=None):
-        path = self.caller.changes_table.get_row(
-            self.caller.selected_rows[0])[0]
+        path = self.caller.changes_table.get_row(self.caller.selected_rows[0])[0]
         if path == ".":
             path = ""
 
         url = helper.url_join(self.caller.first_urls.get_active_text(), path)
         rev = self.caller.get_first_revision()
 
-        helper.launch_ui_window("open", [
-            "--vcs=%s" % self.caller.get_vcs_name(),
-            url,
-            "-r%s" % S(rev)
-        ])
+        helper.launch_ui_window(
+            "open", ["--vcs=%s" % self.caller.get_vcs_name(), url, "-r%s" % S(rev)]
+        )
 
     def open_second(self, widget, data=None):
-        path = self.caller.changes_table.get_row(
-            self.caller.selected_rows[0])[0]
+        path = self.caller.changes_table.get_row(self.caller.selected_rows[0])[0]
         if path == ".":
             path = ""
 
         url = helper.url_join(self.caller.second_urls.get_active_text(), path)
         rev = self.caller.get_second_revision()
-        helper.launch_ui_window("open", [
-            "--vcs=%s" % self.caller.get_vcs_name(),
-            url,
-            "-r%s" % S(rev)
-        ])
+        helper.launch_ui_window(
+            "open", ["--vcs=%s" % self.caller.get_vcs_name(), url, "-r%s" % S(rev)]
+        )
 
     def view_diff(self, widget, data=None):
         self.caller.view_selected_diff()
@@ -534,19 +498,20 @@ class ChangesContextMenuCallbacks(object):
                 url1 = ""
                 url2 = ""
 
-            url1 = helper.url_join(
-                self.caller.first_urls.get_active_text(), url1)
-            url2 = helper.url_join(
-                self.caller.second_urls.get_active_text(), url2)
+            url1 = helper.url_join(self.caller.first_urls.get_active_text(), url1)
+            url2 = helper.url_join(self.caller.second_urls.get_active_text(), url2)
             rev1 = self.caller.get_first_revision()
             rev2 = self.caller.get_second_revision()
 
-            helper.launch_ui_window("diff", [
-                "%s@%s" % (url1, S(rev1)),
-                "%s@%s" % (url2, S(rev2)),
-                "-s",
-                "--vcs=%s" % self.caller.get_vcs_name()
-            ])
+            helper.launch_ui_window(
+                "diff",
+                [
+                    "%s@%s" % (url1, S(rev1)),
+                    "%s@%s" % (url2, S(rev2)),
+                    "-s",
+                    "--vcs=%s" % self.caller.get_vcs_name(),
+                ],
+            )
 
 
 class ChangesContextMenu(object):
@@ -566,15 +531,9 @@ class ChangesContextMenu(object):
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
 
-        self.conditions = ChangesContextMenuConditions(
-            self.caller,
-            self.vcs
-        )
+        self.conditions = ChangesContextMenuConditions(self.caller, self.vcs)
 
-        self.callbacks = ChangesContextMenuCallbacks(
-            self.caller,
-            self.vcs
-        )
+        self.callbacks = ChangesContextMenuCallbacks(self.caller, self.vcs)
 
         # The first element of each tuple is a key that matches a
         # ContextMenuItems item.  The second element is either None when there
@@ -583,22 +542,18 @@ class ChangesContextMenu(object):
             (MenuOpenFirst, None),
             (MenuOpenSecond, None),
             (MenuViewDiff, None),
-            (MenuCompare, None)
+            (MenuCompare, None),
         ]
 
     def show(self):
         if len(self.caller.selected_rows) == 0:
             return
 
-        context_menu = GtkContextMenu(
-            self.structure, self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNChanges,
-    rabbitvcs.vcs.VCS_GIT: GitChanges
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNChanges, rabbitvcs.vcs.VCS_GIT: GitChanges}
 
 
 def changes_factory(vcs, path1=None, revision1=None, path2=None, revision2=None):
@@ -611,9 +566,9 @@ def changes_factory(vcs, path1=None, revision1=None, path2=None, revision2=None)
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT
+
     (options, args) = main(
-        [VCS_OPT],
-        usage="Usage: rabbitvcs changes [url1@rev1] [url2@rev2]"
+        [VCS_OPT], usage="Usage: rabbitvcs changes [url1@rev1] [url2@rev2]"
     )
 
     pathrev1 = helper.parse_path_revision_string(args.pop(0))
@@ -622,6 +577,7 @@ if __name__ == "__main__":
         pathrev2 = helper.parse_path_revision_string(args.pop(0))
 
     window = changes_factory(
-        options.vcs, pathrev1[0], pathrev1[1], pathrev2[0], pathrev2[1])
+        options.vcs, pathrev1[0], pathrev1[1], pathrev2[0], pathrev2[1]
+    )
     window.register_gtk_quit()
     Gtk.main()

--- a/rabbitvcs/ui/checkmods.py
+++ b/rabbitvcs/ui/checkmods.py
@@ -1,4 +1,16 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.decorators import gtk_unsafe
+from rabbitvcs.util.log import Log
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.util.contextmenuitems import MenuItem, MenuUpdate, \
+    MenuSeparator
+from rabbitvcs.util.contextmenu import GtkFilesContextMenu, \
+    GtkContextMenuCaller, GtkFilesContextMenuConditions, GtkContextMenu
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -29,26 +41,15 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.util.contextmenu import GtkFilesContextMenu, \
-    GtkContextMenuCaller, GtkFilesContextMenuConditions, GtkContextMenu
-from rabbitvcs.util.contextmenuitems import MenuItem, MenuUpdate, \
-    MenuSeparator
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util.log import Log
-from rabbitvcs.util.decorators import gtk_unsafe
 
 log = Log("rabbitvcs.ui.checkmods")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
 helper.gobject_threads_init()
+
 
 class SVNCheckForModifications(InterfaceView):
     """
@@ -66,14 +67,14 @@ class SVNCheckForModifications(InterfaceView):
         self.svn = self.vcs.svn()
         self.notebook = self.get_widget("notebook")
 
-        self.local_mods = SVNCheckLocalModifications(self, \
-                                                         self.vcs, \
-                                                         self.paths, \
-                                                         self.base_dir)
-        self.remote_mods = SVNCheckRemoteModifications(self, \
-                                                           self.vcs, \
-                                                           self.paths, \
-                                                           self.base_dir)
+        self.local_mods = SVNCheckLocalModifications(self,
+                                                     self.vcs,
+                                                     self.paths,
+                                                     self.base_dir)
+        self.remote_mods = SVNCheckRemoteModifications(self,
+                                                       self.vcs,
+                                                       self.paths,
+                                                       self.base_dir)
 
         self.remote_refreshed = False
 
@@ -96,6 +97,7 @@ class SVNCheckForModifications(InterfaceView):
 
     def load(self):
         self.local_mods.refresh()
+
 
 class SVNCheckLocalModifications(GtkContextMenuCaller):
     def __init__(self, caller, vcs, paths, base_dir):
@@ -137,7 +139,8 @@ class SVNCheckLocalModifications(GtkContextMenuCaller):
             self.svn,
             notification=False
         )
-        self.action.append(self.svn.get_items, self.paths, self.svn.STATUSES_FOR_CHECK)
+        self.action.append(self.svn.get_items, self.paths,
+                           self.svn.STATUSES_FOR_CHECK)
         self.action.append(self.populate_files_table)
         self.action.schedule()
 
@@ -157,6 +160,7 @@ class SVNCheckLocalModifications(GtkContextMenuCaller):
 
     def on_context_menu_command_finished(self):
         self.refresh()
+
 
 class SVNCheckRemoteModifications(GtkContextMenuCaller):
     def __init__(self, caller, vcs, paths, base_dir):
@@ -195,7 +199,8 @@ class SVNCheckRemoteModifications(GtkContextMenuCaller):
     def on_files_table_mouse_event(self, treeview, event, *args):
         if event.button == 3 and event.type == Gdk.EventType.BUTTON_RELEASE:
             paths = self.files_table.get_selected_row_items(0)
-            CheckRemoteModsContextMenu(self, event, self.base_dir, self.vcs, paths).show()
+            CheckRemoteModsContextMenu(
+                self, event, self.base_dir, self.vcs, paths).show()
 
     def refresh(self):
         self.action = rabbitvcs.ui.action.SVNAction(
@@ -250,15 +255,18 @@ class SVNCheckRemoteModifications(GtkContextMenuCaller):
     def on_context_menu_command_finished(self):
         self.refresh()
 
+
 class MenuViewDiff(MenuItem):
     identifier = "RabbitVCS::View_Diff"
     label = _("View unified diff")
     icon = "rabbitvcs-diff"
 
+
 class MenuCompare(MenuItem):
     identifier = "RabbitVCS::Compare"
     label = _("Compare side by side")
     icon = "rabbitvcs-compare"
+
 
 class CheckRemoteModsContextMenuConditions(GtkFilesContextMenuConditions):
     def __init__(self, vcs, paths=[]):
@@ -269,11 +277,12 @@ class CheckRemoteModsContextMenuConditions(GtkFilesContextMenuConditions):
 
     def view_diff(self, data=None):
         return (self.path_dict["exists"]
-            and self.path_dict["length"] == 1)
+                and self.path_dict["length"] == 1)
 
     def compare(self, data=None):
         return (self.path_dict["exists"]
-            and self.path_dict["length"] == 1)
+                and self.path_dict["length"] == 1)
+
 
 class CheckRemoteModsContextMenuCallbacks(object):
     def __init__(self, caller, base_dir, vcs, paths=[]):
@@ -313,6 +322,7 @@ class CheckRemoteModsContextMenuCallbacks(object):
         )
         self.action.schedule()
 
+
 class CheckRemoteModsContextMenu(object):
     def __init__(self, caller, event, base_dir, vcs, paths=[]):
 
@@ -341,12 +351,15 @@ class CheckRemoteModsContextMenu(object):
         if len(self.paths) == 0:
             return
 
-        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(
+            self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
+
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNCheckForModifications
 }
+
 
 def checkmods_factory(paths, base_dir):
     guess = rabbitvcs.vcs.guess(paths[0])

--- a/rabbitvcs/ui/checkmods.py
+++ b/rabbitvcs/ui/checkmods.py
@@ -5,12 +5,16 @@ from rabbitvcs.util.log import Log
 import rabbitvcs.ui.action
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget
-from rabbitvcs.util.contextmenuitems import MenuItem, MenuUpdate, \
-    MenuSeparator
-from rabbitvcs.util.contextmenu import GtkFilesContextMenu, \
-    GtkContextMenuCaller, GtkFilesContextMenuConditions, GtkContextMenu
+from rabbitvcs.util.contextmenuitems import MenuItem, MenuUpdate, MenuSeparator
+from rabbitvcs.util.contextmenu import (
+    GtkFilesContextMenu,
+    GtkContextMenuCaller,
+    GtkFilesContextMenuConditions,
+    GtkContextMenu,
+)
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -39,6 +43,7 @@ import threading
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -67,14 +72,12 @@ class SVNCheckForModifications(InterfaceView):
         self.svn = self.vcs.svn()
         self.notebook = self.get_widget("notebook")
 
-        self.local_mods = SVNCheckLocalModifications(self,
-                                                     self.vcs,
-                                                     self.paths,
-                                                     self.base_dir)
-        self.remote_mods = SVNCheckRemoteModifications(self,
-                                                       self.vcs,
-                                                       self.paths,
-                                                       self.base_dir)
+        self.local_mods = SVNCheckLocalModifications(
+            self, self.vcs, self.paths, self.base_dir
+        )
+        self.remote_mods = SVNCheckRemoteModifications(
+            self, self.vcs, self.paths, self.base_dir
+        )
 
         self.remote_refreshed = False
 
@@ -112,17 +115,16 @@ class SVNCheckLocalModifications(GtkContextMenuCaller):
             self.caller.get_widget("local_files_table"),
             [GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
             [_("Path"), _("Status"), _("Extension")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 0
+            filters=[
+                {
+                    "callback": rabbitvcs.ui.widget.path_filter,
+                    "user_data": {"base_dir": base_dir, "column": 0},
                 }
-            }],
+            ],
             callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event
-            }
+                "row-activated": self.on_files_table_row_activated,
+                "mouse-event": self.on_files_table_mouse_event,
+            },
         )
 
     def on_files_table_row_activated(self, treeview, event, col):
@@ -135,12 +137,8 @@ class SVNCheckLocalModifications(GtkContextMenuCaller):
             GtkFilesContextMenu(self, event, self.base_dir, paths).show()
 
     def refresh(self):
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
-        self.action.append(self.svn.get_items, self.paths,
-                           self.svn.STATUSES_FOR_CHECK)
+        self.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
+        self.action.append(self.svn.get_items, self.paths, self.svn.STATUSES_FOR_CHECK)
         self.action.append(self.populate_files_table)
         self.action.schedule()
 
@@ -149,11 +147,13 @@ class SVNCheckLocalModifications(GtkContextMenuCaller):
         self.files_table.clear()
         self.items = self.action.get_result(0)
         for item in self.items:
-            self.files_table.append([
-                item.path,
-                item.simple_content_status(),
-                helper.get_file_extension(item.path)
-            ])
+            self.files_table.append(
+                [
+                    item.path,
+                    item.simple_content_status(),
+                    helper.get_file_extension(item.path),
+                ]
+            )
 
     def diff_local(self, path):
         helper.launch_diff_tool(path)
@@ -173,23 +173,32 @@ class SVNCheckRemoteModifications(GtkContextMenuCaller):
 
         self.files_table = rabbitvcs.ui.widget.Table(
             self.caller.get_widget("remote_files_table"),
-            [GObject.TYPE_STRING, GObject.TYPE_STRING,
-                GObject.TYPE_STRING, GObject.TYPE_STRING,
-                GObject.TYPE_STRING, GObject.TYPE_STRING],
-            [_("Path"), _("Extension"),
-                _("Text Status"), _("Property Status"),
-                _("Revision"), _("Author")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 0
+            [
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+            ],
+            [
+                _("Path"),
+                _("Extension"),
+                _("Text Status"),
+                _("Property Status"),
+                _("Revision"),
+                _("Author"),
+            ],
+            filters=[
+                {
+                    "callback": rabbitvcs.ui.widget.path_filter,
+                    "user_data": {"base_dir": base_dir, "column": 0},
                 }
-            }],
+            ],
             callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event
-            }
+                "row-activated": self.on_files_table_row_activated,
+                "mouse-event": self.on_files_table_mouse_event,
+            },
         )
 
     def on_files_table_row_activated(self, treeview, event, col):
@@ -200,13 +209,11 @@ class SVNCheckRemoteModifications(GtkContextMenuCaller):
         if event.button == 3 and event.type == Gdk.EventType.BUTTON_RELEASE:
             paths = self.files_table.get_selected_row_items(0)
             CheckRemoteModsContextMenu(
-                self, event, self.base_dir, self.vcs, paths).show()
+                self, event, self.base_dir, self.vcs, paths
+            ).show()
 
     def refresh(self):
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
         self.action.append(self.svn.get_remote_updates, self.paths)
         self.action.append(self.populate_files_table)
         self.action.schedule()
@@ -224,14 +231,16 @@ class SVNCheckRemoteModifications(GtkContextMenuCaller):
             if item.author is not None:
                 author = item.author
 
-            self.files_table.append([
-                item.path,
-                helper.get_file_extension(item.path),
-                item.remote_content,
-                item.remote_metadata,
-                str(revision),
-                author
-            ])
+            self.files_table.append(
+                [
+                    item.path,
+                    helper.get_file_extension(item.path),
+                    item.remote_content,
+                    item.remote_metadata,
+                    str(revision),
+                    author,
+                ]
+            )
 
     def diff_remote(self, path):
         from rabbitvcs.ui.diff import SVNDiff
@@ -239,17 +248,8 @@ class SVNCheckRemoteModifications(GtkContextMenuCaller):
         path_local = path
         path_remote = self.svn.get_repo_url(path_local)
 
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
-        self.action.append(
-            SVNDiff,
-            path_local,
-            None,
-            path_remote,
-            "HEAD"
-        )
+        self.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
+        self.action.append(SVNDiff, path_local, None, path_remote, "HEAD")
         self.action.schedule()
 
     def on_context_menu_command_finished(self):
@@ -276,12 +276,10 @@ class CheckRemoteModsContextMenuConditions(GtkFilesContextMenuConditions):
         return True
 
     def view_diff(self, data=None):
-        return (self.path_dict["exists"]
-                and self.path_dict["length"] == 1)
+        return self.path_dict["exists"] and self.path_dict["length"] == 1
 
     def compare(self, data=None):
-        return (self.path_dict["exists"]
-                and self.path_dict["length"] == 1)
+        return self.path_dict["exists"] and self.path_dict["length"] == 1
 
 
 class CheckRemoteModsContextMenuCallbacks(object):
@@ -293,10 +291,7 @@ class CheckRemoteModsContextMenuCallbacks(object):
         self.paths = paths
 
     def update(self, data1=None, data2=None):
-        proc = helper.launch_ui_window(
-            "update",
-            self.paths
-        )
+        proc = helper.launch_ui_window("update", self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def view_diff(self, data1=None, data2=None):
@@ -308,17 +303,9 @@ class CheckRemoteModsContextMenuCallbacks(object):
         path_local = self.paths[0]
         path_remote = self.svn.get_repo_url(path_local)
 
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.action = rabbitvcs.ui.action.SVNAction(self.svn, notification=False)
         self.action.append(
-            SVNDiff,
-            path_local,
-            None,
-            path_remote,
-            "HEAD",
-            sidebyside=True
+            SVNDiff, path_local, None, path_remote, "HEAD", sidebyside=True
         )
         self.action.schedule()
 
@@ -334,31 +321,25 @@ class CheckRemoteModsContextMenu(object):
 
         self.conditions = CheckRemoteModsContextMenuConditions(self.vcs, paths)
         self.callbacks = CheckRemoteModsContextMenuCallbacks(
-            self.caller,
-            self.base_dir,
-            self.vcs,
-            paths
+            self.caller, self.base_dir, self.vcs, paths
         )
 
         self.structure = [
             (MenuViewDiff, None),
             (MenuCompare, None),
             (MenuSeparator, None),
-            (MenuUpdate, None)
+            (MenuUpdate, None),
         ]
 
     def show(self):
         if len(self.paths) == 0:
             return
 
-        context_menu = GtkContextMenu(
-            self.structure, self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNCheckForModifications
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNCheckForModifications}
 
 
 def checkmods_factory(paths, base_dir):
@@ -368,9 +349,9 @@ def checkmods_factory(paths, base_dir):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT],
-        usage="Usage: rabbitvcs checkmods [url_or_path]"
+        [BASEDIR_OPT], usage="Usage: rabbitvcs checkmods [url_or_path]"
     )
 
     window = checkmods_factory(paths, options.base_dir)

--- a/rabbitvcs/ui/checkout.py
+++ b/rabbitvcs/ui/checkout.py
@@ -8,6 +8,7 @@ import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -35,6 +36,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -57,15 +59,13 @@ class Checkout(InterfaceView):
         self.vcs = rabbitvcs.vcs.VCS()
 
         self.repositories = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("repositories"),
-            helper.get_repository_paths()
+            self.get_widget("repositories"), helper.get_repository_paths()
         )
 
         # We must set a signal handler for the Gtk.Entry inside the combobox
         # Because glade will not retain that information
         self.repositories.set_child_signal(
-            "key-release-event",
-            self.on_repositories_key_released
+            "key-release-event", self.on_repositories_key_released
         )
 
         self.destination = helper.get_user_path()
@@ -113,8 +113,10 @@ class Checkout(InterfaceView):
 
     def on_repo_chooser_clicked(self, widget, data=None):
         from rabbitvcs.ui.browser import SVNBrowserDialog
-        SVNBrowserDialog(self.repositories.get_active_text(),
-                         callback=self.on_repo_chooser_closed)
+
+        SVNBrowserDialog(
+            self.repositories.get_active_text(), callback=self.on_repo_chooser_closed
+        )
 
     def on_repo_chooser_closed(self, new_url):
         self.repositories.set_child_text(new_url)
@@ -142,7 +144,7 @@ class SVNCheckout(Checkout):
             self.svn,
             revision=revision,
             url_combobox=self.repositories,
-            expand=True
+            expand=True,
         )
 
         self.get_widget("options_box").show()
@@ -158,19 +160,18 @@ class SVNCheckout(Checkout):
 
         if not url or not path:
             rabbitvcs.ui.dialog.MessageBox(
-                _("The repository URL and destination path are both required fields."))
+                _("The repository URL and destination path are both required fields.")
+            )
             return
 
         revision = self.revision_selector.get_revision_object()
 
         self.hide()
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Checkout"))
-        self.action.append(self.action.set_status,
-                           _("Running Checkout Command..."))
+        self.action.append(self.action.set_status, _("Running Checkout Command..."))
         self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.svn.checkout,
@@ -178,7 +179,7 @@ class SVNCheckout(Checkout):
             path,
             recurse=recursive,
             revision=revision,
-            ignore_externals=omit_externals
+            ignore_externals=omit_externals,
         )
         self.action.append(self.action.set_status, _("Completed Checkout"))
         self.action.append(self.action.finish)
@@ -218,19 +219,13 @@ class GitCheckoutQuiet(object):
     def __init__(self, path):
         self.vcs = rabbitvcs.vcs.VCS()
         self.git = self.vcs.git(path)
-        self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            run_in_thread=False
-        )
+        self.action = rabbitvcs.ui.action.GitAction(self.git, run_in_thread=False)
 
         self.action.append(self.git.checkout, [path])
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNCheckout,
-    rabbitvcs.vcs.VCS_GIT: GitCheckout
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNCheckout, rabbitvcs.vcs.VCS_GIT: GitCheckout}
 
 
 def checkout_factory(vcs, path=None, url=None, revision=None, quiet=False):
@@ -251,9 +246,10 @@ def checkout_factory(vcs, path=None, url=None, revision=None, quiet=False):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT, QUIET_OPT
+
     (options, args) = main(
         [REVISION_OPT, VCS_OPT, QUIET_OPT],
-        usage="Usage: rabbitvcs checkout --vcs=[git|svn] [url] [path]"
+        usage="Usage: rabbitvcs checkout --vcs=[git|svn] [url] [path]",
     )
 
     # If two arguments are passed:
@@ -274,9 +270,19 @@ if __name__ == "__main__":
 
     if options.quiet:
         window = checkout_factory(
-            options.vcs, path=path, url=url, revision=options.revision, quiet=options.quiet)
+            options.vcs,
+            path=path,
+            url=url,
+            revision=options.revision,
+            quiet=options.quiet,
+        )
     else:
         window = checkout_factory(
-            options.vcs, path=path, url=url, revision=options.revision, quiet=options.quiet)
+            options.vcs,
+            path=path,
+            url=url,
+            revision=options.revision,
+            quiet=options.quiet,
+        )
         window.register_gtk_quit()
         Gtk.main()

--- a/rabbitvcs/ui/checkout.py
+++ b/rabbitvcs/ui/checkout.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.ui.updateto import GitUpdateToRevision
+import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,18 +37,10 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util.strings import S
-import rabbitvcs.vcs
-from rabbitvcs.ui.updateto import GitUpdateToRevision
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class Checkout(InterfaceView):
     """
@@ -113,7 +114,7 @@ class Checkout(InterfaceView):
     def on_repo_chooser_clicked(self, widget, data=None):
         from rabbitvcs.ui.browser import SVNBrowserDialog
         SVNBrowserDialog(self.repositories.get_active_text(),
-            callback=self.on_repo_chooser_closed)
+                         callback=self.on_repo_chooser_closed)
 
     def on_repo_chooser_closed(self, new_url):
         self.repositories.set_child_text(new_url)
@@ -156,7 +157,8 @@ class SVNCheckout(Checkout):
         recursive = self.get_widget("recursive").get_active()
 
         if not url or not path:
-            rabbitvcs.ui.dialog.MessageBox(_("The repository URL and destination path are both required fields."))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("The repository URL and destination path are both required fields."))
             return
 
         revision = self.revision_selector.get_revision_object()
@@ -167,7 +169,8 @@ class SVNCheckout(Checkout):
             register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Checkout"))
-        self.action.append(self.action.set_status, _("Running Checkout Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Checkout Command..."))
         self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.svn.checkout,
@@ -203,11 +206,13 @@ class SVNCheckout(Checkout):
 
         self.check_form()
 
+
 class GitCheckout(GitUpdateToRevision):
     def __init__(self, path, url, revision):
         GitUpdateToRevision.__init__(self, path, revision)
         self.get_widget("Update").set_title(_("Checkout - %s") % path)
         self.get_widget("options_box").hide()
+
 
 class GitCheckoutQuiet(object):
     def __init__(self, path):
@@ -221,10 +226,12 @@ class GitCheckoutQuiet(object):
         self.action.append(self.git.checkout, [path])
         self.action.schedule()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNCheckout,
     rabbitvcs.vcs.VCS_GIT: GitCheckout
 }
+
 
 def checkout_factory(vcs, path=None, url=None, revision=None, quiet=False):
     if not vcs:
@@ -266,8 +273,10 @@ if __name__ == "__main__":
             url = args[0]
 
     if options.quiet:
-        window = checkout_factory(options.vcs, path=path, url=url, revision=options.revision, quiet=options.quiet)
+        window = checkout_factory(
+            options.vcs, path=path, url=url, revision=options.revision, quiet=options.quiet)
     else:
-        window = checkout_factory(options.vcs, path=path, url=url, revision=options.revision, quiet=options.quiet)
+        window = checkout_factory(
+            options.vcs, path=path, url=url, revision=options.revision, quiet=options.quiet)
         window.register_gtk_quit()
         Gtk.main()

--- a/rabbitvcs/ui/clean.py
+++ b/rabbitvcs/ui/clean.py
@@ -7,6 +7,7 @@ from rabbitvcs.ui import InterfaceView
 import time
 from datetime import datetime
 from gi.repository import Gtk, GObject, Gdk, Pango
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -34,6 +35,7 @@ import os
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -57,19 +59,16 @@ class GitClean(InterfaceView):
     def on_ok_clicked(self, widget):
         remove_dir = self.get_widget("remove_directories").get_active()
         remove_ignored_too = self.get_widget("remove_ignored_too").get_active()
-        remove_only_ignored = self.get_widget(
-            "remove_only_ignored").get_active()
+        remove_only_ignored = self.get_widget("remove_only_ignored").get_active()
         dry_run = self.get_widget("dryrun").get_active()
         force = self.get_widget("force").get_active()
 
         self.hide()
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Clean"))
-        self.action.append(self.action.set_status,
-                           _("Running Clean Command..."))
+        self.action.append(self.action.set_status, _("Running Clean Command..."))
         self.action.append(
             self.git.clean,
             self.path,
@@ -77,7 +76,7 @@ class GitClean(InterfaceView):
             remove_ignored_too,
             remove_only_ignored,
             dry_run,
-            force
+            force,
         )
         self.action.append(self.action.set_status, _("Completed Clean"))
         self.action.append(self.action.finish)
@@ -100,6 +99,7 @@ class GitClean(InterfaceView):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
+
     (options, paths) = main(usage="Usage: rabbitvcs clean path")
 
     window = GitClean(paths[0])

--- a/rabbitvcs/ui/clean.py
+++ b/rabbitvcs/ui/clean.py
@@ -1,4 +1,12 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import GitAction
+from rabbitvcs.ui import InterfaceView
+import time
+from datetime import datetime
+from gi.repository import Gtk, GObject, Gdk, Pango
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,19 +36,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk, Pango
 sa.restore()
 
-from datetime import datetime
-import time
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import GitAction
-import rabbitvcs.ui.widget
-import rabbitvcs.vcs
-
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class GitClean(InterfaceView):
     """
@@ -57,7 +57,8 @@ class GitClean(InterfaceView):
     def on_ok_clicked(self, widget):
         remove_dir = self.get_widget("remove_directories").get_active()
         remove_ignored_too = self.get_widget("remove_ignored_too").get_active()
-        remove_only_ignored = self.get_widget("remove_only_ignored").get_active()
+        remove_only_ignored = self.get_widget(
+            "remove_only_ignored").get_active()
         dry_run = self.get_widget("dryrun").get_active()
         force = self.get_widget("force").get_active()
 
@@ -67,7 +68,8 @@ class GitClean(InterfaceView):
             register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Clean"))
-        self.action.append(self.action.set_status, _("Running Clean Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Clean Command..."))
         self.action.append(
             self.git.clean,
             self.path,

--- a/rabbitvcs/ui/cleanup.py
+++ b/rabbitvcs/ui/cleanup.py
@@ -1,4 +1,9 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui import InterfaceNonView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,15 +31,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceNonView
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.vcs
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNCleanup(InterfaceNonView):
     """

--- a/rabbitvcs/ui/cleanup.py
+++ b/rabbitvcs/ui/cleanup.py
@@ -4,6 +4,7 @@ import rabbitvcs.vcs
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui import InterfaceNonView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -29,6 +30,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -53,10 +55,7 @@ class SVNCleanup(InterfaceNonView):
         self.svn = self.vcs.svn()
 
     def start(self):
-        self.action = SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
-        )
+        self.action = SVNAction(self.svn, register_gtk_quit=self.gtk_quit_is_set())
 
         self.action.append(self.action.set_header, _("Cleanup"))
         self.action.append(self.action.set_status, _("Cleaning Up..."))
@@ -68,6 +67,7 @@ class SVNCleanup(InterfaceNonView):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
+
     (options, paths) = main(usage="Usage: rabbitvcs cleanup [path]")
 
     window = SVNCleanup(paths[0])

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.checkout import Checkout
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,19 +37,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.checkout import Checkout
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util.strings import S
-import rabbitvcs.vcs
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class GitClone(Checkout):
     def __init__(self, path=None, url=None):
@@ -61,7 +62,8 @@ class GitClone(Checkout):
         path = self._get_path().strip()
 
         if not url or not path:
-            rabbitvcs.ui.dialog.MessageBox(_("The repository URL and destination path are both required fields."))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("The repository URL and destination path are both required fields."))
             return
 
         self.hide()
@@ -70,7 +72,8 @@ class GitClone(Checkout):
             register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Clone"))
-        self.action.append(self.action.set_status, _("Running Clone Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Clone Command..."))
         self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.git.clone,
@@ -110,9 +113,11 @@ class GitClone(Checkout):
 
         self.get_widget("ok").set_sensitive(self.complete)
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_GIT: GitClone
 }
+
 
 def clone_factory(classes_map, vcs, path=None, url=None):
     return classes_map[vcs](path, url)

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -8,6 +8,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.ui.checkout import Checkout
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -35,6 +36,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -63,23 +65,18 @@ class GitClone(Checkout):
 
         if not url or not path:
             rabbitvcs.ui.dialog.MessageBox(
-                _("The repository URL and destination path are both required fields."))
+                _("The repository URL and destination path are both required fields.")
+            )
             return
 
         self.hide()
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Clone"))
-        self.action.append(self.action.set_status,
-                           _("Running Clone Command..."))
+        self.action.append(self.action.set_status, _("Running Clone Command..."))
         self.action.append(helper.save_repository_path, url)
-        self.action.append(
-            self.git.clone,
-            url,
-            path
-        )
+        self.action.append(self.git.clone, url, path)
         self.action.append(self.action.set_status, _("Completed Clone"))
         self.action.append(self.action.finish)
         self.action.schedule()
@@ -93,15 +90,17 @@ class GitClone(Checkout):
         if append.endswith(".git"):
             append = append[:-4]
 
-        helper.run_in_main_thread(self.get_widget("destination").set_text,
-                                  S(os.path.join(self.destination, append)).display())
+        helper.run_in_main_thread(
+            self.get_widget("destination").set_text,
+            S(os.path.join(self.destination, append)).display(),
+        )
         self.check_form()
 
     def default_text(self):
         # Use a repo url from the clipboard by default.
         clipboard = Gtk.Clipboard.get(Gdk.Atom.intern("CLIPBOARD", False))
         text = clipboard.wait_for_text()
-        if text and text.endswith(('.git', '.git/')):
+        if text and text.endswith((".git", ".git/")):
             self.repositories.set_child_text(text)
 
     def check_form(self):
@@ -114,9 +113,7 @@ class GitClone(Checkout):
         self.get_widget("ok").set_sensitive(self.complete)
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_GIT: GitClone
-}
+classes_map = {rabbitvcs.vcs.VCS_GIT: GitClone}
 
 
 def clone_factory(classes_map, vcs, path=None, url=None):
@@ -125,9 +122,9 @@ def clone_factory(classes_map, vcs, path=None, url=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT
+
     (options, args) = main(
-        [VCS_OPT],
-        usage="Usage: rabbitvcs clone --vcs=git [url] [path]"
+        [VCS_OPT], usage="Usage: rabbitvcs clone --vcs=git [url] [path]"
     )
 
     # Default to using git

--- a/rabbitvcs/ui/commit.py
+++ b/rabbitvcs/ui/commit.py
@@ -11,6 +11,7 @@ import rabbitvcs.ui.action
 from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk, GLib
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -40,6 +41,7 @@ from time import sleep
 from rabbitvcs.util import helper
 
 from gi import require_version
+
 require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -58,6 +60,7 @@ class Commit(InterfaceView, GtkContextMenuCaller):
     changes to a repository.  Pass it a list of local paths to commit.
 
     """
+
     SETTINGS = rabbitvcs.util.settings.SettingsManager()
 
     TOGGLE_ALL = False
@@ -82,40 +85,41 @@ class Commit(InterfaceView, GtkContextMenuCaller):
 
         self.files_table = rabbitvcs.ui.widget.Table(
             self.get_widget("files_table"),
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+            [
+                GObject.TYPE_BOOLEAN,
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
                 rabbitvcs.ui.widget.TYPE_PATH,
-                GObject.TYPE_STRING, rabbitvcs.ui.widget.TYPE_STATUS,
-                GObject.TYPE_STRING],
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"), _("Extension"),
-                _("Text Status"), _("Property Status")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 2
+                GObject.TYPE_STRING,
+                rabbitvcs.ui.widget.TYPE_STATUS,
+                GObject.TYPE_STRING,
+            ],
+            [
+                rabbitvcs.ui.widget.TOGGLE_BUTTON,
+                "",
+                _("Path"),
+                _("Extension"),
+                _("Text Status"),
+                _("Property Status"),
+            ],
+            filters=[
+                {
+                    "callback": rabbitvcs.ui.widget.path_filter,
+                    "user_data": {"base_dir": base_dir, "column": 2},
                 }
-            }],
+            ],
             callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event,
-                "key-event":     self.on_files_table_key_event,
-                "row-toggled":   self.on_files_table_toggle_event
+                "row-activated": self.on_files_table_row_activated,
+                "mouse-event": self.on_files_table_mouse_event,
+                "key-event": self.on_files_table_key_event,
+                "row-toggled": self.on_files_table_toggle_event,
             },
-            flags={
-                "sortable": True,
-                "sort_on": 2
-            }
+            flags={"sortable": True, "sort_on": 2},
         )
         self.files_table.allow_multiple()
-        self.get_widget("toggle_show_unversioned").set_active(
-            self.SHOW_UNVERSIONED)
+        self.get_widget("toggle_show_unversioned").set_active(self.SHOW_UNVERSIONED)
         if not message:
-            message = self.SETTINGS.get_multiline(
-                "general", "default_commit_message")
-        self.message = rabbitvcs.ui.widget.TextView(
-            self.get_widget("message"),
-            message
-        )
+            message = self.SETTINGS.get_multiline("general", "default_commit_message")
+        self.message = rabbitvcs.ui.widget.TextView(self.get_widget("message"), message)
 
         self.paths = []
         for path in paths:
@@ -128,16 +132,17 @@ class Commit(InterfaceView, GtkContextMenuCaller):
 
     def load(self):
         """
-          - Gets a listing of file items that are valid for the commit window.
-          - Determines which items should be "activated" by default
-          - Populates the files table with the retrieved items
-          - Updates the status area
+        - Gets a listing of file items that are valid for the commit window.
+        - Determines which items should be "activated" by default
+        - Populates the files table with the retrieved items
+        - Updates the status area
         """
 
         self.get_widget("status").set_text(_("Loading..."))
 
         self.items = self.vcs.get_items(
-            self.paths, self.vcs.statuses_for_commit(self.paths))
+            self.paths, self.vcs.statuses_for_commit(self.paths)
+        )
 
         self.populate_files_table()
 
@@ -150,9 +155,11 @@ class Commit(InterfaceView, GtkContextMenuCaller):
         Determines if a file should be activated or not
         """
 
-        if (S(item.path) in self.paths
-                or item.is_versioned()
-                and item.simple_content_status() != rabbitvcs.vcs.status.status_missing):
+        if (
+            S(item.path) in self.paths
+            or item.is_versioned()
+            and item.simple_content_status() != rabbitvcs.vcs.status.status_missing
+        ):
             return True
 
         return False
@@ -193,8 +200,10 @@ class Commit(InterfaceView, GtkContextMenuCaller):
         if InterfaceView.on_key_pressed(self, widget, event, *args):
             return True
 
-        if (event.state & Gdk.ModifierType.CONTROL_MASK and
-                Gdk.keyval_name(event.keyval) == "Return"):
+        if (
+            event.state & Gdk.ModifierType.CONTROL_MASK
+            and Gdk.keyval_name(event.keyval) == "Return"
+        ):
             self.on_ok_clicked(widget)
             return True
 
@@ -210,10 +219,12 @@ class Commit(InterfaceView, GtkContextMenuCaller):
         self.populate_files_table()
 
         # Save this preference for future commits.
-        if self.SETTINGS.get("general", "show_unversioned_files") != self.SHOW_UNVERSIONED:
+        if (
+            self.SETTINGS.get("general", "show_unversioned_files")
+            != self.SHOW_UNVERSIONED
+        ):
             self.SETTINGS.set(
-                "general", "show_unversioned_files",
-                self.SHOW_UNVERSIONED
+                "general", "show_unversioned_files", self.SHOW_UNVERSIONED
             )
             self.SETTINGS.write()
 
@@ -262,18 +273,19 @@ class Commit(InterfaceView, GtkContextMenuCaller):
             if not self.should_item_be_visible(item):
                 continue
 
-            self.files_table.append([
-                checked,
-                S(item.path),
-                item.path,
-                helper.get_file_extension(item.path),
-                item.simple_content_status(),
-                item.simple_metadata_status()
-            ])
-        self.get_widget("status").set_text(_("Found %(changed)d changed and %(unversioned)d unversioned item(s)") % {
-            "changed": n,
-            "unversioned": m
-        }
+            self.files_table.append(
+                [
+                    checked,
+                    S(item.path),
+                    item.path,
+                    helper.get_file_extension(item.path),
+                    item.simple_content_status(),
+                    item.simple_metadata_status(),
+                ]
+            )
+        self.get_widget("status").set_text(
+            _("Found %(changed)d changed and %(unversioned)d unversioned item(s)")
+            % {"changed": n, "unversioned": m}
         )
 
 
@@ -302,8 +314,7 @@ class SVNCommit(Commit):
         added = 0
         recurse = False
         for item in items:
-            status = self.vcs.status(
-                item, summarize=False).simple_content_status()
+            status = self.vcs.status(item, summarize=False).simple_content_status()
             try:
                 if status == rabbitvcs.vcs.status.status_unversioned:
                     self.vcs.svn().add(item)
@@ -316,30 +327,28 @@ class SVNCommit(Commit):
             except Exception as e:
                 log.exception(e)
 
-        ticks = added + len(items)*2
+        ticks = added + len(items) * 2
 
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.vcs.svn(),
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.vcs.svn(), register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.set_pbar_ticks(ticks)
         self.action.append(self.action.set_header, _("Commit"))
-        self.action.append(self.action.set_status,
-                           _("Running Commit Command..."))
-        self.action.append(
-            helper.save_log_message,
-            self.message.get_text()
-        ),
+        self.action.append(self.action.set_status, _("Running Commit Command..."))
+        self.action.append(helper.save_log_message, self.message.get_text()),
         self.action.append(self.do_commit, items, recurse)
         self.action.append(self.action.finish)
         self.action.schedule()
 
     def do_commit(self, items, recurse):
         # pysvn.Revision
-        revision = self.vcs.svn().commit(items, self.message.get_text(), recurse=recurse)
+        revision = self.vcs.svn().commit(
+            items, self.message.get_text(), recurse=recurse
+        )
 
-        self.action.set_status(_("Completed Commit") +
-                               " at Revision: " + str(revision.number))
+        self.action.set_status(
+            _("Completed Commit") + " at Revision: " + str(revision.number)
+        )
 
     def on_files_table_toggle_event(self, row, col):
         # Adds path: True/False to the dict
@@ -356,9 +365,7 @@ class GitCommit(Commit):
 
         active_branch = self.git.get_active_branch()
         if active_branch:
-            self.get_widget("to").set_text(
-                S(active_branch.name).display()
-            )
+            self.get_widget("to").set_text(S(active_branch.name).display())
         else:
             self.get_widget("to").set_text("No active branch")
 
@@ -377,8 +384,7 @@ class GitCommit(Commit):
         staged = 0
         for item in items:
             try:
-                status = self.vcs.status(
-                    item, summarize=False).simple_content_status()
+                status = self.vcs.status(item, summarize=False).simple_content_status()
                 if status == rabbitvcs.vcs.status.status_missing:
                     self.git.checkout([item])
                     self.git.remove(item)
@@ -388,24 +394,16 @@ class GitCommit(Commit):
             except Exception as e:
                 log.exception(e)
 
-        ticks = staged + len(items)*2
+        ticks = staged + len(items) * 2
 
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.set_pbar_ticks(ticks)
         self.action.append(self.action.set_header, _("Commit"))
-        self.action.append(self.action.set_status,
-                           _("Running Commit Command..."))
-        self.action.append(
-            helper.save_log_message,
-            self.message.get_text()
-        )
-        self.action.append(
-            self.git.commit,
-            self.message.get_text()
-        )
+        self.action.append(self.action.set_status, _("Running Commit Command..."))
+        self.action.append(helper.save_log_message, self.message.get_text())
+        self.action.append(self.git.commit, self.message.get_text())
         self.action.append(self.action.set_status, _("Completed Commit"))
         self.action.append(self.action.finish)
         self.action.schedule()
@@ -415,10 +413,7 @@ class GitCommit(Commit):
         self.changes[row[1]] = row[col]
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNCommit,
-    rabbitvcs.vcs.VCS_GIT: GitCommit
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNCommit, rabbitvcs.vcs.VCS_GIT: GitCommit}
 
 
 def commit_factory(paths, base_dir=None, message=None):
@@ -428,10 +423,10 @@ def commit_factory(paths, base_dir=None, message=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT, (["-m", "--message"],
-                       {"help": "add a commit log message"})],
-        usage="Usage: rabbitvcs commit [path1] [path2] ..."
+        [BASEDIR_OPT, (["-m", "--message"], {"help": "add a commit log message"})],
+        usage="Usage: rabbitvcs commit [path1] [path2] ...",
     )
 
     window = commit_factory(paths, options.base_dir, message=options.message)

--- a/rabbitvcs/ui/create.py
+++ b/rabbitvcs/ui/create.py
@@ -3,6 +3,7 @@ from rabbitvcs import gettext
 from rabbitvcs.ui.action import GitAction
 import rabbitvcs.ui.dialog
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -31,6 +32,7 @@ import subprocess
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -53,11 +55,13 @@ class SVNCreate(object):
         # Let svnadmin return a bad value if a repo already exists there
         ret = subprocess.call(["/usr/bin/svnadmin", "create", path])
         if ret == 0:
-            rabbitvcs.ui.dialog.MessageBox(
-                _("Repository successfully created"))
+            rabbitvcs.ui.dialog.MessageBox(_("Repository successfully created"))
         else:
             rabbitvcs.ui.dialog.MessageBox(
-                _("There was an error creating the repository.  Make sure the given folder is empty."))
+                _(
+                    "There was an error creating the repository.  Make sure the given folder is empty."
+                )
+            )
 
 
 class GitCreate(object):
@@ -67,31 +71,25 @@ class GitCreate(object):
         self.git = self.vcs.git()
         self.path = path
 
-        self.action = GitAction(
-            self.git,
-            register_gtk_quit=True
-        )
+        self.action = GitAction(self.git, register_gtk_quit=True)
 
         self.action.append(self.action.set_header, _("Initialize Repository"))
-        self.action.append(self.action.set_status,
-                           _("Setting up repository..."))
+        self.action.append(self.action.set_status, _("Setting up repository..."))
         self.action.append(self.git.initialize_repository, self.path)
-        self.action.append(self.action.set_status,
-                           _("Completed repository setup"))
+        self.action.append(self.action.set_status, _("Completed repository setup"))
         self.action.append(self.action.finish)
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNCreate,
-    rabbitvcs.vcs.VCS_GIT: GitCreate
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNCreate, rabbitvcs.vcs.VCS_GIT: GitCreate}
 
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT, VCS_OPT_ERROR
+
     (options, paths) = main(
-        [VCS_OPT], usage="Usage: rabbitvcs create --vcs [svn|git] path")
+        [VCS_OPT], usage="Usage: rabbitvcs create --vcs [svn|git] path"
+    )
     if options.vcs:
         window = classes_map[options.vcs](paths[0])
         if options.vcs == rabbitvcs.vcs.VCS_GIT:

--- a/rabbitvcs/ui/create.py
+++ b/rabbitvcs/ui/create.py
@@ -1,4 +1,8 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.ui.action import GitAction
+import rabbitvcs.ui.dialog
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -29,14 +33,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-import rabbitvcs.ui.dialog
-from rabbitvcs.ui.action import GitAction
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNCreate(object):
     """
@@ -46,16 +47,18 @@ class SVNCreate(object):
     # Also, might want to just launch a terminal window instead of this
     def __init__(self, path):
 
-
         if not os.path.isdir(path):
             os.makedirs(path)
 
         # Let svnadmin return a bad value if a repo already exists there
         ret = subprocess.call(["/usr/bin/svnadmin", "create", path])
         if ret == 0:
-            rabbitvcs.ui.dialog.MessageBox(_("Repository successfully created"))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("Repository successfully created"))
         else:
-            rabbitvcs.ui.dialog.MessageBox(_("There was an error creating the repository.  Make sure the given folder is empty."))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("There was an error creating the repository.  Make sure the given folder is empty."))
+
 
 class GitCreate(object):
     # Also, might want to just launch a terminal window instead of this
@@ -70,11 +73,14 @@ class GitCreate(object):
         )
 
         self.action.append(self.action.set_header, _("Initialize Repository"))
-        self.action.append(self.action.set_status, _("Setting up repository..."))
+        self.action.append(self.action.set_status,
+                           _("Setting up repository..."))
         self.action.append(self.git.initialize_repository, self.path)
-        self.action.append(self.action.set_status, _("Completed repository setup"))
+        self.action.append(self.action.set_status,
+                           _("Completed repository setup"))
         self.action.append(self.action.finish)
         self.action.schedule()
+
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNCreate,
@@ -84,7 +90,8 @@ classes_map = {
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT, VCS_OPT_ERROR
-    (options, paths) = main([VCS_OPT], usage="Usage: rabbitvcs create --vcs [svn|git] path")
+    (options, paths) = main(
+        [VCS_OPT], usage="Usage: rabbitvcs create --vcs [svn|git] path")
     if options.vcs:
         window = classes_map[options.vcs](paths[0])
         if options.vcs == rabbitvcs.vcs.VCS_GIT:

--- a/rabbitvcs/ui/createpatch.py
+++ b/rabbitvcs/ui/createpatch.py
@@ -9,6 +9,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.ui.action import SVNAction, GitAction
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -39,6 +40,7 @@ import six.moves._thread
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -82,33 +84,39 @@ class CreatePatch(InterfaceView):
         self.common = helper.get_common_directory(paths)
 
         if not self.vcs.is_versioned(self.common):
-            rabbitvcs.ui.dialog.MessageBox(
-                _("The given path is not a working copy"))
+            rabbitvcs.ui.dialog.MessageBox(_("The given path is not a working copy"))
             raise SystemExit()
 
         self.files_table = rabbitvcs.ui.widget.Table(
             self.get_widget("files_table"),
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+            [
+                GObject.TYPE_BOOLEAN,
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
                 rabbitvcs.ui.widget.TYPE_PATH,
-                GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"), _("Extension"),
-                _("Text Status"), _("Property Status")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 2
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+            ],
+            [
+                rabbitvcs.ui.widget.TOGGLE_BUTTON,
+                "",
+                _("Path"),
+                _("Extension"),
+                _("Text Status"),
+                _("Property Status"),
+            ],
+            filters=[
+                {
+                    "callback": rabbitvcs.ui.widget.path_filter,
+                    "user_data": {"base_dir": base_dir, "column": 2},
                 }
-            }],
+            ],
             callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event,
-                "key-event":     self.on_files_table_key_event
+                "row-activated": self.on_files_table_row_activated,
+                "mouse-event": self.on_files_table_mouse_event,
+                "key-event": self.on_files_table_key_event,
             },
-            flags={
-                "sortable": True,
-                "sort_on": 2
-            }
+            flags={"sortable": True, "sort_on": 2},
         )
         self.files_table.allow_multiple()
 
@@ -123,9 +131,8 @@ class CreatePatch(InterfaceView):
         path = ""
 
         dialog = Gtk.FileChooserDialog(
-            title=_("Create Patch"),
-            parent=None,
-            action=Gtk.FileChooserAction.SAVE)
+            title=_("Create Patch"), parent=None, action=Gtk.FileChooserAction.SAVE
+        )
         dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("_Create"), Gtk.ResponseType.OK)
         dialog.set_do_overwrite_confirmation(True)
@@ -166,10 +173,9 @@ class SVNCreatePatch(CreatePatch, SVNCommit):
             self.close()
             return
 
-        ticks = len(items)*2
+        ticks = len(items) * 2
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.set_pbar_ticks(ticks)
         self.action.append(self.action.set_header, _("Create Patch"))
@@ -191,7 +197,7 @@ class SVNCreatePatch(CreatePatch, SVNCommit):
                     rel_path,
                     self.svn.revision("base"),
                     rel_path,
-                    self.svn.revision("working")
+                    self.svn.revision("working"),
                 )
                 fileObj.write(diff_text)
 
@@ -234,10 +240,9 @@ class GitCreatePatch(CreatePatch, GitCommit):
             self.close()
             return
 
-        ticks = len(items)*2
+        ticks = len(items) * 2
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.set_pbar_ticks(ticks)
         self.action.append(self.action.set_header, _("Create Patch"))
@@ -258,7 +263,7 @@ class GitCreatePatch(CreatePatch, GitCommit):
                     rel_path,
                     self.git.revision("HEAD"),
                     rel_path,
-                    self.git.revision("WORKING")
+                    self.git.revision("WORKING"),
                 )
                 fileObj.write(diff_text)
 
@@ -277,7 +282,7 @@ class GitCreatePatch(CreatePatch, GitCommit):
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNCreatePatch,
-    rabbitvcs.vcs.VCS_GIT: GitCreatePatch
+    rabbitvcs.vcs.VCS_GIT: GitCreatePatch,
 }
 
 
@@ -288,9 +293,9 @@ def createpatch_factory(paths, base_dir):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT],
-        usage="Usage: rabbitvcs createpatch [path1] [path2] ..."
+        [BASEDIR_OPT], usage="Usage: rabbitvcs createpatch [path1] [path2] ..."
     )
 
     window = createpatch_factory(paths, options.base_dir)

--- a/rabbitvcs/ui/createpatch.py
+++ b/rabbitvcs/ui/createpatch.py
@@ -1,4 +1,14 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.ui.commit import SVNCommit, GitCommit
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+import rabbitvcs.util
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import SVNAction, GitAction
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -31,24 +41,15 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import SVNAction, GitAction
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.util
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
-from rabbitvcs.ui.commit import SVNCommit, GitCommit
 
 log = Log("rabbitvcs.ui.createpatch")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
 helper.gobject_threads_init()
+
 
 class CreatePatch(InterfaceView):
     """
@@ -81,7 +82,8 @@ class CreatePatch(InterfaceView):
         self.common = helper.get_common_directory(paths)
 
         if not self.vcs.is_versioned(self.common):
-            rabbitvcs.ui.dialog.MessageBox(_("The given path is not a working copy"))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("The given path is not a working copy"))
             raise SystemExit()
 
         self.files_table = rabbitvcs.ui.widget.Table(
@@ -121,9 +123,9 @@ class CreatePatch(InterfaceView):
         path = ""
 
         dialog = Gtk.FileChooserDialog(
-            title = _("Create Patch"),
-            parent = None,
-            action = Gtk.FileChooserAction.SAVE)
+            title=_("Create Patch"),
+            parent=None,
+            action=Gtk.FileChooserAction.SAVE)
         dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("_Create"), Gtk.ResponseType.OK)
         dialog.set_do_overwrite_confirmation(True)
@@ -139,6 +141,7 @@ class CreatePatch(InterfaceView):
         dialog.destroy()
 
         return path
+
 
 class SVNCreatePatch(CreatePatch, SVNCommit):
     def __init__(self, paths, base_dir=None):
@@ -173,7 +176,7 @@ class SVNCreatePatch(CreatePatch, SVNCommit):
         self.action.append(self.action.set_status, _("Creating Patch File..."))
 
         def create_patch_action(patch_path, patch_items, base_dir):
-            fileObj = open(patch_path,"w")
+            fileObj = open(patch_path, "w")
 
             # PySVN takes a path to create its own temp files...
             temp_dir = tempfile.mkdtemp(prefix=rabbitvcs.TEMP_DIR_PREFIX)
@@ -196,7 +199,7 @@ class SVNCreatePatch(CreatePatch, SVNCommit):
 
             # Note: if we don't want to ignore errors here, we could define a
             # function that logs failures.
-            shutil.rmtree(temp_dir, ignore_errors = True)
+            shutil.rmtree(temp_dir, ignore_errors=True)
 
         self.action.append(create_patch_action, path, items, self.common)
 
@@ -206,6 +209,7 @@ class SVNCreatePatch(CreatePatch, SVNCommit):
 
         # TODO: Open the diff file (meld is going to add support in a future version :()
         # helper.launch_diff_tool(path)
+
 
 class GitCreatePatch(CreatePatch, GitCommit):
     def __init__(self, paths, base_dir=None):
@@ -240,7 +244,7 @@ class GitCreatePatch(CreatePatch, GitCommit):
         self.action.append(self.action.set_status, _("Creating Patch File..."))
 
         def create_patch_action(patch_path, patch_items, base_dir):
-            fileObj = open(patch_path,"w")
+            fileObj = open(patch_path, "w")
 
             # PySVN takes a path to create its own temp files...
             temp_dir = tempfile.mkdtemp(prefix=rabbitvcs.TEMP_DIR_PREFIX)
@@ -262,7 +266,7 @@ class GitCreatePatch(CreatePatch, GitCommit):
 
             # Note: if we don't want to ignore errors here, we could define a
             # function that logs failures.
-            shutil.rmtree(temp_dir, ignore_errors = True)
+            shutil.rmtree(temp_dir, ignore_errors=True)
 
         self.action.append(create_patch_action, path, items, self.common)
 
@@ -270,10 +274,12 @@ class GitCreatePatch(CreatePatch, GitCommit):
         self.action.append(self.action.finish)
         self.action.schedule()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNCreatePatch,
     rabbitvcs.vcs.VCS_GIT: GitCreatePatch
 }
+
 
 def createpatch_factory(paths, base_dir):
     guess = rabbitvcs.vcs.guess(paths[0])

--- a/rabbitvcs/ui/delete.py
+++ b/rabbitvcs/ui/delete.py
@@ -5,6 +5,7 @@ import rabbitvcs.vcs
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui import InterfaceNonView
 from gi.repository import Gtk, GObject
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -32,6 +33,7 @@ import os.path
 from rabbitvcs.util import helper
 
 from gi import require_version
+
 require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -107,10 +109,7 @@ class GitDelete(Delete):
             self.vcs.git(paths[0]).remove(paths)
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNDelete,
-    rabbitvcs.vcs.VCS_GIT: GitDelete
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNDelete, rabbitvcs.vcs.VCS_GIT: GitDelete}
 
 
 def delete_factory(paths):
@@ -120,8 +119,8 @@ def delete_factory(paths):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
-    (options, paths) = main(
-        usage="Usage: rabbitvcs delete [path1] [path2] ...")
+
+    (options, paths) = main(usage="Usage: rabbitvcs delete [path1] [path2] ...")
 
     window = delete_factory(paths)
     window.register_gtk_quit()

--- a/rabbitvcs/ui/delete.py
+++ b/rabbitvcs/ui/delete.py
@@ -1,4 +1,10 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+import rabbitvcs.vcs
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui import InterfaceNonView
+from gi.repository import Gtk, GObject
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,18 +34,13 @@ from rabbitvcs.util import helper
 from gi import require_version
 require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject
 sa.restore()
 
-from rabbitvcs.ui import InterfaceNonView
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.vcs
-from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.delete")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class Delete(InterfaceNonView):
     """
@@ -87,6 +88,7 @@ class Delete(InterfaceNonView):
                 for path in unversioned:
                     helper.delete_item(path)
 
+
 class SVNDelete(Delete):
     def __init__(self, paths):
         Delete.__init__(self, paths)
@@ -94,6 +96,7 @@ class SVNDelete(Delete):
     def vcs_remove(self, paths, **kwargs):
         if rabbitvcs.vcs.guess(paths[0])["vcs"] == rabbitvcs.vcs.VCS_SVN:
             self.vcs.svn().remove(paths, **kwargs)
+
 
 class GitDelete(Delete):
     def __init__(self, paths):
@@ -103,10 +106,12 @@ class GitDelete(Delete):
         if rabbitvcs.vcs.guess(paths[0])["vcs"] == rabbitvcs.vcs.VCS_GIT:
             self.vcs.git(paths[0]).remove(paths)
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNDelete,
     rabbitvcs.vcs.VCS_GIT: GitDelete
 }
+
 
 def delete_factory(paths):
     guess = rabbitvcs.vcs.guess(paths[0])
@@ -115,7 +120,8 @@ def delete_factory(paths):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
-    (options, paths) = main(usage="Usage: rabbitvcs delete [path1] [path2] ...")
+    (options, paths) = main(
+        usage="Usage: rabbitvcs delete [path1] [path2] ...")
 
     window = delete_factory(paths)
     window.register_gtk_quit()

--- a/rabbitvcs/ui/dialog.py
+++ b/rabbitvcs/ui/dialog.py
@@ -5,6 +5,7 @@ import rabbitvcs.ui.wraplabel
 import rabbitvcs.ui.widget
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk, Pango
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -30,39 +31,38 @@ from gi.repository import Gtk, GObject, Gdk, Pango
 from gettext import gettext as _
 import os.path
 import gi
+
 gi.require_version("Gtk", "3.0")
 
 
-ERROR_NOTICE = _("""\
+ERROR_NOTICE = _(
+    """\
 An error has occurred in the RabbitVCS Nautilus extension. Please contact the \
 <a href="%s">RabbitVCS team</a> with the error details listed below:"""
-                 % (rabbitvcs.WEBSITE))
+    % (rabbitvcs.WEBSITE)
+)
 
 
 class PreviousMessages(InterfaceView):
     def __init__(self):
-        InterfaceView.__init__(
-            self, "dialogs/previous_messages", "PreviousMessages")
+        InterfaceView.__init__(self, "dialogs/previous_messages", "PreviousMessages")
 
-        self.message = rabbitvcs.ui.widget.TextView(
-            self.get_widget("prevmes_message")
-        )
+        self.message = rabbitvcs.ui.widget.TextView(self.get_widget("prevmes_message"))
 
         self.message_table = rabbitvcs.ui.widget.Table(
             self.get_widget("prevmes_table"),
             [GObject.TYPE_STRING, GObject.TYPE_STRING],
             [_("Date"), _("Message")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.long_text_filter,
-                "user_data": {
-                    "column": 1,
-                    "cols": 80
+            filters=[
+                {
+                    "callback": rabbitvcs.ui.widget.long_text_filter,
+                    "user_data": {"column": 1, "cols": 80},
                 }
-            }],
+            ],
             callbacks={
                 "cursor-changed": self.on_prevmes_table_cursor_changed,
-                "row-activated":  self.on_prevmes_table_row_activated
-            }
+                "row-activated": self.on_prevmes_table_row_activated,
+            },
         )
         self.entries = rabbitvcs.util.helper.get_previous_messages()
         if self.entries is None:
@@ -109,7 +109,8 @@ class FolderChooser(object):
         self.dialog = Gtk.FileChooserDialog(
             title=_("Select a Folder"),
             parent=None,
-            action=Gtk.FileChooserAction.SELECT_FOLDER)
+            action=Gtk.FileChooserAction.SELECT_FOLDER,
+        )
         self.dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         self.dialog.add_button(_("_Select"), Gtk.ResponseType.OK)
         self.dialog.set_default_response(Gtk.ResponseType.OK)
@@ -130,8 +131,15 @@ class Certificate(InterfaceView):
 
     """
 
-    def __init__(self, realm="", host="",
-                 issuer="", valid_from="", valid_until="", fingerprint=""):
+    def __init__(
+        self,
+        realm="",
+        host="",
+        issuer="",
+        valid_from="",
+        valid_until="",
+        fingerprint="",
+    ):
 
         InterfaceView.__init__(self, "dialogs/certificate", "Certificate")
 
@@ -162,8 +170,7 @@ class Certificate(InterfaceView):
 
 class Authentication(InterfaceView):
     def __init__(self, realm="", may_save=True):
-        InterfaceView.__init__(
-            self, "dialogs/authentication", "Authentication")
+        InterfaceView.__init__(self, "dialogs/authentication", "Authentication")
 
         self.get_widget("auth_realm").set_label(realm)
         self.get_widget("auth_save").set_sensitive(may_save)
@@ -187,7 +194,8 @@ class Authentication(InterfaceView):
 class CertAuthentication(InterfaceView):
     def __init__(self, realm="", may_save=True):
         InterfaceView.__init__(
-            self, "dialogs/cert_authentication", "CertAuthentication")
+            self, "dialogs/cert_authentication", "CertAuthentication"
+        )
 
         self.get_widget("certauth_realm").set_label(realm)
         self.get_widget("certauth_save").set_sensitive(may_save)
@@ -209,7 +217,8 @@ class CertAuthentication(InterfaceView):
 class SSLClientCertPrompt(InterfaceView):
     def __init__(self, realm="", may_save=True):
         InterfaceView.__init__(
-            self, "dialogs/ssl_client_cert_prompt", "SSLClientCertPrompt")
+            self, "dialogs/ssl_client_cert_prompt", "SSLClientCertPrompt"
+        )
 
         self.get_widget("sslclientcert_realm").set_label(realm)
         self.get_widget("sslclientcert_save").set_sensitive(may_save)
@@ -243,27 +252,26 @@ class Property(InterfaceView):
 
         self.name = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("property_name"),
-            [   # default svn properties
-                'svn:author',
-                'svn:autoversioned',
-                'svn:date',
-                'svn:eol-style',
-                'svn:executable',
-                'svn:externals',
-                'svn:ignore',
-                'svn:keywords',
-                'svn:log',
-                'svn:mergeinfo',
-                'svn:mime-type',
-                'svn:needs-lock',
-                'svn:special',
-            ]
+            [  # default svn properties
+                "svn:author",
+                "svn:autoversioned",
+                "svn:date",
+                "svn:eol-style",
+                "svn:executable",
+                "svn:externals",
+                "svn:ignore",
+                "svn:keywords",
+                "svn:log",
+                "svn:mergeinfo",
+                "svn:mime-type",
+                "svn:needs-lock",
+                "svn:special",
+            ],
         )
         self.name.set_child_text(name)
 
         self.value = rabbitvcs.ui.widget.TextView(
-            self.get_widget("property_value"),
-            value
+            self.get_widget("property_value"), value
         )
 
         self.recurse = self.get_widget("property_recurse")
@@ -288,11 +296,10 @@ class Property(InterfaceView):
 class FileChooser(object):
     def __init__(self, title=_("Select a File"), folder=None):
         self.dialog = Gtk.FileChooserDialog(
-            title=title,
-            parent=None,
-            action=Gtk.FileChooserAction.OPEN)
+            title=title, parent=None, action=Gtk.FileChooserAction.OPEN
+        )
         self.dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        self.dialog.add_button(_("_Open"),   Gtk.ResponseType.OK)
+        self.dialog.add_button(_("_Open"), Gtk.ResponseType.OK)
         if folder is not None:
             self.dialog.set_current_folder(folder)
         self.dialog.set_default_response(Gtk.ResponseType.OK)
@@ -309,11 +316,10 @@ class FileChooser(object):
 class FileSaveAs(object):
     def __init__(self, title=_("Save As..."), folder=None):
         self.dialog = Gtk.FileChooserDialog(
-            title=title,
-            parent=None,
-            action=Gtk.FileChooserAction.SAVE)
+            title=title, parent=None, action=Gtk.FileChooserAction.SAVE
+        )
         self.dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        self.dialog.add_button(_("_Save"),   Gtk.ResponseType.OK)
+        self.dialog.add_button(_("_Save"), Gtk.ResponseType.OK)
         if folder is not None:
             self.dialog.set_current_folder(folder)
         self.dialog.set_default_response(Gtk.ResponseType.OK)
@@ -354,10 +360,11 @@ class MessageBox(InterfaceView):
 class DeleteConfirmation(InterfaceView):
     def __init__(self, path=None):
         InterfaceView.__init__(
-            self, "dialogs/delete_confirmation", "DeleteConfirmation")
+            self, "dialogs/delete_confirmation", "DeleteConfirmation"
+        )
 
         if path:
-            path = "\"%s\"" % os.path.basename(path)
+            path = '"%s"' % os.path.basename(path)
         else:
             path = _("the selected item(s)")
 
@@ -380,8 +387,7 @@ class TextChange(InterfaceView):
             self.get_widget("TextChange").set_title(title)
 
         self.textview = rabbitvcs.ui.widget.TextView(
-            self.get_widget("textchange_message"),
-            message
+            self.get_widget("textchange_message"), message
         )
 
     def run(self):
@@ -396,7 +402,8 @@ class TextChange(InterfaceView):
 class OneLineTextChange(InterfaceView):
     def __init__(self, title=None, label=None, current_text=None):
         InterfaceView.__init__(
-            self, "dialogs/one_line_text_change", "OneLineTextChange")
+            self, "dialogs/one_line_text_change", "OneLineTextChange"
+        )
         if title:
             self.get_widget("OneLineTextChange").set_title(title)
 
@@ -433,13 +440,12 @@ class NewFolder(InterfaceView):
 
         self.folder_name = self.get_widget("folder_name")
         self.textview = rabbitvcs.ui.widget.TextView(
-            self.get_widget("log_message"),
-            _("Added a folder to the repository")
+            self.get_widget("log_message"), _("Added a folder to the repository")
         )
         self.on_folder_name_changed(self.folder_name)
 
     def on_folder_name_changed(self, widget):
-        complete = (widget.get_text() != "")
+        complete = widget.get_text() != ""
         self.get_widget("ok").set_sensitive(complete)
 
     def run(self):
@@ -458,10 +464,8 @@ class NewFolder(InterfaceView):
 
 
 class ErrorNotification(InterfaceView):
-
     def __init__(self, text):
-        InterfaceView.__init__(
-            self, "dialogs/error_notification", "ErrorNotification")
+        InterfaceView.__init__(self, "dialogs/error_notification", "ErrorNotification")
 
         notice = rabbitvcs.ui.wraplabel.WrapLabel(ERROR_NOTICE)
         notice.set_use_markup(True)
@@ -471,9 +475,7 @@ class ErrorNotification(InterfaceView):
         notice_box.show_all()
 
         self.textview = rabbitvcs.ui.widget.TextView(
-            self.get_widget("error_text"),
-            text,
-            spellcheck=False
+            self.get_widget("error_text"), text, spellcheck=False
         )
 
         self.textview.view.modify_font(Pango.FontDescription("monospace"))
@@ -485,8 +487,7 @@ class ErrorNotification(InterfaceView):
 
 class NameEmailPrompt(InterfaceView):
     def __init__(self):
-        InterfaceView.__init__(
-            self, "dialogs/name_email_prompt", "NameEmailPrompt")
+        InterfaceView.__init__(self, "dialogs/name_email_prompt", "NameEmailPrompt")
 
         self.dialog = self.get_widget("NameEmailPrompt")
 
@@ -512,7 +513,8 @@ class NameEmailPrompt(InterfaceView):
 class MarkResolvedPrompt(InterfaceView):
     def __init__(self):
         InterfaceView.__init__(
-            self, "dialogs/mark_resolved_prompt", "MarkResolvedPrompt")
+            self, "dialogs/mark_resolved_prompt", "MarkResolvedPrompt"
+        )
 
     def run(self):
         self.dialog = self.get_widget("MarkResolvedPrompt")
@@ -530,8 +532,7 @@ class ConflictDecision(InterfaceView):
 
     def __init__(self, filename=""):
 
-        InterfaceView.__init__(
-            self, "dialogs/conflict_decision", "ConflictDecision")
+        InterfaceView.__init__(self, "dialogs/conflict_decision", "ConflictDecision")
         self.get_widget("filename").set_text(S(filename).display())
 
     def run(self):
@@ -559,9 +560,7 @@ class Loading(InterfaceView):
 
         self.get_widget("loading_cancel").set_sensitive(False)
 
-        self.pbar = rabbitvcs.ui.widget.ProgressBar(
-            self.get_widget("pbar")
-        )
+        self.pbar = rabbitvcs.ui.widget.ProgressBar(self.get_widget("pbar"))
         self.pbar.start_pulsate()
 
     def on_destroy(self, widget):

--- a/rabbitvcs/ui/dialog.py
+++ b/rabbitvcs/ui/dialog.py
@@ -1,4 +1,10 @@
 from __future__ import absolute_import
+from rabbitvcs.util.strings import S
+import rabbitvcs.util.helper
+import rabbitvcs.ui.wraplabel
+import rabbitvcs.ui.widget
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk, Pango
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -25,22 +31,18 @@ from gettext import gettext as _
 import os.path
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GObject, Gdk, Pango
 
-from rabbitvcs.ui import InterfaceView
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.wraplabel
-import rabbitvcs.util.helper
-from rabbitvcs.util.strings import S
 
 ERROR_NOTICE = _("""\
 An error has occurred in the RabbitVCS Nautilus extension. Please contact the \
 <a href="%s">RabbitVCS team</a> with the error details listed below:"""
-    % (rabbitvcs.WEBSITE))
+                 % (rabbitvcs.WEBSITE))
+
 
 class PreviousMessages(InterfaceView):
     def __init__(self):
-        InterfaceView.__init__(self, "dialogs/previous_messages", "PreviousMessages")
+        InterfaceView.__init__(
+            self, "dialogs/previous_messages", "PreviousMessages")
 
         self.message = rabbitvcs.ui.widget.TextView(
             self.get_widget("prevmes_message")
@@ -67,7 +69,7 @@ class PreviousMessages(InterfaceView):
             return None
 
         for entry in self.entries:
-            self.message_table.append([entry[0],entry[1]])
+            self.message_table.append([entry[0], entry[1]])
 
         if len(self.entries) > 0:
             self.message.set_text(S(self.entries[0][1]).display())
@@ -101,12 +103,13 @@ class PreviousMessages(InterfaceView):
             selected_message = selection[-1]
             self.message.set_text(S(selected_message).display())
 
+
 class FolderChooser(object):
     def __init__(self):
         self.dialog = Gtk.FileChooserDialog(
-            title = _("Select a Folder"),
-            parent = None,
-            action = Gtk.FileChooserAction.SELECT_FOLDER)
+            title=_("Select a Folder"),
+            parent=None,
+            action=Gtk.FileChooserAction.SELECT_FOLDER)
         self.dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         self.dialog.add_button(_("_Select"), Gtk.ResponseType.OK)
         self.dialog.set_default_response(Gtk.ResponseType.OK)
@@ -120,6 +123,7 @@ class FolderChooser(object):
         self.dialog.destroy()
         return returner
 
+
 class Certificate(InterfaceView):
     """
     Provides a dialog to accept/accept_once/deny an ssl certificate
@@ -127,7 +131,7 @@ class Certificate(InterfaceView):
     """
 
     def __init__(self, realm="", host="",
-            issuer="", valid_from="", valid_until="", fingerprint=""):
+                 issuer="", valid_from="", valid_until="", fingerprint=""):
 
         InterfaceView.__init__(self, "dialogs/certificate", "Certificate")
 
@@ -155,9 +159,11 @@ class Certificate(InterfaceView):
         self.dialog.destroy()
         return result
 
+
 class Authentication(InterfaceView):
     def __init__(self, realm="", may_save=True):
-        InterfaceView.__init__(self, "dialogs/authentication", "Authentication")
+        InterfaceView.__init__(
+            self, "dialogs/authentication", "Authentication")
 
         self.get_widget("auth_realm").set_label(realm)
         self.get_widget("auth_save").set_sensitive(may_save)
@@ -177,9 +183,11 @@ class Authentication(InterfaceView):
         else:
             return (False, "", "", False)
 
+
 class CertAuthentication(InterfaceView):
     def __init__(self, realm="", may_save=True):
-        InterfaceView.__init__(self, "dialogs/cert_authentication", "CertAuthentication")
+        InterfaceView.__init__(
+            self, "dialogs/cert_authentication", "CertAuthentication")
 
         self.get_widget("certauth_realm").set_label(realm)
         self.get_widget("certauth_save").set_sensitive(may_save)
@@ -197,9 +205,11 @@ class CertAuthentication(InterfaceView):
         else:
             return (False, "", False)
 
+
 class SSLClientCertPrompt(InterfaceView):
     def __init__(self, realm="", may_save=True):
-        InterfaceView.__init__(self, "dialogs/ssl_client_cert_prompt", "SSLClientCertPrompt")
+        InterfaceView.__init__(
+            self, "dialogs/ssl_client_cert_prompt", "SSLClientCertPrompt")
 
         self.get_widget("sslclientcert_realm").set_label(realm)
         self.get_widget("sslclientcert_save").set_sensitive(may_save)
@@ -223,6 +233,7 @@ class SSLClientCertPrompt(InterfaceView):
         else:
             return (False, "", False)
 
+
 class Property(InterfaceView):
     def __init__(self, name="", value="", recurse=True):
         InterfaceView.__init__(self, "dialogs/property", "Property")
@@ -231,23 +242,23 @@ class Property(InterfaceView):
         self.save_value = value
 
         self.name = rabbitvcs.ui.widget.ComboBox(
-                self.get_widget("property_name"),
-                [   # default svn properties
-                    'svn:author',
-                    'svn:autoversioned',
-                    'svn:date',
-                    'svn:eol-style',
-                    'svn:executable',
-                    'svn:externals',
-                    'svn:ignore',
-                    'svn:keywords',
-                    'svn:log',
-                    'svn:mergeinfo',
-                    'svn:mime-type',
-                    'svn:needs-lock',
-                    'svn:special',
-                    ]
-                )
+            self.get_widget("property_name"),
+            [   # default svn properties
+                'svn:author',
+                'svn:autoversioned',
+                'svn:date',
+                'svn:eol-style',
+                'svn:executable',
+                'svn:externals',
+                'svn:ignore',
+                'svn:keywords',
+                'svn:log',
+                'svn:mergeinfo',
+                'svn:mime-type',
+                'svn:needs-lock',
+                'svn:special',
+            ]
+        )
         self.name.set_child_text(name)
 
         self.value = rabbitvcs.ui.widget.TextView(
@@ -273,12 +284,13 @@ class Property(InterfaceView):
         self.save_value = self.value.get_text()
         self.save_recurse = self.recurse.get_active()
 
+
 class FileChooser(object):
     def __init__(self, title=_("Select a File"), folder=None):
         self.dialog = Gtk.FileChooserDialog(
-            title = title,
-            parent = None,
-            action = Gtk.FileChooserAction.OPEN)
+            title=title,
+            parent=None,
+            action=Gtk.FileChooserAction.OPEN)
         self.dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         self.dialog.add_button(_("_Open"),   Gtk.ResponseType.OK)
         if folder is not None:
@@ -293,12 +305,13 @@ class FileChooser(object):
         self.dialog.destroy()
         return returner
 
+
 class FileSaveAs(object):
     def __init__(self, title=_("Save As..."), folder=None):
         self.dialog = Gtk.FileChooserDialog(
-            title = title,
-            parent = None,
-            action = Gtk.FileChooserAction.SAVE)
+            title=title,
+            parent=None,
+            action=Gtk.FileChooserAction.SAVE)
         self.dialog.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
         self.dialog.add_button(_("_Save"),   Gtk.ResponseType.OK)
         if folder is not None:
@@ -313,6 +326,7 @@ class FileSaveAs(object):
         self.dialog.destroy()
         return returner
 
+
 class Confirmation(InterfaceView):
     def __init__(self, message=_("Are you sure you want to continue?")):
         InterfaceView.__init__(self, "dialogs/confirmation", "Confirmation")
@@ -326,6 +340,7 @@ class Confirmation(InterfaceView):
 
         return result
 
+
 class MessageBox(InterfaceView):
     def __init__(self, message):
         InterfaceView.__init__(self, "dialogs/message_box", "MessageBox")
@@ -335,9 +350,11 @@ class MessageBox(InterfaceView):
         dialog.run()
         dialog.destroy()
 
+
 class DeleteConfirmation(InterfaceView):
     def __init__(self, path=None):
-        InterfaceView.__init__(self, "dialogs/delete_confirmation", "DeleteConfirmation")
+        InterfaceView.__init__(
+            self, "dialogs/delete_confirmation", "DeleteConfirmation")
 
         if path:
             path = "\"%s\"" % os.path.basename(path)
@@ -354,6 +371,7 @@ class DeleteConfirmation(InterfaceView):
         dialog.destroy()
 
         return result
+
 
 class TextChange(InterfaceView):
     def __init__(self, title=None, message=""):
@@ -374,9 +392,11 @@ class TextChange(InterfaceView):
 
         return (result, self.textview.get_text())
 
+
 class OneLineTextChange(InterfaceView):
     def __init__(self, title=None, label=None, current_text=None):
-        InterfaceView.__init__(self, "dialogs/one_line_text_change", "OneLineTextChange")
+        InterfaceView.__init__(
+            self, "dialogs/one_line_text_change", "OneLineTextChange")
         if title:
             self.get_widget("OneLineTextChange").set_title(title)
 
@@ -405,6 +425,7 @@ class OneLineTextChange(InterfaceView):
         self.dialog.destroy()
 
         return (result, new_text)
+
 
 class NewFolder(InterfaceView):
     def __init__(self):
@@ -435,10 +456,12 @@ class NewFolder(InterfaceView):
         else:
             return None
 
+
 class ErrorNotification(InterfaceView):
 
     def __init__(self, text):
-        InterfaceView.__init__(self, "dialogs/error_notification", "ErrorNotification")
+        InterfaceView.__init__(
+            self, "dialogs/error_notification", "ErrorNotification")
 
         notice = rabbitvcs.ui.wraplabel.WrapLabel(ERROR_NOTICE)
         notice.set_use_markup(True)
@@ -459,9 +482,11 @@ class ErrorNotification(InterfaceView):
         dialog.run()
         dialog.destroy()
 
+
 class NameEmailPrompt(InterfaceView):
     def __init__(self):
-        InterfaceView.__init__(self, "dialogs/name_email_prompt", "NameEmailPrompt")
+        InterfaceView.__init__(
+            self, "dialogs/name_email_prompt", "NameEmailPrompt")
 
         self.dialog = self.get_widget("NameEmailPrompt")
 
@@ -483,15 +508,18 @@ class NameEmailPrompt(InterfaceView):
         else:
             return (None, None)
 
+
 class MarkResolvedPrompt(InterfaceView):
     def __init__(self):
-        InterfaceView.__init__(self, "dialogs/mark_resolved_prompt", "MarkResolvedPrompt")
+        InterfaceView.__init__(
+            self, "dialogs/mark_resolved_prompt", "MarkResolvedPrompt")
 
     def run(self):
         self.dialog = self.get_widget("MarkResolvedPrompt")
         result = self.dialog.run()
         self.dialog.destroy()
         return result
+
 
 class ConflictDecision(InterfaceView):
     """
@@ -502,7 +530,8 @@ class ConflictDecision(InterfaceView):
 
     def __init__(self, filename=""):
 
-        InterfaceView.__init__(self, "dialogs/conflict_decision", "ConflictDecision")
+        InterfaceView.__init__(
+            self, "dialogs/conflict_decision", "ConflictDecision")
         self.get_widget("filename").set_text(S(filename).display())
 
     def run(self):
@@ -522,6 +551,7 @@ class ConflictDecision(InterfaceView):
         result = self.dialog.run()
         self.dialog.destroy()
         return result
+
 
 class Loading(InterfaceView):
     def __init__(self):

--- a/rabbitvcs/ui/diff.py
+++ b/rabbitvcs/ui/diff.py
@@ -1,4 +1,12 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+from rabbitvcs.ui.action import SVNAction, GitAction
+import rabbitvcs.vcs
+from rabbitvcs.ui import InterfaceNonView
+from rabbitvcs import TEMP_DIR_PREFIX
+from gi.repository import Gtk, Gdk, GLib
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -30,24 +38,17 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, Gdk, GLib
 sa.restore()
 
-from rabbitvcs import TEMP_DIR_PREFIX
-from rabbitvcs.ui import InterfaceNonView
-import rabbitvcs.vcs
-from rabbitvcs.ui.action import SVNAction, GitAction
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.diff")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class Diff(InterfaceNonView):
     def __init__(self, path1, revision1=None, path2=None, revision2=None,
-            sidebyside=False):
+                 sidebyside=False):
         InterfaceNonView.__init__(self)
 
         self.vcs = rabbitvcs.vcs.VCS()
@@ -73,7 +74,8 @@ class Diff(InterfaceNonView):
             self.stop_loading()
 
     def _build_export_path(self, index, revision, path):
-        dest = helper.get_tmp_path("rabbitvcs-%s-%s-%s" % (str(index), str(revision)[:5], os.path.basename(path)))
+        dest = helper.get_tmp_path(
+            "rabbitvcs-%s-%s-%s" % (str(index), str(revision)[:5], os.path.basename(path)))
         if os.path.exists(dest):
             if os.path.isdir(dest):
                 rmtree(dest, ignore_errors=True)
@@ -97,9 +99,10 @@ class Diff(InterfaceNonView):
         self.dialog.close()
         self.dialog = None
 
+
 class SVNDiff(Diff):
     def __init__(self, path1, revision1=None, path2=None, revision2=None,
-            sidebyside=False):
+                 sidebyside=False):
         Diff.__init__(self, path1, revision1, path2, revision2, sidebyside)
 
         self.svn = self.vcs.svn()
@@ -151,7 +154,8 @@ class SVNDiff(Diff):
         if diff_text is None:
             diff_text = ""
 
-        fh = tempfile.mkstemp("-rabbitvcs-" + str(self.revision1) + "-" + str(self.revision2) + ".diff")
+        fh = tempfile.mkstemp(
+            "-rabbitvcs-" + str(self.revision1) + "-" + str(self.revision2) + ".diff")
         os.write(fh[0], S(diff_text).bytes())
         os.close(fh[0])
         helper.open_item(fh[1])
@@ -194,9 +198,10 @@ class SVNDiff(Diff):
 
         helper.launch_diff_tool(dest1, dest2)
 
+
 class GitDiff(Diff):
     def __init__(self, path1, revision1=None, path2=None, revision2=None,
-            sidebyside=False):
+                 sidebyside=False):
         Diff.__init__(self, path1, revision1, path2, revision2, sidebyside)
 
         self.git = self.vcs.git(path1)
@@ -258,7 +263,8 @@ class GitDiff(Diff):
         if diff_text is None:
             diff_text = ""
 
-        fh = tempfile.mkstemp("-rabbitvcs-" + str(self.revision1)[:5] + "-" + str(self.revision2)[:5] + ".diff")
+        fh = tempfile.mkstemp("-rabbitvcs-" + str(self.revision1)
+                              [:5] + "-" + str(self.revision2)[:5] + ".diff")
         os.write(fh[0], S(diff_text).bytes())
         os.close(fh[0])
         helper.open_item(fh[1])
@@ -297,10 +303,12 @@ class GitDiff(Diff):
 
         helper.launch_diff_tool(dest1, dest2)
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNDiff,
     rabbitvcs.vcs.VCS_GIT: GitDiff
 }
+
 
 def diff_factory(vcs, path1, revision_obj1, path2=None, revision_obj2=None, sidebyside=False):
     if not vcs:
@@ -326,4 +334,5 @@ if __name__ == "__main__":
     if len(args) > 0:
         pathrev2 = helper.parse_path_revision_string(args.pop(0))
 
-    diff_factory(options.vcs, pathrev1[0], pathrev1[1], pathrev2[0], pathrev2[1], sidebyside=options.sidebyside)
+    diff_factory(options.vcs, pathrev1[0], pathrev1[1],
+                 pathrev2[0], pathrev2[1], sidebyside=options.sidebyside)

--- a/rabbitvcs/ui/diff.py
+++ b/rabbitvcs/ui/diff.py
@@ -7,6 +7,7 @@ import rabbitvcs.vcs
 from rabbitvcs.ui import InterfaceNonView
 from rabbitvcs import TEMP_DIR_PREFIX
 from gi.repository import Gtk, Gdk, GLib
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -36,6 +37,7 @@ import tempfile
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -47,8 +49,9 @@ _ = gettext.gettext
 
 
 class Diff(InterfaceNonView):
-    def __init__(self, path1, revision1=None, path2=None, revision2=None,
-                 sidebyside=False):
+    def __init__(
+        self, path1, revision1=None, path2=None, revision2=None, sidebyside=False
+    ):
         InterfaceNonView.__init__(self)
 
         self.vcs = rabbitvcs.vcs.VCS()
@@ -75,7 +78,9 @@ class Diff(InterfaceNonView):
 
     def _build_export_path(self, index, revision, path):
         dest = helper.get_tmp_path(
-            "rabbitvcs-%s-%s-%s" % (str(index), str(revision)[:5], os.path.basename(path)))
+            "rabbitvcs-%s-%s-%s"
+            % (str(index), str(revision)[:5], os.path.basename(path))
+        )
         if os.path.exists(dest):
             if os.path.isdir(dest):
                 rmtree(dest, ignore_errors=True)
@@ -101,8 +106,9 @@ class Diff(InterfaceNonView):
 
 
 class SVNDiff(Diff):
-    def __init__(self, path1, revision1=None, path2=None, revision2=None,
-                 sidebyside=False):
+    def __init__(
+        self, path1, revision1=None, path2=None, revision2=None, sidebyside=False
+    ):
         Diff.__init__(self, path1, revision1, path2, revision2, sidebyside)
 
         self.svn = self.vcs.svn()
@@ -137,11 +143,7 @@ class SVNDiff(Diff):
 
         """
 
-        action = SVNAction(
-            self.svn,
-            notification=False,
-            run_in_thread=False
-        )
+        action = SVNAction(self.svn, notification=False, run_in_thread=False)
 
         diff_text = action.run_single(
             self.svn.diff,
@@ -149,13 +151,14 @@ class SVNDiff(Diff):
             self.path1,
             self.revision1,
             self.path2,
-            self.revision2
+            self.revision2,
         )
         if diff_text is None:
             diff_text = ""
 
         fh = tempfile.mkstemp(
-            "-rabbitvcs-" + str(self.revision1) + "-" + str(self.revision2) + ".diff")
+            "-rabbitvcs-" + str(self.revision1) + "-" + str(self.revision2) + ".diff"
+        )
         os.write(fh[0], S(diff_text).bytes())
         os.close(fh[0])
         helper.open_item(fh[1])
@@ -166,42 +169,29 @@ class SVNDiff(Diff):
 
         """
 
-        action = SVNAction(
-            self.svn,
-            notification=False,
-            run_in_thread=False
-        )
+        action = SVNAction(self.svn, notification=False, run_in_thread=False)
 
         if self.revision1.kind == "working":
             dest1 = self.path1
         else:
             dest1 = self._build_export_path(1, self.revision1, self.path1)
-            action.run_single(
-                self.svn.export,
-                self.path1,
-                dest1,
-                self.revision1
-            )
+            action.run_single(self.svn.export, self.path1, dest1, self.revision1)
             action.stop_loader()
 
         if self.revision2.kind == "working":
             dest2 = self.path2
         else:
             dest2 = self._build_export_path(2, self.revision2, self.path2)
-            action.run_single(
-                self.svn.export,
-                self.path2,
-                dest2,
-                self.revision2
-            )
+            action.run_single(self.svn.export, self.path2, dest2, self.revision2)
             action.stop_loader()
 
         helper.launch_diff_tool(dest1, dest2)
 
 
 class GitDiff(Diff):
-    def __init__(self, path1, revision1=None, path2=None, revision2=None,
-                 sidebyside=False):
+    def __init__(
+        self, path1, revision1=None, path2=None, revision2=None, sidebyside=False
+    ):
         Diff.__init__(self, path1, revision1, path2, revision2, sidebyside)
 
         self.git = self.vcs.git(path1)
@@ -247,24 +237,21 @@ class GitDiff(Diff):
 
         """
 
-        action = GitAction(
-            self.git,
-            notification=False,
-            run_in_thread=False
-        )
+        action = GitAction(self.git, notification=False, run_in_thread=False)
 
         diff_text = action.run_single(
-            self.git.diff,
-            self.path1,
-            self.revision1,
-            self.path2,
-            self.revision2
+            self.git.diff, self.path1, self.revision1, self.path2, self.revision2
         )
         if diff_text is None:
             diff_text = ""
 
-        fh = tempfile.mkstemp("-rabbitvcs-" + str(self.revision1)
-                              [:5] + "-" + str(self.revision2)[:5] + ".diff")
+        fh = tempfile.mkstemp(
+            "-rabbitvcs-"
+            + str(self.revision1)[:5]
+            + "-"
+            + str(self.revision2)[:5]
+            + ".diff"
+        )
         os.write(fh[0], S(diff_text).bytes())
         os.close(fh[0])
         helper.open_item(fh[1])
@@ -275,42 +262,33 @@ class GitDiff(Diff):
 
         """
 
-        action = GitAction(
-            self.git,
-            notification=False,
-            run_in_thread=False
-        )
+        action = GitAction(self.git, notification=False, run_in_thread=False)
 
         if self.revision1.kind != "WORKING":
             dest1 = self._build_export_path(1, self.revision1, self.path1)
-            self.save_diff_to_file(dest1, action.run_single(
-                self.git.show,
-                self.path1,
-                self.revision1
-            ))
+            self.save_diff_to_file(
+                dest1, action.run_single(self.git.show, self.path1, self.revision1)
+            )
         else:
             dest1 = self.path1
 
         if self.revision2.kind != "WORKING":
             dest2 = self._build_export_path(2, self.revision2, self.path2)
-            self.save_diff_to_file(dest2, action.run_single(
-                self.git.show,
-                self.path2,
-                self.revision2
-            ))
+            self.save_diff_to_file(
+                dest2, action.run_single(self.git.show, self.path2, self.revision2)
+            )
         else:
             dest2 = self.path2
 
         helper.launch_diff_tool(dest1, dest2)
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNDiff,
-    rabbitvcs.vcs.VCS_GIT: GitDiff
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNDiff, rabbitvcs.vcs.VCS_GIT: GitDiff}
 
 
-def diff_factory(vcs, path1, revision_obj1, path2=None, revision_obj2=None, sidebyside=False):
+def diff_factory(
+    vcs, path1, revision_obj1, path2=None, revision_obj2=None, sidebyside=False
+):
     if not vcs:
         guess = rabbitvcs.vcs.guess(path1)
         vcs = guess["vcs"]
@@ -320,13 +298,20 @@ def diff_factory(vcs, path1, revision_obj1, path2=None, revision_obj2=None, side
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT
-    (options, args) = main([
-        (["-s", "--sidebyside"], {
-            "help":     _("View diff as side-by-side comparison"),
-            "action":   "store_true",
-            "default":  False
-        }), VCS_OPT],
-        usage="Usage: rabbitvcs diff [url1@rev1] [url2@rev2]"
+
+    (options, args) = main(
+        [
+            (
+                ["-s", "--sidebyside"],
+                {
+                    "help": _("View diff as side-by-side comparison"),
+                    "action": "store_true",
+                    "default": False,
+                },
+            ),
+            VCS_OPT,
+        ],
+        usage="Usage: rabbitvcs diff [url1@rev1] [url2@rev2]",
     )
 
     pathrev1 = helper.parse_path_revision_string(args.pop(0))
@@ -334,5 +319,11 @@ if __name__ == "__main__":
     if len(args) > 0:
         pathrev2 = helper.parse_path_revision_string(args.pop(0))
 
-    diff_factory(options.vcs, pathrev1[0], pathrev1[1],
-                 pathrev2[0], pathrev2[1], sidebyside=options.sidebyside)
+    diff_factory(
+        options.vcs,
+        pathrev1[0],
+        pathrev1[1],
+        pathrev2[0],
+        pathrev2[1],
+        sidebyside=options.sidebyside,
+    )

--- a/rabbitvcs/ui/editconflicts.py
+++ b/rabbitvcs/ui/editconflicts.py
@@ -1,4 +1,12 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import SVNAction, GitAction
+from rabbitvcs.ui import InterfaceNonView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -31,33 +39,27 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceNonView
-from rabbitvcs.ui.action import SVNAction, GitAction
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.editconflicts")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNEditConflicts(InterfaceNonView):
     def __init__(self, path):
         InterfaceNonView.__init__(self)
 
-        log.debug("incoming path: %s"%path)
+        log.debug("incoming path: %s" % path)
         self.path = path
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
 
         status = self.svn.status(self.path)
         if status.simple_content_status() != rabbitvcs.vcs.status.status_complicated:
-            log.debug("The specified file is not conflicted.  There is nothing to do.")
+            log.debug(
+                "The specified file is not conflicted.  There is nothing to do.")
             self.close()
             return
 
@@ -68,29 +70,31 @@ class SVNEditConflicts(InterfaceNonView):
         dialog.destroy()
 
         if action == -1:
-            #Cancel
+            # Cancel
             pass
 
         elif action == 0:
-            #Accept Mine
+            # Accept Mine
             working = self.get_working_path(path)
             shutil.copyfile(working, path)
             self.svn.resolve(path)
 
         elif action == 1:
-            #Accept Theirs
+            # Accept Theirs
             ancestor, theirs = self.get_revisioned_paths(path)
             shutil.copyfile(theirs, path)
             self.svn.resolve(path)
 
         elif action == 2:
-            #Merge Manually
+            # Merge Manually
 
             working = self.get_working_path(path)
             ancestor, theirs = self.get_revisioned_paths(path)
 
-            log.debug("launching merge tool with base: %s, mine: %s, theirs: %s, merged: %s"%(ancestor, working, theirs, path))
-            helper.launch_merge_tool(base=ancestor, mine=working, theirs=theirs, merged=path)
+            log.debug("launching merge tool with base: %s, mine: %s, theirs: %s, merged: %s" % (
+                ancestor, working, theirs, path))
+            helper.launch_merge_tool(
+                base=ancestor, mine=working, theirs=theirs, merged=path)
 
             dialog = rabbitvcs.ui.dialog.MarkResolvedPrompt()
             mark_resolved = dialog.run()
@@ -120,15 +124,15 @@ class SVNEditConflicts(InterfaceNonView):
         theirsPath = ""
         revisionPaths = []
         baseDir, baseName = os.path.split(path)
-        log.debug("baseDir: %s, baseName: %s"%(baseDir, baseName))
+        log.debug("baseDir: %s, baseName: %s" % (baseDir, baseName))
         for name in os.listdir(baseDir):
             if baseName in name:
                 extension = name.split(".")[-1]
-                log.debug("extension: %s"%extension)
+                log.debug("extension: %s" % extension)
                 if extension.startswith("r"):
                     revision = extension[1:]
-                    log.debug("revision: %s"%revision)
-                    revisionPaths.append((revision,name))
+                    log.debug("revision: %s" % revision)
+                    revisionPaths.append((revision, name))
         if len(revisionPaths) == 2:
             if int(revisionPaths[0][0]) < int(revisionPaths[1][0]):
                 ancestorPath = os.path.join(baseDir, revisionPaths[0][1])
@@ -138,7 +142,8 @@ class SVNEditConflicts(InterfaceNonView):
                 theirsPath = os.path.join(baseDir, revisionPaths[0][1])
             return (ancestorPath, theirsPath)
         else:
-            log.error("Unexpected number (%d) of revision paths found"%len(revisionPaths))
+            log.error("Unexpected number (%d) of revision paths found" %
+                      len(revisionPaths))
             return ("", "")
 
 
@@ -154,10 +159,12 @@ class GitEditConflicts(InterfaceNonView):
 
         self.close()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNEditConflicts,
     rabbitvcs.vcs.VCS_GIT: GitEditConflicts
 }
+
 
 def editconflicts_factory(path):
     guess = rabbitvcs.vcs.guess(path)

--- a/rabbitvcs/ui/editconflicts.py
+++ b/rabbitvcs/ui/editconflicts.py
@@ -7,6 +7,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.ui.action import SVNAction, GitAction
 from rabbitvcs.ui import InterfaceNonView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -37,6 +38,7 @@ import shutil
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -58,8 +60,7 @@ class SVNEditConflicts(InterfaceNonView):
 
         status = self.svn.status(self.path)
         if status.simple_content_status() != rabbitvcs.vcs.status.status_complicated:
-            log.debug(
-                "The specified file is not conflicted.  There is nothing to do.")
+            log.debug("The specified file is not conflicted.  There is nothing to do.")
             self.close()
             return
 
@@ -91,10 +92,13 @@ class SVNEditConflicts(InterfaceNonView):
             working = self.get_working_path(path)
             ancestor, theirs = self.get_revisioned_paths(path)
 
-            log.debug("launching merge tool with base: %s, mine: %s, theirs: %s, merged: %s" % (
-                ancestor, working, theirs, path))
+            log.debug(
+                "launching merge tool with base: %s, mine: %s, theirs: %s, merged: %s"
+                % (ancestor, working, theirs, path)
+            )
             helper.launch_merge_tool(
-                base=ancestor, mine=working, theirs=theirs, merged=path)
+                base=ancestor, mine=working, theirs=theirs, merged=path
+            )
 
             dialog = rabbitvcs.ui.dialog.MarkResolvedPrompt()
             mark_resolved = dialog.run()
@@ -106,10 +110,7 @@ class SVNEditConflicts(InterfaceNonView):
         self.close()
 
     def get_working_path(self, path):
-        paths = [
-            "%s.mine" % path,
-            "%s.working" % path
-        ]
+        paths = ["%s.mine" % path, "%s.working" % path]
 
         for working in paths:
             if os.path.exists(working):
@@ -118,8 +119,8 @@ class SVNEditConflicts(InterfaceNonView):
         return path
 
     def get_revisioned_paths(self, path):
-        """ Will return a tuple where the first element is the common ancestor's
-            path and the second is the path of the the file being merged in."""
+        """Will return a tuple where the first element is the common ancestor's
+        path and the second is the path of the the file being merged in."""
         ancestorPath = ""
         theirsPath = ""
         revisionPaths = []
@@ -142,8 +143,9 @@ class SVNEditConflicts(InterfaceNonView):
                 theirsPath = os.path.join(baseDir, revisionPaths[0][1])
             return (ancestorPath, theirsPath)
         else:
-            log.error("Unexpected number (%d) of revision paths found" %
-                      len(revisionPaths))
+            log.error(
+                "Unexpected number (%d) of revision paths found" % len(revisionPaths)
+            )
             return ("", "")
 
 
@@ -162,7 +164,7 @@ class GitEditConflicts(InterfaceNonView):
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNEditConflicts,
-    rabbitvcs.vcs.VCS_GIT: GitEditConflicts
+    rabbitvcs.vcs.VCS_GIT: GitEditConflicts,
 }
 
 
@@ -173,9 +175,9 @@ def editconflicts_factory(path):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT],
-        usage="Usage: rabbitvcs edit-conflicts [path1] [path2] ..."
+        [BASEDIR_OPT], usage="Usage: rabbitvcs edit-conflicts [path1] [path2] ..."
     )
 
     window = editconflicts_factory(paths[0])

--- a/rabbitvcs/ui/export.py
+++ b/rabbitvcs/ui/export.py
@@ -8,6 +8,7 @@ from rabbitvcs.ui.clone import GitClone
 from rabbitvcs.ui.checkout import SVNCheckout
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -35,6 +36,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -77,7 +79,8 @@ class SVNExport(SVNCheckout):
 
         if not url or not path:
             MessageBox(
-                _("The repository URL and destination path are both required fields."))
+                _("The repository URL and destination path are both required fields.")
+            )
             return
 
         if url.startswith("file://"):
@@ -92,14 +95,10 @@ class SVNExport(SVNCheckout):
         revision = self.revision_selector.get_revision_object()
 
         self.hide()
-        self.action = SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
-        )
+        self.action = SVNAction(self.svn, register_gtk_quit=self.gtk_quit_is_set())
 
         self.action.append(self.action.set_header, _("Export"))
-        self.action.append(self.action.set_status,
-                           _("Running Export Command..."))
+        self.action.append(self.action.set_status, _("Running Export Command..."))
         self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.svn.export,
@@ -108,7 +107,7 @@ class SVNExport(SVNCheckout):
             force=True,
             recurse=recursive,
             revision=revision,
-            ignore_externals=omit_externals
+            ignore_externals=omit_externals,
         )
         self.action.append(self.action.set_status, _("Completed Export"))
         self.action.append(self.action.finish)
@@ -138,7 +137,7 @@ class GitExport(GitClone):
             self.git,
             revision=revision,
             url_combobox=self.repositories,
-            expand=True
+            expand=True,
         )
 
         self.get_widget("revision_selector_box").show()
@@ -149,7 +148,8 @@ class GitExport(GitClone):
 
         if not url or not path:
             MessageBox(
-                _("The repository URL and destination path are both required fields."))
+                _("The repository URL and destination path are both required fields.")
+            )
             return
 
         if url.startswith("file://"):
@@ -164,21 +164,12 @@ class GitExport(GitClone):
         revision = self.revision_selector.get_revision_object()
 
         self.hide()
-        self.action = GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
-        )
+        self.action = GitAction(self.git, register_gtk_quit=self.gtk_quit_is_set())
 
         self.action.append(self.action.set_header, _("Export"))
-        self.action.append(self.action.set_status,
-                           _("Running Export Command..."))
+        self.action.append(self.action.set_status, _("Running Export Command..."))
         self.action.append(helper.save_repository_path, url)
-        self.action.append(
-            self.git.export,
-            url,
-            path,
-            revision=revision
-        )
+        self.action.append(self.git.export, url, path, revision=revision)
         self.action.append(self.action.set_status, _("Completed Export"))
         self.action.append(self.action.finish)
         self.action.schedule()
@@ -206,10 +197,7 @@ class GitExport(GitClone):
         self.check_form()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNExport,
-    rabbitvcs.vcs.VCS_GIT: GitExport
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNExport, rabbitvcs.vcs.VCS_GIT: GitExport}
 
 
 def export_factory(vcs, path, revision=None):
@@ -225,9 +213,10 @@ def export_factory(vcs, path, revision=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT
+
     (options, paths) = main(
         [REVISION_OPT, VCS_OPT],
-        usage="Usage: rabbitvcs export --vcs=[git|svn] [url_or_path]"
+        usage="Usage: rabbitvcs export --vcs=[git|svn] [url_or_path]",
     )
 
     window = export_factory(options.vcs, paths[0], revision=options.revision)

--- a/rabbitvcs/ui/export.py
+++ b/rabbitvcs/ui/export.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
+from rabbitvcs.ui.action import SVNAction, GitAction
+from rabbitvcs.ui.dialog import MessageBox
+from rabbitvcs.ui.clone import GitClone
+from rabbitvcs.ui.checkout import SVNCheckout
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,19 +37,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.checkout import SVNCheckout
-from rabbitvcs.ui.clone import GitClone
-from rabbitvcs.ui.dialog import MessageBox
-from rabbitvcs.ui.action import SVNAction, GitAction
-from rabbitvcs.util.strings import S
-import rabbitvcs.vcs
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNExport(SVNCheckout):
     def __init__(self, path=None, revision=None):
@@ -75,7 +76,8 @@ class SVNExport(SVNCheckout):
         recursive = self.get_widget("recursive").get_active()
 
         if not url or not path:
-            MessageBox(_("The repository URL and destination path are both required fields."))
+            MessageBox(
+                _("The repository URL and destination path are both required fields."))
             return
 
         if url.startswith("file://"):
@@ -96,7 +98,8 @@ class SVNExport(SVNCheckout):
         )
 
         self.action.append(self.action.set_header, _("Export"))
-        self.action.append(self.action.set_status, _("Running Export Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Export Command..."))
         self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.svn.export,
@@ -110,6 +113,7 @@ class SVNExport(SVNCheckout):
         self.action.append(self.action.set_status, _("Completed Export"))
         self.action.append(self.action.finish)
         self.action.schedule()
+
 
 class GitExport(GitClone):
     def __init__(self, path=None, revision=None):
@@ -144,7 +148,8 @@ class GitExport(GitClone):
         path = self._get_path()
 
         if not url or not path:
-            MessageBox(_("The repository URL and destination path are both required fields."))
+            MessageBox(
+                _("The repository URL and destination path are both required fields."))
             return
 
         if url.startswith("file://"):
@@ -165,7 +170,8 @@ class GitExport(GitClone):
         )
 
         self.action.append(self.action.set_header, _("Export"))
-        self.action.append(self.action.set_status, _("Running Export Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Export Command..."))
         self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.git.export,
@@ -199,10 +205,12 @@ class GitExport(GitClone):
 
         self.check_form()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNExport,
     rabbitvcs.vcs.VCS_GIT: GitExport
 }
+
 
 def export_factory(vcs, path, revision=None):
     if not vcs:

--- a/rabbitvcs/ui/ignore.py
+++ b/rabbitvcs/ui/ignore.py
@@ -1,4 +1,9 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.ui.action import SVNAction, GitAction
+from rabbitvcs.ui import InterfaceNonView, InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -29,16 +34,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceNonView, InterfaceView
-from rabbitvcs.ui.action import SVNAction, GitAction
 
-import rabbitvcs.vcs
-
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNIgnore(InterfaceNonView):
     """
@@ -72,6 +72,7 @@ class SVNIgnore(InterfaceNonView):
 
         raise SystemExit()
 
+
 class GitIgnore(InterfaceView):
     def __init__(self, path, pattern=""):
         InterfaceView.__init__(self, "ignore", "Ignore")
@@ -92,7 +93,7 @@ class GitIgnore(InterfaceView):
         for ignore_file in ignore_files:
             label = path
             if ignore_file.startswith(path_dir):
-               label = ignore_file[len(path_dir)+1:]
+                label = ignore_file[len(path_dir)+1:]
 
             ignore_file_labels.append(label)
 
@@ -114,11 +115,11 @@ class GitIgnore(InterfaceView):
         self.close()
 
 
-
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNIgnore,
     rabbitvcs.vcs.VCS_GIT: GitIgnore
 }
+
 
 def ignore_factory(path, pattern):
     guess = rabbitvcs.vcs.guess(path)

--- a/rabbitvcs/ui/ignore.py
+++ b/rabbitvcs/ui/ignore.py
@@ -4,6 +4,7 @@ import rabbitvcs.vcs
 from rabbitvcs.ui.action import SVNAction, GitAction
 from rabbitvcs.ui import InterfaceNonView, InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -32,6 +33,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -93,7 +95,7 @@ class GitIgnore(InterfaceView):
         for ignore_file in ignore_files:
             label = path
             if ignore_file.startswith(path_dir):
-                label = ignore_file[len(path_dir)+1:]
+                label = ignore_file[len(path_dir) + 1 :]
 
             ignore_file_labels.append(label)
 
@@ -107,7 +109,7 @@ class GitIgnore(InterfaceView):
             ignore_file_labels,
             ignore_files,
             show_add_line=True,
-            line_content=text
+            line_content=text,
         )
 
     def on_ok_clicked(self, widget, data=None):
@@ -115,10 +117,7 @@ class GitIgnore(InterfaceView):
         self.close()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNIgnore,
-    rabbitvcs.vcs.VCS_GIT: GitIgnore
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNIgnore, rabbitvcs.vcs.VCS_GIT: GitIgnore}
 
 
 def ignore_factory(path, pattern):
@@ -128,6 +127,7 @@ def ignore_factory(path, pattern):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
+
     (options, args) = main(usage="Usage: rabbitvcs ignore <folder> <pattern>")
 
     path = getcwd()

--- a/rabbitvcs/ui/import.py
+++ b/rabbitvcs/ui/import.py
@@ -1,4 +1,11 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,17 +33,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-from rabbitvcs.util.strings import S
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNImport(InterfaceView):
     def __init__(self, path):
@@ -49,7 +50,8 @@ class SVNImport(InterfaceView):
         self.svn = self.vcs.svn()
 
         if self.svn.is_in_a_or_a_working_copy(path):
-            self.get_widget("repository").set_text(S(self.svn.get_repo_url(path)).display())
+            self.get_widget("repository").set_text(
+                S(self.svn.get_repo_url(path)).display())
 
         self.repositories = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("repositories"),
@@ -64,7 +66,8 @@ class SVNImport(InterfaceView):
 
         url = self.get_widget("repository").get_text()
         if not url:
-            rabbitvcs.ui.dialog.MessageBox(_("The repository URL field is required."))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("The repository URL field is required."))
             return
 
         ignore = not self.get_widget("include_ignored").get_active()
@@ -77,7 +80,8 @@ class SVNImport(InterfaceView):
         )
 
         self.action.append(self.action.set_header, _("Import"))
-        self.action.append(self.action.set_status, _("Running Import Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Import Command..."))
         self.action.append(
             self.svn.import_,
             self.path,
@@ -96,10 +100,10 @@ class SVNImport(InterfaceView):
             self.message.set_text(S(message).display())
 
 
-
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNImport
 }
+
 
 def import_factory(path):
     vcs = rabbitvcs.vcs.VCS_SVN

--- a/rabbitvcs/ui/import.py
+++ b/rabbitvcs/ui/import.py
@@ -6,6 +6,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -31,6 +32,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -51,23 +53,20 @@ class SVNImport(InterfaceView):
 
         if self.svn.is_in_a_or_a_working_copy(path):
             self.get_widget("repository").set_text(
-                S(self.svn.get_repo_url(path)).display())
+                S(self.svn.get_repo_url(path)).display()
+            )
 
         self.repositories = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("repositories"),
-            helper.get_repository_paths()
+            self.get_widget("repositories"), helper.get_repository_paths()
         )
 
-        self.message = rabbitvcs.ui.widget.TextView(
-            self.get_widget("message")
-        )
+        self.message = rabbitvcs.ui.widget.TextView(self.get_widget("message"))
 
     def on_ok_clicked(self, widget):
 
         url = self.get_widget("repository").get_text()
         if not url:
-            rabbitvcs.ui.dialog.MessageBox(
-                _("The repository URL field is required."))
+            rabbitvcs.ui.dialog.MessageBox(_("The repository URL field is required."))
             return
 
         ignore = not self.get_widget("include_ignored").get_active()
@@ -75,19 +74,13 @@ class SVNImport(InterfaceView):
         self.hide()
 
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Import"))
-        self.action.append(self.action.set_status,
-                           _("Running Import Command..."))
+        self.action.append(self.action.set_status, _("Running Import Command..."))
         self.action.append(
-            self.svn.import_,
-            self.path,
-            url,
-            self.message.get_text(),
-            ignore=ignore
+            self.svn.import_, self.path, url, self.message.get_text(), ignore=ignore
         )
         self.action.append(self.action.set_status, _("Completed Import"))
         self.action.append(self.action.finish)
@@ -100,9 +93,7 @@ class SVNImport(InterfaceView):
             self.message.set_text(S(message).display())
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNImport
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNImport}
 
 
 def import_factory(path):
@@ -112,6 +103,7 @@ def import_factory(path):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
+
     (options, paths) = main(usage="Usage: rabbitvcs import [path]")
 
     window = import_factory(paths[0])

--- a/rabbitvcs/ui/lock.py
+++ b/rabbitvcs/ui/lock.py
@@ -9,6 +9,7 @@ from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -37,6 +38,7 @@ import os
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -71,26 +73,24 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
 
         self.files_table = rabbitvcs.ui.widget.Table(
             self.get_widget("files_table"),
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
-                rabbitvcs.ui.widget.TYPE_PATH, GObject.TYPE_STRING,
-                GObject.TYPE_STRING],
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension"),
-                _("Locked")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 2
+            [
+                GObject.TYPE_BOOLEAN,
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+            ],
+            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Path"), _("Extension"), _("Locked")],
+            filters=[
+                {
+                    "callback": rabbitvcs.ui.widget.path_filter,
+                    "user_data": {"base_dir": base_dir, "column": 2},
                 }
-            }],
-            callbacks={
-                "mouse-event":   self.on_files_table_mouse_event
-            }
+            ],
+            callbacks={"mouse-event": self.on_files_table_mouse_event},
         )
 
-        self.message = rabbitvcs.ui.widget.TextView(
-            self.get_widget("message")
-        )
+        self.message = rabbitvcs.ui.widget.TextView(self.get_widget("message"))
 
         self.items = None
         self.initialize_items()
@@ -117,8 +117,7 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
         self.get_widget("status").set_text(_("Loading..."))
         self.items = self.vcs.get_items(self.paths)
         self.populate_files_table()
-        self.get_widget("status").set_text(
-            _("Found %d item(s)") % len(self.items))
+        self.get_widget("status").set_text(_("Found %d item(s)") % len(self.items))
 
     def populate_files_table(self):
         for item in self.items:
@@ -129,13 +128,15 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
             if not self.svn.is_versioned(item.path):
                 continue
 
-            self.files_table.append([
-                True,
-                S(item.path),
-                item.path,
-                helper.get_file_extension(item.path),
-                locked
-            ])
+            self.files_table.append(
+                [
+                    True,
+                    S(item.path),
+                    item.path,
+                    helper.get_file_extension(item.path),
+                    locked,
+                ]
+            )
 
     def show_files_table_popup_menu(self, treeview, data):
         paths = self.files_table.get_selected_row_items(1)
@@ -157,21 +158,14 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
         self.hide()
 
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Get Lock"))
-        self.action.append(self.action.set_status,
-                           _("Running Lock Command..."))
+        self.action.append(self.action.set_status, _("Running Lock Command..."))
         self.action.append(helper.save_log_message, message)
         for path in items:
-            self.action.append(
-                self.svn.lock,
-                path,
-                message,
-                force=steal_locks
-            )
+            self.action.append(self.svn.lock, path, message, force=steal_locks)
         self.action.append(self.action.set_status, _("Completed Lock"))
         self.action.append(self.action.finish)
         self.action.schedule()
@@ -191,9 +185,7 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
             self.message.set_text(S(message).display())
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNLock
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNLock}
 
 
 def lock_factory(paths, base_dir):
@@ -203,9 +195,9 @@ def lock_factory(paths, base_dir):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT],
-        usage="Usage: rabbitvcs lock [path1] [path2] ..."
+        [BASEDIR_OPT], usage="Usage: rabbitvcs lock [path1] [path2] ..."
     )
 
     window = lock_factory(paths, options.base_dir)

--- a/rabbitvcs/ui/lock.py
+++ b/rabbitvcs/ui/lock.py
@@ -1,4 +1,14 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+import rabbitvcs.vcs
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -29,24 +39,15 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import SVNAction
-from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.vcs
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.lock")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
 helper.gobject_threads_init()
+
 
 class SVNLock(InterfaceView, GtkContextMenuCaller):
     """
@@ -116,7 +117,8 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
         self.get_widget("status").set_text(_("Loading..."))
         self.items = self.vcs.get_items(self.paths)
         self.populate_files_table()
-        self.get_widget("status").set_text(_("Found %d item(s)") % len(self.items))
+        self.get_widget("status").set_text(
+            _("Found %d item(s)") % len(self.items))
 
     def populate_files_table(self):
         for item in self.items:
@@ -160,7 +162,8 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
         )
 
         self.action.append(self.action.set_header, _("Get Lock"))
-        self.action.append(self.action.set_status, _("Running Lock Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Lock Command..."))
         self.action.append(helper.save_log_message, message)
         for path in items:
             self.action.append(
@@ -188,10 +191,10 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
             self.message.set_text(S(message).display())
 
 
-
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNLock
 }
+
 
 def lock_factory(paths, base_dir):
     guess = rabbitvcs.vcs.guess(paths[0])

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -44,6 +44,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -88,7 +89,7 @@ def revision_grapher(history):
             if parent not in next_revisions:
                 parents_to_add.append(parent)
 
-        next_revisions[index:index+1] = parents_to_add
+        next_revisions[index : index + 1] = parents_to_add
 
         lines = []
         for i, revision in enumerate(revisions):
@@ -149,9 +150,7 @@ class Log(InterfaceView):
         self.head_row = 0
         self.get_widget("limit").set_text(S(self.limit).display())
 
-        self.message = rabbitvcs.ui.widget.TextView(
-            self.get_widget("message")
-        )
+        self.message = rabbitvcs.ui.widget.TextView(self.get_widget("message"))
 
         self.stop_on_copy = False
         self.revision_clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
@@ -177,8 +176,10 @@ class Log(InterfaceView):
 
     def on_key_pressed(self, widget, event, *args):
         InterfaceView.on_key_pressed(self, widget, event)
-        if (event.state & Gdk.ModifierType.CONTROL_MASK and
-                Gdk.keyval_name(event.keyval).lower() == "c"):
+        if (
+            event.state & Gdk.ModifierType.CONTROL_MASK
+            and Gdk.keyval_name(event.keyval).lower() == "c"
+        ):
             if len(self.revisions_table.get_selected_rows()) > 0:
                 self.copy_revision_text()
 
@@ -195,7 +196,8 @@ class Log(InterfaceView):
     def on_search(self, widget):
         tb = self.get_widget("search_buffer")
         self.filter_text = tb.get_text(
-            tb.get_start_iter(), tb.get_end_iter(), 0).lower()
+            tb.get_start_iter(), tb.get_end_iter(), 0
+        ).lower()
 
         self.refresh()
 
@@ -241,14 +243,18 @@ class Log(InterfaceView):
     def on_paths_table_row_activated(self, treeview, data=None, col=None):
         try:
             revision1 = S(
-                self.display_items[self.revisions_table.get_selected_rows()[0]].revision)
+                self.display_items[self.revisions_table.get_selected_rows()[0]].revision
+            )
             revision2 = S(
-                self.display_items[self.revisions_table.get_selected_rows()[0]+1].revision)
+                self.display_items[
+                    self.revisions_table.get_selected_rows()[0] + 1
+                ].revision
+            )
             path_item = self.paths_table.get_row(
-                self.paths_table.get_selected_rows()[0])[1]
+                self.paths_table.get_selected_rows()[0]
+            )[1]
             url = self.root_url + path_item
-            self.view_diff_for_path(
-                url, S(revision1), S(revision2), sidebyside=True)
+            self.view_diff_for_path(url, S(revision1), S(revision2), sidebyside=True)
         except IndexError:
             pass
 
@@ -262,19 +268,19 @@ class Log(InterfaceView):
             line = {
                 "revision": self.display_items[row].revision,
                 "author": self.display_items[row].author,
-                "message": self.display_items[row].message
+                "message": self.display_items[row].message,
             }
 
             if self.display_items[row].parents:
                 line["parents"] = self.display_items[row].parents
 
             try:
-                line["next_revision"] = self.display_items[row+1].revision
+                line["next_revision"] = self.display_items[row + 1].revision
             except IndexError as e:
                 pass
 
             try:
-                line["previous_revision"] = self.display_items[row-1].revision
+                line["previous_revision"] = self.display_items[row - 1].revision
             except IndexError as e:
                 pass
 
@@ -304,15 +310,18 @@ class Log(InterfaceView):
 
         revisions = []
         for row in self.revisions_table.get_selected_rows():
-            revisions.append(int(self.revisions_table.get_row(row)[
-                             self.revision_number_column]))
+            revisions.append(
+                int(self.revisions_table.get_row(row)[self.revision_number_column])
+            )
 
         revisions.sort()
         return helper.encode_revisions(revisions)
 
     def get_selected_revision_number(self):
         if len(self.revisions_table.get_selected_rows()):
-            return self.revisions_table.get_row(self.revisions_table.get_selected_rows()[0])[self.revision_number_column]
+            return self.revisions_table.get_row(
+                self.revisions_table.get_selected_rows()[0]
+            )[self.revision_number_column]
         else:
             return ""
 
@@ -337,15 +346,15 @@ class Log(InterfaceView):
             line = {
                 "revision": self.display_items[row].revision,
                 "author": self.display_items[row].author,
-                "message": self.display_items[row].message
+                "message": self.display_items[row].message,
             }
             try:
-                line["next_revision"] = self.display_items[row+1].revision
+                line["next_revision"] = self.display_items[row + 1].revision
             except IndexError as e:
                 pass
 
             try:
-                line["previous_revision"] = self.display_items[row-1].revision
+                line["previous_revision"] = self.display_items[row - 1].revision
             except IndexError as e:
                 pass
 
@@ -364,7 +373,7 @@ class Log(InterfaceView):
         options = [
             "%s@%s" % (url, revision2),
             "%s@%s" % (url, revision1),
-            "--vcs=%s" % self.get_vcs_name()
+            "--vcs=%s" % self.get_vcs_name(),
         ]
 
         if sidebyside:
@@ -391,53 +400,49 @@ class SVNLog(Log):
 
         self.revisions_table = rabbitvcs.ui.widget.Table(
             self.get_widget("revisions_table"),
-            [GObject.TYPE_STRING, GObject.TYPE_STRING,
-                GObject.TYPE_STRING, GObject.TYPE_STRING,
-                rabbitvcs.ui.widget.TYPE_HIDDEN],
-            [_("Revision"), _("Author"),
-                _("Date"), _("Message"),
-                _("Color")],
+            [
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                rabbitvcs.ui.widget.TYPE_HIDDEN,
+            ],
+            [_("Revision"), _("Author"), _("Date"), _("Message"), _("Color")],
             callbacks={
-                "mouse-event":   self.on_revisions_table_mouse_event,
-                "cursor-changed": self.on_revisions_table_cursor_changed
-            }
+                "mouse-event": self.on_revisions_table_mouse_event,
+                "cursor-changed": self.on_revisions_table_cursor_changed,
+            },
         )
 
         for i in range(4):
             column = self.revisions_table.get_column(i)
             cell = column.get_cells()[0]
-            column.add_attribute(cell, 'foreground', 4)
+            column.add_attribute(cell, "foreground", 4)
 
         self.paths_table = rabbitvcs.ui.widget.Table(
             self.get_widget("paths_table"),
-            [GObject.TYPE_STRING, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
-                GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
-            [_("Action"), "", _("Path"),
-                _("Copy From Path"), _("Copy From Revision")],
+            [
+                GObject.TYPE_STRING,
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+            ],
+            [_("Action"), "", _("Path"), _("Copy From Path"), _("Copy From Revision")],
             callbacks={
-                "mouse-event":      self.on_paths_table_mouse_event,
-                "row-activated":    self.on_paths_table_row_activated
+                "mouse-event": self.on_paths_table_mouse_event,
+                "row-activated": self.on_paths_table_row_activated,
             },
-            flags={
-                "sortable": True,
-                "sort_on": 2
-            }
+            flags={"sortable": True, "sort_on": 2},
         )
 
         self.initialize_root_url()
         self.load_or_refresh()
 
     def initialize_root_url(self):
-        action = SVNAction(
-            self.svn,
-            notification=False,
-            run_in_thread=False
-        )
+        action = SVNAction(self.svn, notification=False, run_in_thread=False)
 
-        self.root_url = action.run_single(
-            self.svn.get_repo_root_url,
-            self.path
-        )
+        self.root_url = action.run_single(self.svn.get_repo_root_url, self.path)
 
     #
     # Log-loading callback methods
@@ -485,10 +490,12 @@ class SVNLog(Log):
             should_add = not self.filter_text
             should_add = should_add or msg.find(self.filter_text) > -1
             should_add = should_add or item.author.lower().find(self.filter_text) > -1
-            should_add = should_add or str(
-                item.revision).lower().find(self.filter_text) > -1
-            should_add = should_add or str(
-                item.date).lower().find(self.filter_text) > -1
+            should_add = (
+                should_add or str(item.revision).lower().find(self.filter_text) > -1
+            )
+            should_add = (
+                should_add or str(item.date).lower().find(self.filter_text) > -1
+            )
 
             if should_add:
                 self.display_items.append(item)
@@ -500,12 +507,13 @@ class SVNLog(Log):
         self.check_next_sensitive()
 
         for item in self.display_items:
-            msg = helper.format_long_text(
-                item.message, cols=80, line1only=True)
+            msg = helper.format_long_text(item.message, cols=80, line1only=True)
             rev = item.revision
             color = self.orgTextColor  # "#000000"
-            if (self.merge_candidate_revisions != None and
-                    int(rev.short()) not in self.merge_candidate_revisions):
+            if (
+                self.merge_candidate_revisions != None
+                and int(rev.short()) not in self.merge_candidate_revisions
+            ):
                 color = "#c9c9c9"
 
             self.populate_table(rev, item.author, item.date, msg, color)
@@ -521,21 +529,20 @@ class SVNLog(Log):
         self.set_loading(False)
 
     def populate_table(self, revision, author, date, msg, color):
-        self.revisions_table.append([
-            S(revision),
-            author,
-            helper.format_datetime(date, self.datetime_format),
-            msg,
-            color
-        ])
+        self.revisions_table.append(
+            [
+                S(revision),
+                author,
+                helper.format_datetime(date, self.datetime_format),
+                msg,
+                color,
+            ]
+        )
 
     def load(self):
         self.set_loading(True)
 
-        self.action = SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.action = SVNAction(self.svn, notification=False)
 
         start = self.svn.revision("head")
         if self.rev_start:
@@ -546,7 +553,7 @@ class SVNLog(Log):
             self.path,
             revision_start=start,
             limit=self.limit,
-            discover_changed_paths=True
+            discover_changed_paths=True,
         )
         self.action.append(self.refresh)
         self.action.schedule()
@@ -556,19 +563,12 @@ class SVNLog(Log):
         failure = False
         url = S(self.svn.get_repo_url(self.path))
 
-        self.action = SVNAction(
-            self.svn,
-            notification=False
-        )
+        self.action = SVNAction(self.svn, notification=False)
 
         for row in self.revisions_table.get_selected_rows():
             item = self.display_items[row]
             self.action.append(
-                self.svn.revpropset,
-                prop_name,
-                prop_value,
-                url,
-                item.revision
+                self.svn.revpropset, prop_name, prop_value, url, item.revision
             )
 
             self.action.append(callback, row, prop_value)
@@ -597,12 +597,16 @@ class SVNLog(Log):
             text += "%s\n\n" % S(item.message).display()
             if item.changed_paths is not None:
                 for subitem in item.changed_paths:
-                    text += "%s\t%s" % (S(subitem.action).display(),
-                                        S(subitem.path).display())
+                    text += "%s\t%s" % (
+                        S(subitem.action).display(),
+                        S(subitem.path).display(),
+                    )
 
                     if subitem.copy_from_path or subitem.copy_from_revision:
-                        text += " (Copied from %s %s)" % (S(subitem.copy_from_path).display(),
-                                                          S(subitem.copy_from_revision).display())
+                        text += " (Copied from %s %s)" % (
+                            S(subitem.copy_from_path).display(),
+                            S(subitem.copy_from_revision).display(),
+                        )
 
                     text += "\n"
 
@@ -623,30 +627,28 @@ class SVNLog(Log):
             else:
                 indented_message = msg.replace("\n", "\n\t")
                 self.message.append_text(
-                    "%s %s:\n\t%s\n" % (REVISION_LABEL,
-                                        S(item.revision).display(),
-                                        indented_message))
+                    "%s %s:\n\t%s\n"
+                    % (REVISION_LABEL, S(item.revision).display(), indented_message)
+                )
             if item.changed_paths is not None:
                 for subitem in item.changed_paths:
                     if subitem.path not in combined_paths:
                         combined_paths.append(subitem.path)
 
-                        subitems.append([
-                            subitem.action,
-                            subitem.path,
-                            subitem.copy_from_path,
-                            S(subitem.copy_from_revision)
-                        ])
+                        subitems.append(
+                            [
+                                subitem.action,
+                                subitem.path,
+                                subitem.copy_from_path,
+                                S(subitem.copy_from_revision),
+                            ]
+                        )
 
         subitems.sort(key=lambda x: strxfrm(x[1]))
         for subitem in subitems:
-            self.paths_table.append([
-                subitem[0],
-                S(subitem[1]),
-                subitem[1],
-                subitem[2],
-                S(subitem[3])
-            ])
+            self.paths_table.append(
+                [subitem[0], S(subitem[1]), subitem[1], subitem[2], S(subitem[3])]
+            )
 
     def on_previous_clicked(self, widget):
         self.rev_start = self.previous_starts.pop()
@@ -662,7 +664,7 @@ class SVNLog(Log):
         self.load_or_refresh()
 
     def check_previous_sensitive(self):
-        sensitive = (self.rev_start < self.rev_max)
+        sensitive = self.rev_start < self.rev_max
         self.get_widget("previous").set_sensitive(sensitive)
 
     def check_next_sensitive(self):
@@ -688,34 +690,36 @@ class GitLog(Log):
 
         self.revisions_table = rabbitvcs.ui.widget.Table(
             self.get_widget("revisions_table"),
-            [rabbitvcs.ui.widget.TYPE_GRAPH, GObject.TYPE_STRING,
+            [
+                rabbitvcs.ui.widget.TYPE_GRAPH,
+                GObject.TYPE_STRING,
                 rabbitvcs.ui.widget.TYPE_MARKUP,
-                rabbitvcs.ui.widget.TYPE_MARKUP, rabbitvcs.ui.widget.TYPE_MARKUP],
-            [_("Graph"), _("Revision"), _("Author"),
-                _("Date"), _("Message")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.git_revision_filter,
-                "user_data": {
-                    "column": 1
+                rabbitvcs.ui.widget.TYPE_MARKUP,
+                rabbitvcs.ui.widget.TYPE_MARKUP,
+            ],
+            [_("Graph"), _("Revision"), _("Author"), _("Date"), _("Message")],
+            filters=[
+                {
+                    "callback": rabbitvcs.ui.widget.git_revision_filter,
+                    "user_data": {"column": 1},
                 }
-            }],
-            callbacks={
-                "mouse-event":   self.on_revisions_table_mouse_event
-            }
+            ],
+            callbacks={"mouse-event": self.on_revisions_table_mouse_event},
         )
 
         self.paths_table = rabbitvcs.ui.widget.Table(
             self.get_widget("paths_table"),
-            [GObject.TYPE_STRING, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
-                GObject.TYPE_STRING],
+            [
+                GObject.TYPE_STRING,
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                GObject.TYPE_STRING,
+            ],
             [_("Action"), "", _("Path")],
             callbacks={
-                "mouse-event":      self.on_paths_table_mouse_event,
-                "row-activated":    self.on_paths_table_row_activated
+                "mouse-event": self.on_paths_table_mouse_event,
+                "row-activated": self.on_paths_table_row_activated,
             },
-            flags={
-                "sortable": False
-            }
+            flags={"sortable": False},
         )
         self.start_point = 0
         self.initialize_root_url()
@@ -755,15 +759,14 @@ class GitLog(Log):
                 id = tag.sha
 
             # Add tags to list so we can match on id and display in the message.
-            self.tagItems.append({'id': id, 'name': name})
+            self.tagItems.append({"id": id, "name": name})
 
         # Load branches.
         self.branchItems = []
         for branch in self.branchAction.get_result(0):
             if branch.name.startswith("remotes/"):
-                branch.name = branch.name[len("remotes/"):]
-            self.branchItems.append(
-                {'id': branch.revision, 'name': branch.name})
+                branch.name = branch.name[len("remotes/") :]
+            self.branchItems.append({"id": branch.revision, "name": branch.name})
 
         self.set_start_revision(self.revision_items[0].revision.short())
         self.set_end_revision(self.revision_items[-1].revision.short())
@@ -776,10 +779,12 @@ class GitLog(Log):
             should_add = not self.filter_text
             should_add = should_add or msg.find(self.filter_text) > -1
             should_add = should_add or item.author.lower().find(self.filter_text) > -1
-            should_add = should_add or S(
-                item.revision).lower().find(self.filter_text) > -1
-            should_add = should_add or str(
-                item.date).lower().find(self.filter_text) > -1
+            should_add = (
+                should_add or S(item.revision).lower().find(self.filter_text) > -1
+            )
+            should_add = (
+                should_add or str(item.date).lower().find(self.filter_text) > -1
+            )
 
             if should_add:
                 self.display_items.append(item)
@@ -802,8 +807,9 @@ class GitLog(Log):
         index = 0
         for (item, node, in_lines, out_lines) in grapher:
             revision = S(item.revision)
-            msg = helper.html_escape(helper.format_long_text(
-                item.message, cols=80, line1only=True))
+            msg = helper.html_escape(
+                helper.format_long_text(item.message, cols=80, line1only=True)
+            )
             author = item.author
             date = helper.format_datetime(item.date, self.datetime_format)
 
@@ -818,26 +824,20 @@ class GitLog(Log):
                 graph_render = {
                     "node": node,
                     "in_lines": in_lines,
-                    "out_lines": out_lines
+                    "out_lines": out_lines,
                 }
 
             # Check if a branch is available for this revision, and if so, insert it in the message description.
             for branch in self.branchItems:
-                if branch['id'] == revision:
-                    msg = "<b>[" + branch['name'] + "]</b> " + msg
+                if branch["id"] == revision:
+                    msg = "<b>[" + branch["name"] + "]</b> " + msg
 
             # Check if a tag is available for this revision, and if so, insert it in the message description.
             for tag in self.tagItems:
-                if tag['id'] == revision:
-                    msg = "<i>[" + tag['name'] + "]</i> " + msg
+                if tag["id"] == revision:
+                    msg = "<i>[" + tag["name"] + "]</i> " + msg
 
-            self.revisions_table.append([
-                graph_render,
-                revision,
-                author,
-                date,
-                msg
-            ])
+            self.revisions_table.append([graph_render, revision, author, date, msg])
 
             index += 1
 
@@ -849,37 +849,22 @@ class GitLog(Log):
         self.set_loading(True)
 
         # Load branches.
-        self.branchAction = GitAction(
-            self.git,
-            notification=False,
-            run_in_thread=True
-        )
+        self.branchAction = GitAction(self.git, notification=False, run_in_thread=True)
 
         self.branchAction.append(self.git.branch_list)
         self.branchAction.schedule()
 
         # Load tags.
-        self.tagAction = GitAction(
-            self.git,
-            notification=False,
-            run_in_thread=True
-        )
+        self.tagAction = GitAction(self.git, notification=False, run_in_thread=True)
 
         self.tagAction.append(self.git.tag_list)
         self.tagAction.schedule()
 
         # Load log.
-        self.action = GitAction(
-            self.git,
-            notification=False,
-            run_in_thread=True
-        )
+        self.action = GitAction(self.git, notification=False, run_in_thread=True)
 
         self.action.append(
-            self.git.log,
-            path=self.path,
-            skip=self.start_point,
-            limit=self.limit+1
+            self.git.log, path=self.path, skip=self.start_point, limit=self.limit + 1
         )
         self.action.append(self.refresh)
         self.action.schedule()
@@ -889,8 +874,7 @@ class GitLog(Log):
         for selected_row in self.revisions_table.get_selected_rows():
             item = self.display_items[selected_row]
 
-            text += "%s: %s\n" % (REVISION_LABEL,
-                                  S(item.revision.short()).display())
+            text += "%s: %s\n" % (REVISION_LABEL, S(item.revision.short()).display())
             text += "%s: %s\n" % (AUTHOR_LABEL, S(item.author).display())
             text += "%s: %s\n" % (DATE_LABEL, S(item.date).display())
             text += "%s\n\n" % S(item.message).display()
@@ -910,27 +894,19 @@ class GitLog(Log):
             else:
                 indented_message = msg.replace("\n", "\n\t")
                 self.message.append_text(
-                    "%s %s:\n\t%s\n" % (REVISION_LABEL,
-                                        item.revision.short(),
-                                        msg))
+                    "%s %s:\n\t%s\n" % (REVISION_LABEL, item.revision.short(), msg)
+                )
 
             for subitem in item.changed_paths:
 
                 if subitem.path not in combined_paths:
                     combined_paths.append(subitem.path)
 
-                    subitems.append([
-                        subitem.action,
-                        subitem.path
-                    ])
+                    subitems.append([subitem.action, subitem.path])
 
-#        subitems.sort(key = lambda x: strxfrm(x[1]))
+        #        subitems.sort(key = lambda x: strxfrm(x[1]))
         for subitem in subitems:
-            self.paths_table.append([
-                subitem[0],
-                S(subitem[1]),
-                subitem[1]
-            ])
+            self.paths_table.append([subitem[0], S(subitem[1]), subitem[1]])
 
     def on_previous_clicked(self, widget):
         self.start_point -= self.limit
@@ -943,7 +919,7 @@ class GitLog(Log):
         self.load()
 
     def check_previous_sensitive(self):
-        sensitive = (self.start_point > 0)
+        sensitive = self.start_point > 0
         self.get_widget("previous").set_sensitive(sensitive)
 
     def check_next_sensitive(self):
@@ -958,7 +934,9 @@ class GitLog(Log):
 
 
 class SVNLogDialog(SVNLog):
-    def __init__(self, path, ok_callback=None, multiple=False, merge_candidate_revisions=None):
+    def __init__(
+        self, path, ok_callback=None, multiple=False, merge_candidate_revisions=None
+    ):
         """
         Override the normal SVNLog class so that we can hide the window as we need.
         Also, provide a callback for when the OK button is clicked so that we
@@ -1015,7 +993,7 @@ class LogCache(object):
         return self.cache[key]
 
     def has(self, key):
-        return (key in self.cache)
+        return key in self.cache
 
     def empty(self):
         self.cache = {}
@@ -1124,57 +1102,61 @@ class LogTopContextMenuConditions(object):
         self.vcs_name = caller.get_vcs_name()
 
     def view_diff_working_copy(self, data=None):
-        return (self.vcs.is_in_a_or_a_working_copy(self.path) and len(self.revisions) == 1)
+        return (
+            self.vcs.is_in_a_or_a_working_copy(self.path) and len(self.revisions) == 1
+        )
 
     def copy_clipboard(self, data=None):
-        return (len(self.revisions) > 0)
+        return len(self.revisions) > 0
 
     def view_diff_previous_revision(self, data=None):
         item = self.revisions[0]["revision"]
-        return ("previous_revision" in self.revisions[0] and len(self.revisions) == 1)
+        return "previous_revision" in self.revisions[0] and len(self.revisions) == 1
 
     def view_diff_revisions(self, data=None):
-        return (len(self.revisions) > 1)
+        return len(self.revisions) > 1
 
     def compare_working_copy(self, data=None):
-        return (self.vcs.is_in_a_or_a_working_copy(self.path) and len(self.revisions) == 1)
+        return (
+            self.vcs.is_in_a_or_a_working_copy(self.path) and len(self.revisions) == 1
+        )
 
     def compare_previous_revision(self, data=None):
         item = self.revisions[0]["revision"]
-        return ("previous_revision" in self.revisions[0] and len(self.revisions) == 1)
+        return "previous_revision" in self.revisions[0] and len(self.revisions) == 1
 
     def compare_revisions(self, data=None):
-        return (len(self.revisions) > 1)
+        return len(self.revisions) > 1
 
     def show_changes_previous_revision(self, data=None):
         item = self.revisions[0]["revision"]
-        return ("previous_revision" in self.revisions[0] and len(self.revisions) == 1)
+        return "previous_revision" in self.revisions[0] and len(self.revisions) == 1
 
     def show_changes_revisions(self, data=None):
-        return (len(self.revisions) > 1)
+        return len(self.revisions) > 1
 
     def update_to_this_revision(self, data=None):
-        return (self.vcs_name == rabbitvcs.vcs.VCS_SVN and len(self.revisions) == 1)
+        return self.vcs_name == rabbitvcs.vcs.VCS_SVN and len(self.revisions) == 1
 
     # TODO Evaluate multiple revisions later
     # TODO Git?
     def revert_changes_from_this_revision(self, data=None):
-        return (self.vcs_name == rabbitvcs.vcs.VCS_SVN and len(self.revisions) == 1)
+        return self.vcs_name == rabbitvcs.vcs.VCS_SVN and len(self.revisions) == 1
 
     def checkout(self, data=None):
-        return (len(self.revisions) == 1)
+        return len(self.revisions) == 1
 
     def branches(self, data=None):
-        return (len(self.revisions) == 1 and self.vcs_name == rabbitvcs.vcs.VCS_GIT)
+        return len(self.revisions) == 1 and self.vcs_name == rabbitvcs.vcs.VCS_GIT
 
     def tags(self, data=None):
-        return (len(self.revisions) == 1 and self.vcs_name == rabbitvcs.vcs.VCS_GIT)
+        return len(self.revisions) == 1 and self.vcs_name == rabbitvcs.vcs.VCS_GIT
 
     def branch_tag(self, data=None):
-        return (self.vcs_name == rabbitvcs.vcs.VCS_SVN and len(self.revisions) == 1)
+        return self.vcs_name == rabbitvcs.vcs.VCS_SVN and len(self.revisions) == 1
 
     def export(self, data=None):
-        return (len(self.revisions) == 1)
+        return len(self.revisions) == 1
 
     def edit_author(self, data=None):
         return self.vcs_name == rabbitvcs.vcs.VCS_SVN
@@ -1183,19 +1165,19 @@ class LogTopContextMenuConditions(object):
         return self.vcs_name == rabbitvcs.vcs.VCS_SVN
 
     def edit_revision_properties(self, data=None):
-        return (self.vcs_name == rabbitvcs.vcs.VCS_SVN and len(self.revisions) == 1)
+        return self.vcs_name == rabbitvcs.vcs.VCS_SVN and len(self.revisions) == 1
 
     def separator(self, data=None):
         return True
 
     def separator_last(self, data=None):
-        return (self.vcs_name == rabbitvcs.vcs.VCS_SVN)
+        return self.vcs_name == rabbitvcs.vcs.VCS_SVN
 
     def merge(self, data=None):
-        return (self.vcs_name == rabbitvcs.vcs.VCS_GIT)
+        return self.vcs_name == rabbitvcs.vcs.VCS_GIT
 
     def reset(self, data=None):
-        return (self.vcs_name == rabbitvcs.vcs.VCS_GIT)
+        return self.vcs_name == rabbitvcs.vcs.VCS_GIT
 
 
 class LogTopContextMenuCallbacks(object):
@@ -1210,7 +1192,7 @@ class LogTopContextMenuCallbacks(object):
     def find_parent(self, revision):
         if ("parents" in revision) and len(revision["parents"]) > 0:
             parent = S(revision["parents"][0])
-        elif ("next_revision" in revision):
+        elif "next_revision" in revision:
             parent = S(revision["next_revision"])
         else:
             parent = S(int(S(revision["revision"])) - 1)
@@ -1218,10 +1200,13 @@ class LogTopContextMenuCallbacks(object):
         return parent
 
     def view_diff_working_copy(self, widget, data=None):
-        helper.launch_ui_window("diff", [
-            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def copy_clipboard(self, widget, data=None):
         self.caller.copy_revision_text()
@@ -1229,56 +1214,71 @@ class LogTopContextMenuCallbacks(object):
     def view_diff_previous_revision(self, widget, data=None):
         parent = self.find_parent(self.revisions[0])
 
-        helper.launch_ui_window("diff", [
-            "%s@%s" % (self.path, parent),
-            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "%s@%s" % (self.path, parent),
+                "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def view_diff_revisions(self, widget, data=None):
         path_older = self.path
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path_older = self.vcs.svn().get_repo_url(self.path)
 
-        helper.launch_ui_window("diff", [
-            "%s@%s" % (path_older, self.revisions[1]["revision"].value),
-            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "%s@%s" % (path_older, self.revisions[1]["revision"].value),
+                "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def compare_working_copy(self, widget, data=None):
         path_older = self.path
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path_older = self.vcs.svn().get_repo_url(self.path)
 
-        helper.launch_ui_window("diff", [
-            "-s",
-            "%s@%s" % (path_older, S(self.revisions[0]["revision"])),
-            "%s" % (self.path),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "-s",
+                "%s@%s" % (path_older, S(self.revisions[0]["revision"])),
+                "%s" % (self.path),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def compare_previous_revision(self, widget, data=None):
         parent = self.find_parent(self.revisions[0])
 
-        helper.launch_ui_window("diff", [
-            "-s",
-            "%s@%s" % (self.path, parent),
-            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "-s",
+                "%s@%s" % (self.path, parent),
+                "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def compare_revisions(self, widget, data=None):
         path_older = self.path
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path_older = self.vcs.svn().get_repo_url(self.path)
 
-        helper.launch_ui_window("diff", [
-            "-s",
-            "%s@%s" % (path_older, self.revisions[1]["revision"].value),
-            "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "diff",
+            [
+                "-s",
+                "%s@%s" % (path_older, self.revisions[1]["revision"].value),
+                "%s@%s" % (self.path, S(self.revisions[0]["revision"])),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def show_changes_previous_revision(self, widget, data=None):
         rev_first = S(self.revisions[0]["revision"])
@@ -1288,11 +1288,14 @@ class LogTopContextMenuCallbacks(object):
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path = self.vcs.svn().get_repo_url(self.path)
 
-        helper.launch_ui_window("changes", [
-            "%s@%s" % (path, parent),
-            "%s@%s" % (path, S(rev_first)),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "changes",
+            [
+                "%s@%s" % (path, parent),
+                "%s@%s" % (path, S(rev_first)),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def show_changes_revisions(self, widget, data=None):
         rev_first = S(self.revisions[0]["revision"])
@@ -1302,66 +1305,97 @@ class LogTopContextMenuCallbacks(object):
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             path = self.vcs.svn().get_repo_url(self.path)
 
-        helper.launch_ui_window("changes", [
-            "%s@%s" % (path, S(rev_first)),
-            "%s@%s" % (path, S(rev_last)),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "changes",
+            [
+                "%s@%s" % (path, S(rev_first)),
+                "%s@%s" % (path, S(rev_last)),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def update_to_this_revision(self, widget, data=None):
-        helper.launch_ui_window("updateto", [
-            self.path,
-            "-r", S(self.revisions[0]["revision"]),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "updateto",
+            [
+                self.path,
+                "-r",
+                S(self.revisions[0]["revision"]),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def revert_changes_from_this_revision(self, widget, data=None):
-        helper.launch_ui_window("merge", [
-            self.path,
-            S(self.revisions[0]["revision"]) + "-" +
-            str(int(S(self.revisions[0]["revision"])) - 1),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "merge",
+            [
+                self.path,
+                S(self.revisions[0]["revision"])
+                + "-"
+                + str(int(S(self.revisions[0]["revision"])) - 1),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def checkout(self, widget, data=None):
         url = ""
         if self.vcs_name == rabbitvcs.vcs.VCS_SVN:
             url = self.vcs.svn().get_repo_url(self.path)
 
-        helper.launch_ui_window("checkout", [
-            self.path,
-            url,
-            "-r", S(self.revisions[0]["revision"]),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "checkout",
+            [
+                self.path,
+                url,
+                "-r",
+                S(self.revisions[0]["revision"]),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def branch_tag(self, widget, data=None):
-        helper.launch_ui_window("branch", [
-            self.path,
-            "-r", S(self.revisions[0]["revision"]),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "branch",
+            [
+                self.path,
+                "-r",
+                S(self.revisions[0]["revision"]),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def branches(self, widget, data=None):
-        helper.launch_ui_window("branches", [
-            self.path,
-            "-r", S(self.revisions[0]["revision"]),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "branches",
+            [
+                self.path,
+                "-r",
+                S(self.revisions[0]["revision"]),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def tags(self, widget, data=None):
-        helper.launch_ui_window("tags", [
-            self.path,
-            "-r", S(self.revisions[0]["revision"]),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "tags",
+            [
+                self.path,
+                "-r",
+                S(self.revisions[0]["revision"]),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def export(self, widget, data=None):
-        helper.launch_ui_window("export", [
-            self.path,
-            "-r", S(self.revisions[0]["revision"]),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "export",
+            [
+                self.path,
+                "-r",
+                S(self.revisions[0]["revision"]),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def merge(self, widget, data=None):
         extra = []
@@ -1378,11 +1412,15 @@ class LogTopContextMenuCallbacks(object):
         helper.launch_ui_window("merge", [self.path] + extra)
 
     def reset(self, widget, data=None):
-        helper.launch_ui_window("reset", [
-            self.path,
-            "-r", S(self.revisions[0]["revision"]),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "reset",
+            [
+                self.path,
+                "-r",
+                S(self.revisions[0]["revision"]),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def edit_author(self, widget, data=None):
         author = ""
@@ -1392,12 +1430,14 @@ class LogTopContextMenuCallbacks(object):
                 author = ""
 
         from rabbitvcs.ui.dialog import TextChange
+
         dialog = TextChange(_("Edit author"), author)
         (result, new_author) = dialog.run()
 
         if result == Gtk.ResponseType.OK:
             self.caller.edit_revprop(
-                "svn:author", new_author, self.caller.on_author_edited)
+                "svn:author", new_author, self.caller.on_author_edited
+            )
 
     def edit_log_message(self, widget, data=None):
         message = ""
@@ -1405,20 +1445,25 @@ class LogTopContextMenuCallbacks(object):
             message = self.revisions[0]["message"]
 
         from rabbitvcs.ui.dialog import TextChange
+
         dialog = TextChange(_("Edit log message"), message)
         (result, new_message) = dialog.run()
 
         if result == Gtk.ResponseType.OK:
             self.caller.edit_revprop(
-                "svn:log", new_message, self.caller.on_log_message_edited)
+                "svn:log", new_message, self.caller.on_log_message_edited
+            )
 
     def edit_revision_properties(self, widget, data=None):
         url = self.vcs.svn().get_repo_url(self.path)
 
-        helper.launch_ui_window("revprops", [
-            "%s@%s" % (url, S(self.revisions[0]["revision"])),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "revprops",
+            [
+                "%s@%s" % (url, S(self.revisions[0]["revision"])),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
 
 class LogTopContextMenu(object):
@@ -1449,17 +1494,11 @@ class LogTopContextMenu(object):
         self.vcs = rabbitvcs.vcs.VCS()
 
         self.conditions = LogTopContextMenuConditions(
-            self.caller,
-            self.vcs,
-            self.path,
-            self.revisions
+            self.caller, self.vcs, self.path, self.revisions
         )
 
         self.callbacks = LogTopContextMenuCallbacks(
-            self.caller,
-            self.vcs,
-            self.path,
-            self.revisions
+            self.caller, self.vcs, self.path, self.revisions
         )
 
         # The first element of each tuple is a key that matches a
@@ -1489,15 +1528,14 @@ class LogTopContextMenu(object):
             (MenuSeparatorLast, None),
             (MenuEditAuthor, None),
             (MenuEditLogMessage, None),
-            (MenuEditRevisionProperties, None)
+            (MenuEditRevisionProperties, None),
         ]
 
     def show(self):
         if len(self.revisions) == 0:
             return
 
-        context_menu = GtkContextMenu(
-            self.structure, self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
 
 
@@ -1513,33 +1551,33 @@ class LogBottomContextMenuConditions(object):
 
     def view_diff_previous_revision(self, data=None):
         item = self.revisions[0]["revision"]
-        return ("previous_revision" in self.revisions[0] and len(self.revisions) == 1)
+        return "previous_revision" in self.revisions[0] and len(self.revisions) == 1
 
     def view_diff_revisions(self, data=None):
-        return (len(self.paths) == 1 and len(self.revisions) > 1)
+        return len(self.paths) == 1 and len(self.revisions) > 1
 
     def compare_working_copy(self, data=None):
         return False
 
     def compare_previous_revision(self, data=None):
         item = self.revisions[0]["revision"]
-        return ("previous_revision" in self.revisions[0] and len(self.revisions) == 1)
+        return "previous_revision" in self.revisions[0] and len(self.revisions) == 1
 
     def compare_revisions(self, data=None):
-        return (len(self.paths) == 1 and len(self.revisions) > 1)
+        return len(self.paths) == 1 and len(self.revisions) > 1
 
     def show_changes_previous_revision(self, data=None):
         item = self.revisions[0]["revision"]
-        return ("previous_revision" in self.revisions[0] and len(self.revisions) == 1)
+        return "previous_revision" in self.revisions[0] and len(self.revisions) == 1
 
     def show_changes_revisions(self, data=None):
-        return (len(self.paths) == 1 and len(self.revisions) > 1)
+        return len(self.paths) == 1 and len(self.revisions) > 1
 
     def _open(self, data=None):
         return True
 
     def annotate(self, data=None):
-        return (len(self.paths) == 1)
+        return len(self.paths) == 1
 
     def separator(self, data=None):
         return True
@@ -1558,7 +1596,7 @@ class LogBottomContextMenuCallbacks(object):
     def find_parent(self, revision):
         if ("parents" in revision) and len(revision["parents"]) > 0:
             parent = S(revision["parents"][0])
-        elif ("next_revision" in revision):
+        elif "next_revision" in revision:
             parent = S(revision["next_revision"])
         else:
             parent = S(int(S(revision["revision"])) - 1)
@@ -1579,8 +1617,9 @@ class LogBottomContextMenuCallbacks(object):
         rev_last = S(self.revisions[-1]["revision"])
         path_item = S(self.paths[0]).unicode()
         url = self.caller.root_url + path_item
-        self.caller.view_diff_for_path(url, latest_revision_number=rev_last,
-                                       earliest_revision_number=rev_first)
+        self.caller.view_diff_for_path(
+            url, latest_revision_number=rev_last, earliest_revision_number=rev_first
+        )
 
     def compare_previous_revision(self, widget, data=None):
         rev = S(self.revisions[0]["revision"])
@@ -1596,10 +1635,9 @@ class LogBottomContextMenuCallbacks(object):
         latest_rev = S(self.revisions[-1]["revision"])
         path_item = S(self.paths[0]).unicode()
         url = self.caller.root_url + path_item
-        self.caller.view_diff_for_path(url,
-                                       latest_rev,
-                                       sidebyside=True,
-                                       earliest_revision_number=earliest_rev)
+        self.caller.view_diff_for_path(
+            url, latest_rev, sidebyside=True, earliest_revision_number=earliest_rev
+        )
 
     def show_changes_previous_revision(self, widget, data=None):
         rev_first = S(self.revisions[0]["revision"])
@@ -1609,11 +1647,14 @@ class LogBottomContextMenuCallbacks(object):
 
         url = self.caller.root_url + S(self.paths[0]).unicode()
 
-        helper.launch_ui_window("changes", [
-            six.u("%s@%s") % (url, parent),
-            six.u("%s@%s") % (url, rev_last),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "changes",
+            [
+                six.u("%s@%s") % (url, parent),
+                six.u("%s@%s") % (url, rev_last),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def show_changes_revisions(self, widget, data=None):
         rev_first = S(self.revisions[0]["revision"])
@@ -1621,28 +1662,34 @@ class LogBottomContextMenuCallbacks(object):
 
         url = self.caller.root_url + S(self.paths[0]).unicode()
 
-        helper.launch_ui_window("changes", [
-            six.u("%s@%s") % (url, rev_first),
-            six.u("%s@%s") % (url, rev_last),
-            "--vcs=%s" % self.caller.get_vcs_name()
-        ])
+        helper.launch_ui_window(
+            "changes",
+            [
+                six.u("%s@%s") % (url, rev_first),
+                six.u("%s@%s") % (url, rev_last),
+                "--vcs=%s" % self.caller.get_vcs_name(),
+            ],
+        )
 
     def _open(self, widget, data=None):
         for path in self.paths:
             path = self.caller.root_url + S(path).unicode()
-            helper.launch_ui_window("open", [
-                path,
-                "--vcs=%s" % self.vcs_name,
-                "-r", S(self.revisions[0]["revision"])
-            ])
+            helper.launch_ui_window(
+                "open",
+                [
+                    path,
+                    "--vcs=%s" % self.vcs_name,
+                    "-r",
+                    S(self.revisions[0]["revision"]),
+                ],
+            )
 
     def annotate(self, widget, data=None):
         url = self.caller.root_url + S(self.paths[0]).unicode()
-        helper.launch_ui_window("annotate", [
-            url,
-            "--vcs=%s" % self.vcs_name,
-            "-r", S(self.revisions[0]["revision"])
-        ])
+        helper.launch_ui_window(
+            "annotate",
+            [url, "--vcs=%s" % self.vcs_name, "-r", S(self.revisions[0]["revision"])],
+        )
 
 
 class LogBottomContextMenu(object):
@@ -1674,17 +1721,11 @@ class LogBottomContextMenu(object):
         self.svn = self.vcs.svn()
 
         self.conditions = LogBottomContextMenuConditions(
-            self.caller,
-            self.vcs,
-            self.paths,
-            self.revisions
+            self.caller, self.vcs, self.paths, self.revisions
         )
 
         self.callbacks = LogBottomContextMenuCallbacks(
-            self.caller,
-            self.vcs,
-            self.paths,
-            self.revisions
+            self.caller, self.vcs, self.paths, self.revisions
         )
 
         # The first element of each tuple is a key that matches a
@@ -1699,27 +1740,20 @@ class LogBottomContextMenu(object):
             (MenuShowChangesRevisions, None),
             (MenuSeparator, None),
             (MenuOpen, None),
-            (MenuAnnotate, None)
+            (MenuAnnotate, None),
         ]
 
     def show(self):
         if len(self.paths) == 0:
             return
 
-        context_menu = GtkContextMenu(
-            self.structure, self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNLog,
-    rabbitvcs.vcs.VCS_GIT: GitLog
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNLog, rabbitvcs.vcs.VCS_GIT: GitLog}
 
-dialogs_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNLogDialog,
-    rabbitvcs.vcs.VCS_GIT: GitLogDialog
-}
+dialogs_map = {rabbitvcs.vcs.VCS_SVN: SVNLogDialog, rabbitvcs.vcs.VCS_GIT: GitLogDialog}
 
 
 def log_factory(path, vcs):
@@ -1732,6 +1766,7 @@ def log_factory(path, vcs):
         vcs = guess["vcs"]
         if not vcs in classes_map:
             from rabbitvcs.ui import VCS_OPT_ERROR
+
             raise SystemExit(VCS_OPT_ERROR)
 
     return classes_map[vcs](path)
@@ -1747,9 +1782,9 @@ def log_dialog_factory(path, ok_callback=None, multiple=False, vcs=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT
+
     (options, paths) = main(
-        [VCS_OPT],
-        usage="Usage: rabbitvcs log [--vcs=svn|git] [url_or_path]"
+        [VCS_OPT], usage="Usage: rabbitvcs log [--vcs=svn|git] [url_or_path]"
     )
 
     window = log_factory(paths[0], vcs=options.vcs)

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -21,6 +21,19 @@
 #
 
 from __future__ import division
+from six.moves import range
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+import rabbitvcs.util.settings
+from rabbitvcs.util.strings import S
+from rabbitvcs.util.decorators import gtk_unsafe
+from rabbitvcs.util.contextmenuitems import *
+from rabbitvcs.util.contextmenu import GtkContextMenu
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.dialog import MessageBox
+from rabbitvcs.ui.action import SVNAction, GitAction, vcs_action_factory
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 from __future__ import absolute_import
 import six
 import threading
@@ -33,24 +46,10 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import SVNAction, GitAction, vcs_action_factory
-from rabbitvcs.ui.dialog import MessageBox
-import rabbitvcs.ui.widget
-from rabbitvcs.util.contextmenu import GtkContextMenu
-from rabbitvcs.util.contextmenuitems import *
-from rabbitvcs.util.decorators import gtk_unsafe
-from rabbitvcs.util.strings import S
-import rabbitvcs.util.settings
-import rabbitvcs.vcs
 
-from rabbitvcs import gettext
 _ = gettext.gettext
-
-from six.moves import range
 
 
 REVISION_LABEL = _("Revision")
@@ -106,6 +105,7 @@ def revision_grapher(history):
         last_lines = lines
 
     return items
+
 
 class Log(InterfaceView):
     """
@@ -178,7 +178,7 @@ class Log(InterfaceView):
     def on_key_pressed(self, widget, event, *args):
         InterfaceView.on_key_pressed(self, widget, event)
         if (event.state & Gdk.ModifierType.CONTROL_MASK and
-            Gdk.keyval_name(event.keyval).lower() == "c"):
+                Gdk.keyval_name(event.keyval).lower() == "c"):
             if len(self.revisions_table.get_selected_rows()) > 0:
                 self.copy_revision_text()
 
@@ -192,10 +192,10 @@ class Log(InterfaceView):
         self.cache.empty()
         self.load()
 
-
     def on_search(self, widget):
         tb = self.get_widget("search_buffer")
-        self.filter_text = tb.get_text(tb.get_start_iter(), tb.get_end_iter(), 0).lower()
+        self.filter_text = tb.get_text(
+            tb.get_start_iter(), tb.get_end_iter(), 0).lower()
 
         self.refresh()
 
@@ -234,18 +234,21 @@ class Log(InterfaceView):
 
         # Let the rest be handled by the on_revisions_table_cursor changed event
 
-
     #
     # Paths table callbacks
     #
 
     def on_paths_table_row_activated(self, treeview, data=None, col=None):
         try:
-            revision1 = S(self.display_items[self.revisions_table.get_selected_rows()[0]].revision)
-            revision2 = S(self.display_items[self.revisions_table.get_selected_rows()[0]+1].revision)
-            path_item = self.paths_table.get_row(self.paths_table.get_selected_rows()[0])[1]
+            revision1 = S(
+                self.display_items[self.revisions_table.get_selected_rows()[0]].revision)
+            revision2 = S(
+                self.display_items[self.revisions_table.get_selected_rows()[0]+1].revision)
+            path_item = self.paths_table.get_row(
+                self.paths_table.get_selected_rows()[0])[1]
             url = self.root_url + path_item
-            self.view_diff_for_path(url, S(revision1), S(revision2), sidebyside=True)
+            self.view_diff_for_path(
+                url, S(revision1), S(revision2), sidebyside=True)
         except IndexError:
             pass
 
@@ -301,7 +304,8 @@ class Log(InterfaceView):
 
         revisions = []
         for row in self.revisions_table.get_selected_rows():
-            revisions.append(int(self.revisions_table.get_row(row)[self.revision_number_column]))
+            revisions.append(int(self.revisions_table.get_row(row)[
+                             self.revision_number_column]))
 
         revisions.sort()
         return helper.encode_revisions(revisions)
@@ -376,6 +380,7 @@ class Log(InterfaceView):
             vcs = rabbitvcs.vcs.VCS_GIT
 
         return vcs
+
 
 class SVNLog(Log):
     def __init__(self, path, merge_candidate_revisions=None):
@@ -480,8 +485,10 @@ class SVNLog(Log):
             should_add = not self.filter_text
             should_add = should_add or msg.find(self.filter_text) > -1
             should_add = should_add or item.author.lower().find(self.filter_text) > -1
-            should_add = should_add or str(item.revision).lower().find(self.filter_text) > -1
-            should_add = should_add or str(item.date).lower().find(self.filter_text) > -1
+            should_add = should_add or str(
+                item.revision).lower().find(self.filter_text) > -1
+            should_add = should_add or str(
+                item.date).lower().find(self.filter_text) > -1
 
             if should_add:
                 self.display_items.append(item)
@@ -493,11 +500,12 @@ class SVNLog(Log):
         self.check_next_sensitive()
 
         for item in self.display_items:
-            msg = helper.format_long_text(item.message, cols = 80, line1only = True)
+            msg = helper.format_long_text(
+                item.message, cols=80, line1only=True)
             rev = item.revision
-            color = self.orgTextColor #"#000000"
+            color = self.orgTextColor  # "#000000"
             if (self.merge_candidate_revisions != None and
-                int(rev.short()) not in self.merge_candidate_revisions):
+                    int(rev.short()) not in self.merge_candidate_revisions):
                 color = "#c9c9c9"
 
             self.populate_table(rev, item.author, item.date, msg, color)
@@ -520,7 +528,6 @@ class SVNLog(Log):
             msg,
             color
         ])
-
 
     def load(self):
         self.set_loading(True)
@@ -587,13 +594,15 @@ class SVNLog(Log):
             text += "%s: %s\n" % (REVISION_LABEL, S(item.revision).display())
             text += "%s: %s\n" % (AUTHOR_LABEL, S(item.author).display())
             text += "%s: %s\n" % (DATE_LABEL, S(item.date).display())
-            text += "%s\n\n"   % S(item.message).display()
+            text += "%s\n\n" % S(item.message).display()
             if item.changed_paths is not None:
                 for subitem in item.changed_paths:
-                    text += "%s\t%s" % (S(subitem.action).display(), S(subitem.path).display())
+                    text += "%s\t%s" % (S(subitem.action).display(),
+                                        S(subitem.path).display())
 
                     if subitem.copy_from_path or subitem.copy_from_revision:
-                        text += " (Copied from %s %s)" % (S(subitem.copy_from_path).display(), S(subitem.copy_from_revision).display())
+                        text += " (Copied from %s %s)" % (S(subitem.copy_from_path).display(),
+                                                          S(subitem.copy_from_revision).display())
 
                     text += "\n"
 
@@ -612,11 +621,11 @@ class SVNLog(Log):
             if len(self.revisions_table.get_selected_rows()) == 1:
                 self.message.set_text(msg)
             else:
-                indented_message = msg.replace("\n","\n\t")
+                indented_message = msg.replace("\n", "\n\t")
                 self.message.append_text(
-                                         "%s %s:\n\t%s\n" % (REVISION_LABEL,
-                                         S(item.revision).display(),
-                                         indented_message))
+                    "%s %s:\n\t%s\n" % (REVISION_LABEL,
+                                        S(item.revision).display(),
+                                        indented_message))
             if item.changed_paths is not None:
                 for subitem in item.changed_paths:
                     if subitem.path not in combined_paths:
@@ -629,7 +638,7 @@ class SVNLog(Log):
                             S(subitem.copy_from_revision)
                         ])
 
-        subitems.sort(key = lambda x: strxfrm(x[1]))
+        subitems.sort(key=lambda x: strxfrm(x[1]))
         for subitem in subitems:
             self.paths_table.append([
                 subitem[0],
@@ -664,6 +673,7 @@ class SVNLog(Log):
             sensitive = False
 
         self.get_widget("next").set_sensitive(sensitive)
+
 
 class GitLog(Log):
     def __init__(self, path):
@@ -752,7 +762,8 @@ class GitLog(Log):
         for branch in self.branchAction.get_result(0):
             if branch.name.startswith("remotes/"):
                 branch.name = branch.name[len("remotes/"):]
-            self.branchItems.append({'id': branch.revision, 'name': branch.name})
+            self.branchItems.append(
+                {'id': branch.revision, 'name': branch.name})
 
         self.set_start_revision(self.revision_items[0].revision.short())
         self.set_end_revision(self.revision_items[-1].revision.short())
@@ -765,8 +776,10 @@ class GitLog(Log):
             should_add = not self.filter_text
             should_add = should_add or msg.find(self.filter_text) > -1
             should_add = should_add or item.author.lower().find(self.filter_text) > -1
-            should_add = should_add or S(item.revision).lower().find(self.filter_text) > -1
-            should_add = should_add or str(item.date).lower().find(self.filter_text) > -1
+            should_add = should_add or S(
+                item.revision).lower().find(self.filter_text) > -1
+            should_add = should_add or str(
+                item.date).lower().find(self.filter_text) > -1
 
             if should_add:
                 self.display_items.append(item)
@@ -789,7 +802,8 @@ class GitLog(Log):
         index = 0
         for (item, node, in_lines, out_lines) in grapher:
             revision = S(item.revision)
-            msg = helper.html_escape(helper.format_long_text(item.message, cols = 80, line1only = True))
+            msg = helper.html_escape(helper.format_long_text(
+                item.message, cols=80, line1only=True))
             author = item.author
             date = helper.format_datetime(item.date, self.datetime_format)
 
@@ -842,7 +856,7 @@ class GitLog(Log):
         )
 
         self.branchAction.append(self.git.branch_list)
-        self.branchAction.schedule();
+        self.branchAction.schedule()
 
         # Load tags.
         self.tagAction = GitAction(
@@ -875,7 +889,8 @@ class GitLog(Log):
         for selected_row in self.revisions_table.get_selected_rows():
             item = self.display_items[selected_row]
 
-            text += "%s: %s\n" % (REVISION_LABEL, S(item.revision.short()).display())
+            text += "%s: %s\n" % (REVISION_LABEL,
+                                  S(item.revision.short()).display())
             text += "%s: %s\n" % (AUTHOR_LABEL, S(item.author).display())
             text += "%s: %s\n" % (DATE_LABEL, S(item.date).display())
             text += "%s\n\n" % S(item.message).display()
@@ -893,11 +908,11 @@ class GitLog(Log):
             if len(self.revisions_table.get_selected_rows()) == 1:
                 self.message.set_text(msg)
             else:
-                indented_message = msg.replace("\n","\n\t")
+                indented_message = msg.replace("\n", "\n\t")
                 self.message.append_text(
-                                         "%s %s:\n\t%s\n" % (REVISION_LABEL,
-                                         item.revision.short(),
-                                         msg))
+                    "%s %s:\n\t%s\n" % (REVISION_LABEL,
+                                        item.revision.short(),
+                                        msg))
 
             for subitem in item.changed_paths:
 
@@ -941,6 +956,7 @@ class GitLog(Log):
     def initialize_root_url(self):
         self.root_url = self.git.get_repository() + "/"
 
+
 class SVNLogDialog(SVNLog):
     def __init__(self, path, ok_callback=None, multiple=False, merge_candidate_revisions=None):
         """
@@ -964,6 +980,7 @@ class SVNLogDialog(SVNLog):
             else:
                 self.ok_callback(self.get_selected_revision_number())
 
+
 class GitLogDialog(GitLog):
     def __init__(self, path, ok_callback=None, multiple=False):
         """
@@ -985,6 +1002,7 @@ class GitLogDialog(GitLog):
                 self.ok_callback(self.get_selected_revision_numbers())
             else:
                 self.ok_callback(self.get_selected_revision_number())
+
 
 class LogCache(object):
     def __init__(self, cache={}):
@@ -1008,30 +1026,36 @@ class MenuViewDiffWorkingCopy(MenuItem):
     label = _("View diff against working copy")
     icon = "rabbitvcs-diff"
 
+
 class MenuViewDiffPreviousRevision(MenuItem):
     identifier = "RabbitVCS::View_Diff_Previous_Revision"
     label = _("View diff against previous revision")
     icon = "rabbitvcs-diff"
+
 
 class MenuViewDiffRevisions(MenuItem):
     identifier = "RabbitVCS::View_Diff_Revisions"
     label = _("View diff between revisions")
     icon = "rabbitvcs-diff"
 
+
 class MenuCompareWorkingCopy(MenuItem):
     identifier = "RabbitVCS::Compare_Working_Copy"
     label = _("Compare with working copy")
     icon = "rabbitvcs-compare"
+
 
 class MenuComparePreviousRevision(MenuItem):
     identifier = "RabbitVCS::Compare_Previous_Revision"
     label = _("Compare with previous revision")
     icon = "rabbitvcs-compare"
 
+
 class MenuCompareRevisions(MenuItem):
     identifier = "RabbitVCS::Compare_Revisions"
     label = _("Compare revisions")
     icon = "rabbitvcs-compare"
+
 
 class MenuShowChangesPreviousRevision(MenuItem):
     # This is for the revs list
@@ -1039,11 +1063,13 @@ class MenuShowChangesPreviousRevision(MenuItem):
     label = _("Show changes against previous revision")
     icon = "rabbitvcs-changes"
 
+
 class MenuShowChangesRevisions(MenuItem):
     # This is for the revs list
     identifier = "RabbitVCS::Show_Changes_Revisions"
     label = _("Show changes between revisions")
     icon = "rabbitvcs-changes"
+
 
 class MenuUpdateToThisRevision(MenuItem):
     identifier = "RabbitVCS::Update_To_This_Revision"
@@ -1051,11 +1077,13 @@ class MenuUpdateToThisRevision(MenuItem):
     tooltip = _("Update the selected path to this revision")
     icon = "rabbitvcs-update"
 
+
 class MenuRevertChangesFromThisRevision(MenuItem):
     identifier = "RabbitVCS::Revert_Changes_From_This_Revision"
     label = _("Revert changes from this revision")
     tooltip = _("Update the selected path by reverse merging the changes")
     icon = "rabbitvcs-revert"
+
 
 class MenuCopyClipboard(MenuItem):
     identifier = "RabbitVCS::Copy_Clipboard"
@@ -1063,23 +1091,28 @@ class MenuCopyClipboard(MenuItem):
     tooltip = _("Copy to clipboard the full data of these revisions")
     icon = "rabbitvcs-asynchronous"
 
+
 class MenuEditAuthor(MenuItem):
     identifier = "RabbitVCS::Edit_Author"
     label = _("Edit author...")
     icon = "rabbitvcs-monkey"
+
 
 class MenuEditLogMessage(MenuItem):
     identifier = "RabbitVCS::Edit_Log_Message"
     label = _("Edit log message...")
     icon = "rabbitvcs-editconflicts"
 
+
 class MenuEditRevisionProperties(MenuItem):
     identifier = "RabbitVCS::Edit_Revision_Properties"
     label = _("Edit revision properties...")
     icon = "rabbitvcs-editprops"
 
+
 class MenuSeparatorLast(MenuSeparator):
     identifier = "RabbitVCS::Separator_Last"
+
 
 class LogTopContextMenuConditions(object):
     def __init__(self, caller, vcs, path, revisions):
@@ -1163,6 +1196,7 @@ class LogTopContextMenuConditions(object):
 
     def reset(self, data=None):
         return (self.vcs_name == rabbitvcs.vcs.VCS_GIT)
+
 
 class LogTopContextMenuCallbacks(object):
     def __init__(self, caller, vcs, path, revisions):
@@ -1284,7 +1318,8 @@ class LogTopContextMenuCallbacks(object):
     def revert_changes_from_this_revision(self, widget, data=None):
         helper.launch_ui_window("merge", [
             self.path,
-            S(self.revisions[0]["revision"]) + "-" + str(int(S(self.revisions[0]["revision"])) - 1),
+            S(self.revisions[0]["revision"]) + "-" +
+            str(int(S(self.revisions[0]["revision"])) - 1),
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
@@ -1361,7 +1396,8 @@ class LogTopContextMenuCallbacks(object):
         (result, new_author) = dialog.run()
 
         if result == Gtk.ResponseType.OK:
-            self.caller.edit_revprop("svn:author", new_author, self.caller.on_author_edited)
+            self.caller.edit_revprop(
+                "svn:author", new_author, self.caller.on_author_edited)
 
     def edit_log_message(self, widget, data=None):
         message = ""
@@ -1373,7 +1409,8 @@ class LogTopContextMenuCallbacks(object):
         (result, new_message) = dialog.run()
 
         if result == Gtk.ResponseType.OK:
-            self.caller.edit_revprop("svn:log", new_message, self.caller.on_log_message_edited)
+            self.caller.edit_revprop(
+                "svn:log", new_message, self.caller.on_log_message_edited)
 
     def edit_revision_properties(self, widget, data=None):
         url = self.vcs.svn().get_repo_url(self.path)
@@ -1383,11 +1420,13 @@ class LogTopContextMenuCallbacks(object):
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
+
 class LogTopContextMenu(object):
     """
     Defines context menu items for a table with files
 
     """
+
     def __init__(self, caller, event, path, revisions=[]):
         """
         @param  caller: The calling object
@@ -1457,7 +1496,8 @@ class LogTopContextMenu(object):
         if len(self.revisions) == 0:
             return
 
-        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(
+            self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
 
 
@@ -1503,6 +1543,7 @@ class LogBottomContextMenuConditions(object):
 
     def separator(self, data=None):
         return True
+
 
 class LogBottomContextMenuCallbacks(object):
     def __init__(self, caller, vcs, paths, revisions):
@@ -1556,9 +1597,9 @@ class LogBottomContextMenuCallbacks(object):
         path_item = S(self.paths[0]).unicode()
         url = self.caller.root_url + path_item
         self.caller.view_diff_for_path(url,
-                                        latest_rev,
-                                        sidebyside=True,
-                                        earliest_revision_number=earliest_rev)
+                                       latest_rev,
+                                       sidebyside=True,
+                                       earliest_revision_number=earliest_rev)
 
     def show_changes_previous_revision(self, widget, data=None):
         rev_first = S(self.revisions[0]["revision"])
@@ -1586,7 +1627,6 @@ class LogBottomContextMenuCallbacks(object):
             "--vcs=%s" % self.caller.get_vcs_name()
         ])
 
-
     def _open(self, widget, data=None):
         for path in self.paths:
             path = self.caller.root_url + S(path).unicode()
@@ -1604,11 +1644,13 @@ class LogBottomContextMenuCallbacks(object):
             "-r", S(self.revisions[0]["revision"])
         ])
 
+
 class LogBottomContextMenu(object):
     """
     Defines context menu items for a table with files
 
     """
+
     def __init__(self, caller, event, paths, revisions):
         """
         @param  caller: The calling object
@@ -1664,8 +1706,10 @@ class LogBottomContextMenu(object):
         if len(self.paths) == 0:
             return
 
-        context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
+        context_menu = GtkContextMenu(
+            self.structure, self.conditions, self.callbacks)
         context_menu.show(self.event)
+
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNLog,
@@ -1676,6 +1720,7 @@ dialogs_map = {
     rabbitvcs.vcs.VCS_SVN: SVNLogDialog,
     rabbitvcs.vcs.VCS_GIT: GitLogDialog
 }
+
 
 def log_factory(path, vcs):
     # vcs option is allowed for URL only
@@ -1690,6 +1735,7 @@ def log_factory(path, vcs):
             raise SystemExit(VCS_OPT_ERROR)
 
     return classes_map[vcs](path)
+
 
 def log_dialog_factory(path, ok_callback=None, multiple=False, vcs=None):
     if not vcs:

--- a/rabbitvcs/ui/markresolved.py
+++ b/rabbitvcs/ui/markresolved.py
@@ -1,4 +1,14 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui.add import Add
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,21 +38,12 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.add import Add
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.markresolved")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNMarkResolved(Add):
     def setup(self, window, columns):
@@ -50,11 +51,11 @@ class SVNMarkResolved(Add):
         self.svn = self.vcs.svn()
         self.statuses = self.svn.STATUSES_FOR_RESOLVE
         columns[0] = [GObject.TYPE_BOOLEAN,
-                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
-                rabbitvcs.ui.widget.TYPE_PATH,
-                GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
+                      rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                      rabbitvcs.ui.widget.TYPE_PATH,
+                      GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
         columns[1] = [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"),
-                _("Extension"), _("Text Status"), _("Property Status")]
+                      _("Extension"), _("Text Status"), _("Property Status")]
 
     def populate_files_table(self):
         self.files_table.clear()
@@ -81,16 +82,20 @@ class SVNMarkResolved(Add):
         )
 
         self.action.append(self.action.set_header, _("Mark as Resolved"))
-        self.action.append(self.action.set_status, _("Running Resolved Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Resolved Command..."))
         for item in items:
             self.action.append(self.svn.resolve, item, recurse=True)
-        self.action.append(self.action.set_status, _("Completed Mark as Resolved"))
+        self.action.append(self.action.set_status,
+                           _("Completed Mark as Resolved"))
         self.action.append(self.action.finish)
         self.action.schedule()
+
 
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNMarkResolved
 }
+
 
 def markresolved_factory(paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])

--- a/rabbitvcs/ui/markresolved.py
+++ b/rabbitvcs/ui/markresolved.py
@@ -9,6 +9,7 @@ from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui.add import Add
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -36,6 +37,7 @@ import six.moves._thread
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -50,24 +52,38 @@ class SVNMarkResolved(Add):
         window.set_title(_("Mark as Resolved"))
         self.svn = self.vcs.svn()
         self.statuses = self.svn.STATUSES_FOR_RESOLVE
-        columns[0] = [GObject.TYPE_BOOLEAN,
-                      rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
-                      rabbitvcs.ui.widget.TYPE_PATH,
-                      GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING],
-        columns[1] = [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"),
-                      _("Extension"), _("Text Status"), _("Property Status")]
+        columns[0] = (
+            [
+                GObject.TYPE_BOOLEAN,
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+                GObject.TYPE_STRING,
+            ],
+        )
+        columns[1] = [
+            rabbitvcs.ui.widget.TOGGLE_BUTTON,
+            "",
+            _("Path"),
+            _("Extension"),
+            _("Text Status"),
+            _("Property Status"),
+        ]
 
     def populate_files_table(self):
         self.files_table.clear()
         for item in self.items:
-            self.files_table.append([
-                True,
-                S(item.path),
-                item.path,
-                helper.get_file_extension(item.path),
-                item.simple_content_status(),
-                item.simple_metadata_status()
-            ])
+            self.files_table.append(
+                [
+                    True,
+                    S(item.path),
+                    item.path,
+                    helper.get_file_extension(item.path),
+                    item.simple_content_status(),
+                    item.simple_metadata_status(),
+                ]
+            )
 
     def on_ok_clicked(self, widget):
         items = self.files_table.get_activated_rows(1)
@@ -77,24 +93,19 @@ class SVNMarkResolved(Add):
         self.hide()
 
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Mark as Resolved"))
-        self.action.append(self.action.set_status,
-                           _("Running Resolved Command..."))
+        self.action.append(self.action.set_status, _("Running Resolved Command..."))
         for item in items:
             self.action.append(self.svn.resolve, item, recurse=True)
-        self.action.append(self.action.set_status,
-                           _("Completed Mark as Resolved"))
+        self.action.append(self.action.set_status, _("Completed Mark as Resolved"))
         self.action.append(self.action.finish)
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNMarkResolved
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNMarkResolved}
 
 
 def markresolved_factory(paths, base_dir=None):
@@ -104,9 +115,9 @@ def markresolved_factory(paths, base_dir=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT],
-        usage="Usage: rabbitvcs markresolved [path1] [path2] ..."
+        [BASEDIR_OPT], usage="Usage: rabbitvcs markresolved [path1] [path2] ..."
     )
 
     window = markresolved_factory(paths, options.base_dir)

--- a/rabbitvcs/ui/merge.py
+++ b/rabbitvcs/ui/merge.py
@@ -8,6 +8,7 @@ from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui.log import SVNLogDialog
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -33,6 +34,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -77,16 +79,9 @@ class SVNMerge(InterfaceView):
         self.initialize_root_url()
 
     def initialize_root_url(self):
-        action = SVNAction(
-            self.svn,
-            notification=False,
-            run_in_thread=False
-        )
+        action = SVNAction(self.svn, notification=False, run_in_thread=False)
 
-        self.root_url = action.run_single(
-            self.svn.get_repo_url,
-            self.path
-        )
+        self.root_url = action.run_single(self.svn.get_repo_url, self.path)
 
     #
     # Assistant UI Signal Callbacks
@@ -111,13 +106,11 @@ class SVNMerge(InterfaceView):
             self.hide()
 
         recursive = self.get_widget("mergeoptions_recursive").get_active()
-        ignore_ancestry = self.get_widget(
-            "mergeoptions_ignore_ancestry").get_active()
+        ignore_ancestry = self.get_widget("mergeoptions_ignore_ancestry").get_active()
 
         record_only = False
         if self.svn.has_merge2():
-            record_only = self.get_widget(
-                "mergeoptions_only_record").get_active()
+            record_only = self.get_widget("mergeoptions_only_record").get_active()
 
         action = SVNAction(self.svn, register_gtk_quit=(not test))
         action.append(action.set_header, _("Merge"))
@@ -151,17 +144,23 @@ class SVNMerge(InterfaceView):
                 # Before pysvn v1.6.3, there was a bug that required the ranges
                 # tuple to have three elements, even though only two were used
                 # Fixed in Pysvn Revision 1114
-                if (self.svn.interface == "pysvn" and self.svn.is_version_less_than((1, 6, 3, 0))):
-                    ranges.append((
-                        self.svn.revision("number", number=low).primitive(),
-                        self.svn.revision("number", number=high).primitive(),
-                        None
-                    ))
+                if self.svn.interface == "pysvn" and self.svn.is_version_less_than(
+                    (1, 6, 3, 0)
+                ):
+                    ranges.append(
+                        (
+                            self.svn.revision("number", number=low).primitive(),
+                            self.svn.revision("number", number=high).primitive(),
+                            None,
+                        )
+                    )
                 else:
-                    ranges.append((
-                        self.svn.revision("number", number=low).primitive(),
-                        self.svn.revision("number", number=high).primitive(),
-                    ))
+                    ranges.append(
+                        (
+                            self.svn.revision("number", number=low).primitive(),
+                            self.svn.revision("number", number=high).primitive(),
+                        )
+                    )
 
             action.append(helper.save_repository_path, url)
 
@@ -172,12 +171,9 @@ class SVNMerge(InterfaceView):
                 url,
                 ranges,
                 self.svn.revision("head"),
-                self.path
+                self.path,
             )
-            kwargs = {
-                "notice_ancestry": (not ignore_ancestry),
-                "dry_run":          test
-            }
+            kwargs = {"notice_ancestry": (not ignore_ancestry), "dry_run": test}
             if record_only:
                 kwargs["record_only"] = record_only
 
@@ -189,15 +185,8 @@ class SVNMerge(InterfaceView):
 
             # Build up args and kwargs because some args are not supported
             # with older versions of pysvn/svn
-            args = (
-                self.svn.merge_reintegrate,
-                url,
-                revision,
-                self.path
-            )
-            kwargs = {
-                "dry_run":          test
-            }
+            args = (self.svn.merge_reintegrate, url, revision, self.path)
+            kwargs = {"dry_run": test}
 
         elif self.type == "tree":
             from_url = self.mergetree_from_repos.get_active_text()
@@ -205,16 +194,18 @@ class SVNMerge(InterfaceView):
             if self.get_widget("mergetree_from_revision_number_opt").get_active():
                 from_revision = self.svn.revision(
                     "number",
-                    number=int(self.get_widget(
-                        "mergetree_from_revision_number").get_text())
+                    number=int(
+                        self.get_widget("mergetree_from_revision_number").get_text()
+                    ),
                 )
             to_url = self.mergetree_to_repos.get_active_text()
             to_revision = self.svn.revision("head")
             if self.get_widget("mergetree_to_revision_number_opt").get_active():
                 to_revision = self.svn.revision(
                     "number",
-                    number=int(self.get_widget(
-                        "mergetree_to_revision_number").get_text())
+                    number=int(
+                        self.get_widget("mergetree_to_revision_number").get_text()
+                    ),
                 )
 
             action.append(helper.save_repository_path, from_url)
@@ -228,12 +219,9 @@ class SVNMerge(InterfaceView):
                 from_revision,
                 to_url,
                 to_revision,
-                self.path
+                self.path,
             )
-            kwargs = {
-                "recurse": recursive,
-                "dry_run": test
-            }
+            kwargs = {"recurse": recursive, "dry_run": test}
 
         if len(args) > 0:
             action.append(*args, **kwargs)
@@ -265,7 +253,8 @@ class SVNMerge(InterfaceView):
                 self.type = "range"
                 if self.revision_range:
                     self.get_widget("mergerange_revisions").set_text(
-                        S(self.revision_range).display())
+                        S(self.revision_range).display()
+                    )
             elif self.get_widget("mergetype_tree_opt").get_active():
                 next = 2
                 self.type = "tree"
@@ -284,25 +273,22 @@ class SVNMerge(InterfaceView):
     def on_mergerange_prepare(self):
         if not hasattr(self, "mergerange_repos"):
             self.mergerange_repos = rabbitvcs.ui.widget.ComboBox(
-                self.get_widget("mergerange_from_urls"),
-                self.repo_paths
+                self.get_widget("mergerange_from_urls"), self.repo_paths
             )
             self.mergerange_repos.set_child_text(self.root_url)
-            self.get_widget("mergerange_working_copy").set_text(
-                S(self.path).display())
+            self.get_widget("mergerange_working_copy").set_text(S(self.path).display())
 
         self.mergerange_check_ready()
 
     def on_mergerange_show_log1_clicked(self, widget):
         merge_candidate_revisions = self.svn.find_merge_candidate_revisions(
-            self.mergerange_repos.get_active_text(),
-            self.path
+            self.mergerange_repos.get_active_text(), self.path
         )
         SVNLogDialog(
             self.mergerange_repos.get_active_text(),
             ok_callback=self.on_mergerange_log1_closed,
             multiple=True,
-            merge_candidate_revisions=merge_candidate_revisions
+            merge_candidate_revisions=merge_candidate_revisions,
         )
 
     def on_mergerange_log1_closed(self, data):
@@ -334,24 +320,26 @@ class SVNMerge(InterfaceView):
     def on_merge_reintegrate_prepare(self):
         if not hasattr(self, "merge_reintegrate_repos"):
             self.merge_reintegrate_repos = rabbitvcs.ui.widget.ComboBox(
-                self.get_widget("merge_reintegrate_repos"),
-                self.repo_paths
+                self.get_widget("merge_reintegrate_repos"), self.repo_paths
             )
             self.merge_reintegrate_repos.cb.connect(
-                "changed", self.on_merge_reintegrate_from_urls_changed)
+                "changed", self.on_merge_reintegrate_from_urls_changed
+            )
             self.get_widget("merge_reintegrate_working_copy").set_text(
-                S(self.path).display())
+                S(self.path).display()
+            )
 
         if not hasattr(self, "merge_reintegrate_revision"):
             self.merge_reintegrate_revision = rabbitvcs.ui.widget.RevisionSelector(
                 self.get_widget("revision_container"),
                 self.svn,
                 url_combobox=self.merge_reintegrate_repos,
-                expand=True
+                expand=True,
             )
 
     def on_merge_reintegrate_browse_clicked(self, widget):
         from rabbitvcs.ui.browser import SVNBrowserDialog
+
         SVNBrowserDialog(self.path, callback=self.on_repo_chooser_closed)
 
     def on_repo_chooser_closed(self, new_url):
@@ -375,38 +363,31 @@ class SVNMerge(InterfaceView):
     def on_mergetree_prepare(self):
         if not hasattr(self, "mergetree_from_repos"):
             self.mergetree_from_repos = rabbitvcs.ui.widget.ComboBox(
-                self.get_widget("mergetree_from_urls"),
-                self.repo_paths
+                self.get_widget("mergetree_from_urls"), self.repo_paths
             )
             self.mergetree_to_repos = rabbitvcs.ui.widget.ComboBox(
-                self.get_widget("mergetree_to_urls"),
-                self.repo_paths
+                self.get_widget("mergetree_to_urls"), self.repo_paths
             )
-            self.get_widget("mergetree_working_copy").set_text(
-                S(self.path).display())
+            self.get_widget("mergetree_working_copy").set_text(S(self.path).display())
 
     def on_mergetree_from_show_log_clicked(self, widget):
         SVNLogDialog(
             self.path,
             ok_callback=self.on_mergetree_from_show_log_closed,
-            multiple=False
+            multiple=False,
         )
 
     def on_mergetree_from_show_log_closed(self, data):
-        self.get_widget("mergetree_from_revision_number").set_text(
-            S(data).display())
+        self.get_widget("mergetree_from_revision_number").set_text(S(data).display())
         self.get_widget("mergetree_from_revision_number_opt").set_active(True)
 
     def on_mergetree_to_show_log_clicked(self, widget):
         SVNLogDialog(
-            self.path,
-            ok_callback=self.on_mergetree_to_show_log_closed,
-            multiple=False
+            self.path, ok_callback=self.on_mergetree_to_show_log_closed, multiple=False
         )
 
     def on_mergetree_to_show_log_closed(self, data):
-        self.get_widget("mergetree_to_revision_number").set_text(
-            S(data).display())
+        self.get_widget("mergetree_to_revision_number").set_text(S(data).display())
         self.get_widget("mergetree_to_revision_number_opt").set_active(True)
 
     def on_mergetree_working_copy_show_log_clicked(self, widget):
@@ -478,7 +459,7 @@ class GitMerge(BranchMerge):
             revision=self.branch,
             url=path,
             expand=True,
-            revision_changed_callback=self.__revision_changed
+            revision_changed_callback=self.__revision_changed,
         )
 
         self.update_branch_info()
@@ -486,7 +467,13 @@ class GitMerge(BranchMerge):
         self.active_branch = self.git.get_active_branch()
         if self.active_branch:
             self.get_widget("to_branch").set_text(
-                S(self.active_branch.name + " (" + self.active_branch.revision[0:7] + ")").display())
+                S(
+                    self.active_branch.name
+                    + " ("
+                    + self.active_branch.revision[0:7]
+                    + ")"
+                ).display()
+            )
         else:
             self.get_widget("to_branch").set_text(_("No active branch"))
 
@@ -496,60 +483,55 @@ class GitMerge(BranchMerge):
 
         # FROM BRANCH INFO #
         from_container = rabbitvcs.ui.widget.Box(
-            self.get_widget("from_branch_info"), vertical=True)
+            self.get_widget("from_branch_info"), vertical=True
+        )
 
         # Set up the Author line
         author = Gtk.Label(label=_("Author:"))
         author.set_size_request(90, -1)
         author.set_properties(xalign=0, yalign=0)
-        self.info['from']['author'] = Gtk.Label(label="")
-        self.info['from']['author'].set_properties(
-            xalign=0, yalign=0, selectable=True)
-        self.info['from']['author'].set_line_wrap(True)
+        self.info["from"]["author"] = Gtk.Label(label="")
+        self.info["from"]["author"].set_properties(xalign=0, yalign=0, selectable=True)
+        self.info["from"]["author"].set_line_wrap(True)
         author_container = rabbitvcs.ui.widget.Box()
         author_container.pack_start(author, False, False, 0)
-        author_container.pack_start(
-            self.info['from']['author'], False, False, 0)
+        author_container.pack_start(self.info["from"]["author"], False, False, 0)
         from_container.pack_start(author_container, False, False, 0)
 
         # Set up the Date line
         date = Gtk.Label(label=_("Date:"))
         date.set_size_request(90, -1)
         date.set_properties(xalign=0, yalign=0)
-        self.info['from']['date'] = Gtk.Label(label="")
-        self.info['from']['date'].set_properties(
-            xalign=0, yalign=0, selectable=True)
+        self.info["from"]["date"] = Gtk.Label(label="")
+        self.info["from"]["date"].set_properties(xalign=0, yalign=0, selectable=True)
         date_container = rabbitvcs.ui.widget.Box()
         date_container.pack_start(date, False, False, 0)
-        date_container.pack_start(self.info['from']['date'], False, False, 0)
+        date_container.pack_start(self.info["from"]["date"], False, False, 0)
         from_container.pack_start(date_container, False, False, 0)
 
         # Set up the Revision line
         revision = Gtk.Label(label=_("Revision:"))
         revision.set_size_request(90, -1)
         revision.set_properties(xalign=0, yalign=0)
-        self.info['from']['revision'] = Gtk.Label(label="")
-        self.info['from']['revision'].set_properties(xalign=0, selectable=True)
-        self.info['from']['revision'].set_line_wrap(True)
+        self.info["from"]["revision"] = Gtk.Label(label="")
+        self.info["from"]["revision"].set_properties(xalign=0, selectable=True)
+        self.info["from"]["revision"].set_line_wrap(True)
         revision_container = rabbitvcs.ui.widget.Box()
         revision_container.pack_start(revision, False, False, 0)
-        revision_container.pack_start(
-            self.info['from']['revision'], False, False, 0)
+        revision_container.pack_start(self.info["from"]["revision"], False, False, 0)
         from_container.pack_start(revision_container, False, False, 0)
 
         # Set up the Log Message line
         message = Gtk.Label(label=_("Message:"))
         message.set_size_request(90, -1)
         message.set_properties(xalign=0, yalign=0)
-        self.info['from']['message'] = Gtk.Label(label="")
-        self.info['from']['message'].set_properties(
-            xalign=0, yalign=0, selectable=True)
-        self.info['from']['message'].set_line_wrap(True)
-        self.info['from']['message'].set_size_request(250, -1)
+        self.info["from"]["message"] = Gtk.Label(label="")
+        self.info["from"]["message"].set_properties(xalign=0, yalign=0, selectable=True)
+        self.info["from"]["message"].set_line_wrap(True)
+        self.info["from"]["message"].set_size_request(250, -1)
         message_container = rabbitvcs.ui.widget.Box()
         message_container.pack_start(message, False, False, 0)
-        message_container.pack_start(
-            self.info['from']['message'], False, False, 0)
+        message_container.pack_start(self.info["from"]["message"], False, False, 0)
         from_container.pack_start(message_container, False, False, 0)
 
         from_container.show_all()
@@ -558,18 +540,25 @@ class GitMerge(BranchMerge):
         from_branch = self.from_branches.get_revision_object()
 
         if from_branch.value:
-            log = self.git.log(self.path, limit=1,
-                               revision=from_branch, showtype="branch")
+            log = self.git.log(
+                self.path, limit=1, revision=from_branch, showtype="branch"
+            )
             if log:
                 from_info = log[0]
-                self.info['from']['author'].set_text(
-                    S(from_info.author).display())
-                self.info['from']['date'].set_text(
-                    helper.format_datetime(from_info.date, self.datetime_format))
-                self.info['from']['revision'].set_text(
-                    S(from_info.revision).display()[0:7])
-                self.info['from']['message'].set_text(S(helper.html_escape(
-                    helper.format_long_text(from_info.message, 500))).display())
+                self.info["from"]["author"].set_text(S(from_info.author).display())
+                self.info["from"]["date"].set_text(
+                    helper.format_datetime(from_info.date, self.datetime_format)
+                )
+                self.info["from"]["revision"].set_text(
+                    S(from_info.revision).display()[0:7]
+                )
+                self.info["from"]["message"].set_text(
+                    S(
+                        helper.html_escape(
+                            helper.format_long_text(from_info.message, 500)
+                        )
+                    ).display()
+                )
 
     def on_from_branches_changed(self, widget):
         self.update_branch_info()
@@ -580,17 +569,12 @@ class GitMerge(BranchMerge):
         from_branch = self.from_branches.get_revision_object()
 
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Merge"))
-        self.action.append(self.action.set_status,
-                           _("Running Merge Command..."))
-        self.action.append(
-            self.git.merge,
-            from_branch
-        )
+        self.action.append(self.action.set_status, _("Running Merge Command..."))
+        self.action.append(self.git.merge, from_branch)
 
         self.action.append(self.action.set_status, _("Completed Merge"))
         self.action.append(self.action.finish)
@@ -602,9 +586,9 @@ class GitMerge(BranchMerge):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT
+
     (options, args) = main(
-        [VCS_OPT],
-        usage="Usage: rabbitvcs merge path [revision/revision_range]"
+        [VCS_OPT], usage="Usage: rabbitvcs merge path [revision/revision_range]"
     )
 
     path = args[0]

--- a/rabbitvcs/ui/merge.py
+++ b/rabbitvcs/ui/merge.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.strings import S
+import rabbitvcs.util.settings
+import rabbitvcs.ui.widget
+import rabbitvcs.vcs
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui.log import SVNLogDialog
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,22 +35,14 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.log import SVNLogDialog
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.vcs
-import rabbitvcs.ui.widget
-import rabbitvcs.util.settings
-from rabbitvcs.util.strings import S
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
+
 class SVNMerge(InterfaceView):
-    def __init__(self, path, revision_range = None):
+    def __init__(self, path, revision_range=None):
         InterfaceView.__init__(self, "merge", "Merge")
 
         self.revision_range = revision_range
@@ -87,7 +88,6 @@ class SVNMerge(InterfaceView):
             self.path
         )
 
-
     #
     # Assistant UI Signal Callbacks
     #
@@ -97,8 +97,6 @@ class SVNMerge(InterfaceView):
 
     def on_test_clicked(self, widget):
         self.merge(test=True)
-
-
 
     def merge(self, test=False):
         if self.type is None:
@@ -113,11 +111,13 @@ class SVNMerge(InterfaceView):
             self.hide()
 
         recursive = self.get_widget("mergeoptions_recursive").get_active()
-        ignore_ancestry = self.get_widget("mergeoptions_ignore_ancestry").get_active()
+        ignore_ancestry = self.get_widget(
+            "mergeoptions_ignore_ancestry").get_active()
 
         record_only = False
         if self.svn.has_merge2():
-            record_only = self.get_widget("mergeoptions_only_record").get_active()
+            record_only = self.get_widget(
+                "mergeoptions_only_record").get_active()
 
         action = SVNAction(self.svn, register_gtk_quit=(not test))
         action.append(action.set_header, _("Merge"))
@@ -137,11 +137,11 @@ class SVNMerge(InterfaceView):
             ranges = []
             for r in revisions.split(","):
                 if r.find("-") != -1:
-                    (low, high) = [ int(i) for i in r.split("-") ]
+                    (low, high) = [int(i) for i in r.split("-")]
                     if low < high:
                         low -= 1
                 elif r.find(":") != -1:
-                    (low, high) = [ int(i) for i in r.split(":") ]
+                    (low, high) = [int(i) for i in r.split(":")]
                     if low < high:
                         low -= 1
                 else:
@@ -151,7 +151,7 @@ class SVNMerge(InterfaceView):
                 # Before pysvn v1.6.3, there was a bug that required the ranges
                 # tuple to have three elements, even though only two were used
                 # Fixed in Pysvn Revision 1114
-                if (self.svn.interface == "pysvn" and self.svn.is_version_less_than((1,6,3,0))):
+                if (self.svn.interface == "pysvn" and self.svn.is_version_less_than((1, 6, 3, 0))):
                     ranges.append((
                         self.svn.revision("number", number=low).primitive(),
                         self.svn.revision("number", number=high).primitive(),
@@ -205,14 +205,16 @@ class SVNMerge(InterfaceView):
             if self.get_widget("mergetree_from_revision_number_opt").get_active():
                 from_revision = self.svn.revision(
                     "number",
-                    number=int(self.get_widget("mergetree_from_revision_number").get_text())
+                    number=int(self.get_widget(
+                        "mergetree_from_revision_number").get_text())
                 )
             to_url = self.mergetree_to_repos.get_active_text()
             to_revision = self.svn.revision("head")
             if self.get_widget("mergetree_to_revision_number_opt").get_active():
                 to_revision = self.svn.revision(
                     "number",
-                    number=int(self.get_widget("mergetree_to_revision_number").get_text())
+                    number=int(self.get_widget(
+                        "mergetree_to_revision_number").get_text())
                 )
 
             action.append(helper.save_repository_path, from_url)
@@ -262,7 +264,8 @@ class SVNMerge(InterfaceView):
                 next = 1
                 self.type = "range"
                 if self.revision_range:
-                    self.get_widget("mergerange_revisions").set_text(S(self.revision_range).display())
+                    self.get_widget("mergerange_revisions").set_text(
+                        S(self.revision_range).display())
             elif self.get_widget("mergetype_tree_opt").get_active():
                 next = 2
                 self.type = "tree"
@@ -285,7 +288,8 @@ class SVNMerge(InterfaceView):
                 self.repo_paths
             )
             self.mergerange_repos.set_child_text(self.root_url)
-            self.get_widget("mergerange_working_copy").set_text(S(self.path).display())
+            self.get_widget("mergerange_working_copy").set_text(
+                S(self.path).display())
 
         self.mergerange_check_ready()
 
@@ -333,8 +337,10 @@ class SVNMerge(InterfaceView):
                 self.get_widget("merge_reintegrate_repos"),
                 self.repo_paths
             )
-            self.merge_reintegrate_repos.cb.connect("changed", self.on_merge_reintegrate_from_urls_changed)
-            self.get_widget("merge_reintegrate_working_copy").set_text(S(self.path).display())
+            self.merge_reintegrate_repos.cb.connect(
+                "changed", self.on_merge_reintegrate_from_urls_changed)
+            self.get_widget("merge_reintegrate_working_copy").set_text(
+                S(self.path).display())
 
         if not hasattr(self, "merge_reintegrate_revision"):
             self.merge_reintegrate_revision = rabbitvcs.ui.widget.RevisionSelector(
@@ -376,7 +382,8 @@ class SVNMerge(InterfaceView):
                 self.get_widget("mergetree_to_urls"),
                 self.repo_paths
             )
-            self.get_widget("mergetree_working_copy").set_text(S(self.path).display())
+            self.get_widget("mergetree_working_copy").set_text(
+                S(self.path).display())
 
     def on_mergetree_from_show_log_clicked(self, widget):
         SVNLogDialog(
@@ -386,7 +393,8 @@ class SVNMerge(InterfaceView):
         )
 
     def on_mergetree_from_show_log_closed(self, data):
-        self.get_widget("mergetree_from_revision_number").set_text(S(data).display())
+        self.get_widget("mergetree_from_revision_number").set_text(
+            S(data).display())
         self.get_widget("mergetree_from_revision_number_opt").set_active(True)
 
     def on_mergetree_to_show_log_clicked(self, widget):
@@ -397,7 +405,8 @@ class SVNMerge(InterfaceView):
         )
 
     def on_mergetree_to_show_log_closed(self, data):
-        self.get_widget("mergetree_to_revision_number").set_text(S(data).display())
+        self.get_widget("mergetree_to_revision_number").set_text(
+            S(data).display())
         self.get_widget("mergetree_to_revision_number_opt").set_active(True)
 
     def on_mergetree_working_copy_show_log_clicked(self, widget):
@@ -440,6 +449,7 @@ class SVNMerge(InterfaceView):
 
         self.assistant.set_page_complete(self.page, True)
 
+
 class BranchMerge(InterfaceView):
     def __init__(self, path, branch=None):
         InterfaceView.__init__(self, "branch-merge", "Merge")
@@ -451,10 +461,8 @@ class BranchMerge(InterfaceView):
         sm = rabbitvcs.util.settings.SettingsManager()
         self.datetime_format = sm.get("general", "datetime_format")
 
-
     def on_cancel_clicked(self, widget, data=None):
         self.close()
-
 
 
 class GitMerge(BranchMerge):
@@ -477,64 +485,71 @@ class GitMerge(BranchMerge):
 
         self.active_branch = self.git.get_active_branch()
         if self.active_branch:
-            self.get_widget("to_branch").set_text(S(self.active_branch.name + " (" + self.active_branch.revision[0:7] + ")").display())
+            self.get_widget("to_branch").set_text(
+                S(self.active_branch.name + " (" + self.active_branch.revision[0:7] + ")").display())
         else:
             self.get_widget("to_branch").set_text(_("No active branch"))
 
-
     def init_branch_widgets(self):
 
-        self.info = {"from":{}, "to":{}}
+        self.info = {"from": {}, "to": {}}
 
         # FROM BRANCH INFO #
-        from_container = rabbitvcs.ui.widget.Box(self.get_widget("from_branch_info"), vertical = True)
+        from_container = rabbitvcs.ui.widget.Box(
+            self.get_widget("from_branch_info"), vertical=True)
 
         # Set up the Author line
-        author = Gtk.Label(label = _("Author:"))
+        author = Gtk.Label(label=_("Author:"))
         author.set_size_request(90, -1)
-        author.set_properties(xalign=0,yalign=0)
-        self.info['from']['author'] = Gtk.Label(label = "")
-        self.info['from']['author'].set_properties(xalign=0,yalign=0,selectable=True)
+        author.set_properties(xalign=0, yalign=0)
+        self.info['from']['author'] = Gtk.Label(label="")
+        self.info['from']['author'].set_properties(
+            xalign=0, yalign=0, selectable=True)
         self.info['from']['author'].set_line_wrap(True)
         author_container = rabbitvcs.ui.widget.Box()
         author_container.pack_start(author, False, False, 0)
-        author_container.pack_start(self.info['from']['author'], False, False, 0)
+        author_container.pack_start(
+            self.info['from']['author'], False, False, 0)
         from_container.pack_start(author_container, False, False, 0)
 
         # Set up the Date line
-        date = Gtk.Label(label = _("Date:"))
+        date = Gtk.Label(label=_("Date:"))
         date.set_size_request(90, -1)
-        date.set_properties(xalign=0,yalign=0)
-        self.info['from']['date'] = Gtk.Label(label = "")
-        self.info['from']['date'].set_properties(xalign=0,yalign=0,selectable=True)
+        date.set_properties(xalign=0, yalign=0)
+        self.info['from']['date'] = Gtk.Label(label="")
+        self.info['from']['date'].set_properties(
+            xalign=0, yalign=0, selectable=True)
         date_container = rabbitvcs.ui.widget.Box()
         date_container.pack_start(date, False, False, 0)
         date_container.pack_start(self.info['from']['date'], False, False, 0)
         from_container.pack_start(date_container, False, False, 0)
 
         # Set up the Revision line
-        revision = Gtk.Label(label = _("Revision:"))
+        revision = Gtk.Label(label=_("Revision:"))
         revision.set_size_request(90, -1)
-        revision.set_properties(xalign=0,yalign=0)
-        self.info['from']['revision'] = Gtk.Label(label = "")
-        self.info['from']['revision'].set_properties(xalign=0,selectable=True)
+        revision.set_properties(xalign=0, yalign=0)
+        self.info['from']['revision'] = Gtk.Label(label="")
+        self.info['from']['revision'].set_properties(xalign=0, selectable=True)
         self.info['from']['revision'].set_line_wrap(True)
         revision_container = rabbitvcs.ui.widget.Box()
         revision_container.pack_start(revision, False, False, 0)
-        revision_container.pack_start(self.info['from']['revision'], False, False, 0)
+        revision_container.pack_start(
+            self.info['from']['revision'], False, False, 0)
         from_container.pack_start(revision_container, False, False, 0)
 
         # Set up the Log Message line
-        message = Gtk.Label(label = _("Message:"))
+        message = Gtk.Label(label=_("Message:"))
         message.set_size_request(90, -1)
-        message.set_properties(xalign=0,yalign=0)
-        self.info['from']['message'] = Gtk.Label(label = "")
-        self.info['from']['message'].set_properties(xalign=0,yalign=0,selectable=True)
+        message.set_properties(xalign=0, yalign=0)
+        self.info['from']['message'] = Gtk.Label(label="")
+        self.info['from']['message'].set_properties(
+            xalign=0, yalign=0, selectable=True)
         self.info['from']['message'].set_line_wrap(True)
         self.info['from']['message'].set_size_request(250, -1)
         message_container = rabbitvcs.ui.widget.Box()
         message_container.pack_start(message, False, False, 0)
-        message_container.pack_start(self.info['from']['message'], False, False, 0)
+        message_container.pack_start(
+            self.info['from']['message'], False, False, 0)
         from_container.pack_start(message_container, False, False, 0)
 
         from_container.show_all()
@@ -543,13 +558,18 @@ class GitMerge(BranchMerge):
         from_branch = self.from_branches.get_revision_object()
 
         if from_branch.value:
-            log = self.git.log(self.path, limit=1, revision=from_branch, showtype="branch")
+            log = self.git.log(self.path, limit=1,
+                               revision=from_branch, showtype="branch")
             if log:
                 from_info = log[0]
-                self.info['from']['author'].set_text(S(from_info.author).display())
-                self.info['from']['date'].set_text(helper.format_datetime(from_info.date, self.datetime_format))
-                self.info['from']['revision'].set_text(S(from_info.revision).display()[0:7])
-                self.info['from']['message'].set_text(S(helper.html_escape(helper.format_long_text(from_info.message, 500))).display())
+                self.info['from']['author'].set_text(
+                    S(from_info.author).display())
+                self.info['from']['date'].set_text(
+                    helper.format_datetime(from_info.date, self.datetime_format))
+                self.info['from']['revision'].set_text(
+                    S(from_info.revision).display()[0:7])
+                self.info['from']['message'].set_text(S(helper.html_escape(
+                    helper.format_long_text(from_info.message, 500))).display())
 
     def on_from_branches_changed(self, widget):
         self.update_branch_info()
@@ -565,7 +585,8 @@ class GitMerge(BranchMerge):
         )
 
         self.action.append(self.action.set_header, _("Merge"))
-        self.action.append(self.action.set_status, _("Running Merge Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Merge Command..."))
         self.action.append(
             self.git.merge,
             from_branch
@@ -577,7 +598,6 @@ class GitMerge(BranchMerge):
 
     def __revision_changed(self, widget):
         self.update_branch_info()
-
 
 
 if __name__ == "__main__":

--- a/rabbitvcs/ui/open.py
+++ b/rabbitvcs/ui/open.py
@@ -6,6 +6,7 @@ import rabbitvcs.vcs
 from rabbitvcs.ui.action import SVNAction, GitAction
 from rabbitvcs.ui import InterfaceNonView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -34,6 +35,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -70,16 +72,12 @@ class SVNOpen(InterfaceNonView):
 
         url = path
         if not self.svn.is_path_repository_url(path):
-            url = self.svn.get_repo_root_url(path) + '/' + path
+            url = self.svn.get_repo_root_url(path) + "/" + path
         dest = helper.get_tmp_path(
-            "rabbitvcs-" + revision + "-" + os.path.basename(path))
-
-        self.svn.export(
-            url,
-            dest,
-            revision=revision_obj,
-            force=True
+            "rabbitvcs-" + revision + "-" + os.path.basename(path)
         )
+
+        self.svn.export(url, dest, revision=revision_obj, force=True)
 
         helper.open_item(dest)
 
@@ -114,16 +112,12 @@ class GitOpen(InterfaceNonView):
 
         dest_dir = helper.get_tmp_path("rabbitvcs-" + S(revision))
 
-        self.git.export(
-            path,
-            dest_dir,
-            revision=revision_obj
-        )
+        self.git.export(path, dest_dir, revision=revision_obj)
 
         repo_path = self.git.find_repository_path(path)
         relative_path = path
         if path.startswith(repo_path):
-            relative_path = path[len(repo_path)+1:]
+            relative_path = path[len(repo_path) + 1 :]
 
         dest_path = "%s/%s" % (dest_dir, relative_path)
 
@@ -132,10 +126,7 @@ class GitOpen(InterfaceNonView):
         raise SystemExit()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNOpen,
-    rabbitvcs.vcs.VCS_GIT: GitOpen
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNOpen, rabbitvcs.vcs.VCS_GIT: GitOpen}
 
 
 def open_factory(vcs, path, revision):
@@ -148,9 +139,9 @@ def open_factory(vcs, path, revision):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT
+
     (options, paths) = main(
-        [REVISION_OPT, VCS_OPT],
-        usage="Usage: rabbitvcs open path [-r REVISION]"
+        [REVISION_OPT, VCS_OPT], usage="Usage: rabbitvcs open path [-r REVISION]"
     )
 
     window = open_factory(options.vcs, paths[0], options.revision)

--- a/rabbitvcs/ui/open.py
+++ b/rabbitvcs/ui/open.py
@@ -1,4 +1,11 @@
 from __future__ import absolute_import
+import six
+from rabbitvcs import gettext
+from rabbitvcs.util.strings import S
+import rabbitvcs.vcs
+from rabbitvcs.ui.action import SVNAction, GitAction
+from rabbitvcs.ui import InterfaceNonView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -29,19 +36,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceNonView
-from rabbitvcs.ui.action import SVNAction, GitAction
 
-import rabbitvcs.vcs
-from rabbitvcs.util.strings import S
-
-from rabbitvcs import gettext
 _ = gettext.gettext
 
-import six
 
 class SVNOpen(InterfaceNonView):
     """
@@ -72,7 +71,8 @@ class SVNOpen(InterfaceNonView):
         url = path
         if not self.svn.is_path_repository_url(path):
             url = self.svn.get_repo_root_url(path) + '/' + path
-        dest = helper.get_tmp_path("rabbitvcs-" + revision + "-" + os.path.basename(path))
+        dest = helper.get_tmp_path(
+            "rabbitvcs-" + revision + "-" + os.path.basename(path))
 
         self.svn.export(
             url,
@@ -84,6 +84,7 @@ class SVNOpen(InterfaceNonView):
         helper.open_item(dest)
 
         raise SystemExit()
+
 
 class GitOpen(InterfaceNonView):
     """
@@ -130,10 +131,12 @@ class GitOpen(InterfaceNonView):
 
         raise SystemExit()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNOpen,
     rabbitvcs.vcs.VCS_GIT: GitOpen
 }
+
 
 def open_factory(vcs, path, revision):
     if not vcs:

--- a/rabbitvcs/ui/properties.py
+++ b/rabbitvcs/ui/properties.py
@@ -1,4 +1,12 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+import rabbitvcs.vcs
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,20 +34,13 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.vcs
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.properties")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class PropertiesBase(InterfaceView):
     """
@@ -76,20 +77,19 @@ class PropertiesBase(InterfaceView):
     # UI Signal Callbacks
     #
 
-
     def on_ok_clicked(self, widget):
         self.save()
 
     def on_new_clicked(self, widget):
         dialog = rabbitvcs.ui.dialog.Property()
-        name,value,recurse = dialog.run()
+        name, value, recurse = dialog.run()
         if name:
-            self.table.append([recurse,name,value])
+            self.table.append([recurse, name, value])
 
     def on_edit_clicked(self, widget):
-        (recurse,name,value) = self.get_selected_name_value()
+        (recurse, name, value) = self.get_selected_name_value()
         dialog = rabbitvcs.ui.dialog.Property(name, value)
-        name,value,recurse = dialog.run()
+        name, value, recurse = dialog.run()
         if name:
             self.set_selected_name_value(name, value, recurse)
 
@@ -99,7 +99,7 @@ class PropertiesBase(InterfaceView):
 
         for i in self.selected_rows:
             row = self.table.get_row(i)
-            self.delete_stack.append([row[0],row[1]])
+            self.delete_stack.append([row[0], row[1]])
 
         self.table.remove_multiple(self.selected_rows)
 
@@ -135,13 +135,14 @@ class PropertiesBase(InterfaceView):
     #
 
     def set_selected_name_value(self, name, value, recurse):
-        self.table.set_row(self.selected_rows[0], [recurse,name,value])
+        self.table.set_row(self.selected_rows[0], [recurse, name, value])
 
     def get_selected_name_value(self):
         returner = None
         if self.selected_rows is not None:
             returner = self.table.get_row(self.selected_rows[0])
         return returner
+
 
 class SVNProperties(PropertiesBase):
     def __init__(self, path):
@@ -152,15 +153,17 @@ class SVNProperties(PropertiesBase):
     def load(self):
         self.table.clear()
         try:
-            self.proplist = self.svn.proplist(self.get_widget("path").get_text())
+            self.proplist = self.svn.proplist(
+                self.get_widget("path").get_text())
         except Exception as e:
             log.exception(e)
-            rabbitvcs.ui.dialog.MessageBox(_("Unable to retrieve properties list"))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("Unable to retrieve properties list"))
             self.proplist = []
 
         if self.proplist:
-            for key,val in list(self.proplist.items()):
-                self.table.append([False, key,val.rstrip()])
+            for key, val in list(self.proplist.items()):
+                self.table.append([False, key, val.rstrip()])
 
     def save(self):
         delete_recurse = self.get_widget("delete_recurse").get_active()
@@ -171,12 +174,13 @@ class SVNProperties(PropertiesBase):
         failure = False
         for row in self.table.get_items():
             if (not self.svn.propset(self.path, row[1], row[2],
-                             overwrite=True, recurse=row[0])):
+                                     overwrite=True, recurse=row[0])):
                 failure = True
                 break
 
         if failure:
-            rabbitvcs.ui.dialog.MessageBox(_("There was a problem saving your properties."))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("There was a problem saving your properties."))
 
         self.close()
 

--- a/rabbitvcs/ui/properties.py
+++ b/rabbitvcs/ui/properties.py
@@ -7,6 +7,7 @@ import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -32,6 +33,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -58,16 +60,14 @@ class PropertiesBase(InterfaceView):
         self.path = path
         self.delete_stack = []
 
-        self.get_widget("Properties").set_title(
-            _("Properties - %s") % path
-        )
+        self.get_widget("Properties").set_title(_("Properties - %s") % path)
 
         self.get_widget("path").set_text(S(path).display())
 
         self.table = rabbitvcs.ui.widget.Table(
             self.get_widget("table"),
             [GObject.TYPE_BOOLEAN, GObject.TYPE_STRING, GObject.TYPE_STRING],
-            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Name"), _("Value")]
+            [rabbitvcs.ui.widget.TOGGLE_BUTTON, _("Name"), _("Value")],
         )
         self.table.allow_multiple()
 
@@ -153,12 +153,10 @@ class SVNProperties(PropertiesBase):
     def load(self):
         self.table.clear()
         try:
-            self.proplist = self.svn.proplist(
-                self.get_widget("path").get_text())
+            self.proplist = self.svn.proplist(self.get_widget("path").get_text())
         except Exception as e:
             log.exception(e)
-            rabbitvcs.ui.dialog.MessageBox(
-                _("Unable to retrieve properties list"))
+            rabbitvcs.ui.dialog.MessageBox(_("Unable to retrieve properties list"))
             self.proplist = []
 
         if self.proplist:
@@ -173,20 +171,23 @@ class SVNProperties(PropertiesBase):
 
         failure = False
         for row in self.table.get_items():
-            if (not self.svn.propset(self.path, row[1], row[2],
-                                     overwrite=True, recurse=row[0])):
+            if not self.svn.propset(
+                self.path, row[1], row[2], overwrite=True, recurse=row[0]
+            ):
                 failure = True
                 break
 
         if failure:
             rabbitvcs.ui.dialog.MessageBox(
-                _("There was a problem saving your properties."))
+                _("There was a problem saving your properties.")
+            )
 
         self.close()
 
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
+
     (options, paths) = main(usage="Usage: rabbitvcs properties [url_or_path]")
 
     window = SVNProperties(paths[0])

--- a/rabbitvcs/ui/property_editor.py
+++ b/rabbitvcs/ui/property_editor.py
@@ -29,6 +29,18 @@ apply later, no trying to keep track of what was done recursively and what
 wasn't; just do the work and make sure the UI is sensible.
 """
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+from rabbitvcs.vcs.svn import Revision
+from rabbitvcs.util.strings import S
+import rabbitvcs.vcs
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+import rabbitvcs.util.contextmenuitems
+import rabbitvcs.ui.wraplabel
+from rabbitvcs.util.contextmenu import GtkContextMenu, GtkContextMenuCaller
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 from __future__ import print_function
 
 import os.path
@@ -38,23 +50,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.util.contextmenu import GtkContextMenu, GtkContextMenuCaller
-import rabbitvcs.ui.wraplabel
-import rabbitvcs.util.contextmenuitems
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.vcs
-from rabbitvcs.util.strings import S
-from rabbitvcs.vcs.svn import Revision
-from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.property_editor")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
 
@@ -74,6 +74,7 @@ PROP_MENU_STRUCTURE = [
     (rabbitvcs.util.contextmenuitems.PropMenuDelete, None),
     (rabbitvcs.util.contextmenuitems.PropMenuDeleteRecursive, None)]
 
+
 class PropEditor(InterfaceView, GtkContextMenuCaller):
     '''
     User interface for the property editor.
@@ -82,7 +83,6 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
     property in the dialog, it is actually added in the WC. Each row has a
     context menu available to perform other actions.
     '''
-
 
     def __init__(self, path):
         '''
@@ -99,17 +99,20 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
 
         self.path = path
 
-        self.get_widget("wc_text").set_text(S(self.get_local_path(os.path.realpath(path))).display())
+        self.get_widget("wc_text").set_text(
+            S(self.get_local_path(os.path.realpath(path))).display())
 
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
 
         if not self.svn.is_versioned(self.path):
-            rabbitvcs.ui.dialog.MessageBox(_("File is not under version control."))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("File is not under version control."))
             self.close()
             return
 
-        self.get_widget("remote_uri_text").set_text(S(self.svn.get_repo_url(path)).display())
+        self.get_widget("remote_uri_text").set_text(
+            S(self.svn.get_repo_url(path)).display())
 
         self.table = rabbitvcs.ui.widget.Table(
             self.get_widget("table"),
@@ -159,13 +162,14 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
 
         except Exception as e:
             log.exception(e)
-            rabbitvcs.ui.dialog.MessageBox(_("Unable to retrieve properties list"))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("Unable to retrieve properties list"))
 
         for propname, details in list(propdets.items()):
 
             self.table.append(
                 [propname, details["value"], "N/A", details["status"]]
-                              )
+            )
 
     def on_refresh_clicked(self, widget):
         self.refresh()
@@ -179,11 +183,13 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
 
         dialog = rabbitvcs.ui.dialog.Property(name, value)
 
-        name,value,recurse = dialog.run()
+        name, value, recurse = dialog.run()
         if name:
-            success = self.svn.propset(self.path, name, value, overwrite=True, recurse=False)
+            success = self.svn.propset(
+                self.path, name, value, overwrite=True, recurse=False)
             if not success:
-                rabbitvcs.ui.dialog.MessageBox(_("Unable to set new value for property."))
+                rabbitvcs.ui.dialog.MessageBox(
+                    _("Unable to set new value for property."))
 
         self.refresh()
 
@@ -229,6 +235,7 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
 
         GtkContextMenu(PROP_MENU_STRUCTURE, conditions, callbacks).show(event)
 
+
 class PropMenuCallbacks(object):
 
     def __init__(self, caller, path, propdetails, vcs):
@@ -240,7 +247,7 @@ class PropMenuCallbacks(object):
 
     def property_edit(self, widget, *args):
         if list(self.propdetails.keys()):
-            propname  = list(self.propdetails.keys())[0]
+            propname = list(self.propdetails.keys())[0]
             self.caller.edit_property(propname)
 
     def property_delete(self, widget, *args):
@@ -268,11 +275,11 @@ class PropMenuConditions(object):
 
     def all_modified(self):
         return all([detail["status"] != "unchanged"
-                       for (propname, detail) in list(self.propdetails.items())])
+                    for (propname, detail) in list(self.propdetails.items())])
 
     def all_not_deleted(self):
         return all([detail["status"] != "deleted"
-                       for (propname, detail) in list(self.propdetails.items())])
+                    for (propname, detail) in list(self.propdetails.items())])
 
     def property_revert(self):
         return False

--- a/rabbitvcs/ui/property_editor.py
+++ b/rabbitvcs/ui/property_editor.py
@@ -48,6 +48,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -58,36 +59,41 @@ log = Log("rabbitvcs.ui.property_editor")
 _ = gettext.gettext
 
 
-PROP_EDITOR_NOTE = _("""\
+PROP_EDITOR_NOTE = _(
+    """\
 <b>Note:</b> changes to properties are applied instantly. You may review and \
 undo changes using the context menu for each item.
-""")
+"""
+)
 
-RECURSIVE_DELETE_MSG = _("""\
+RECURSIVE_DELETE_MSG = _(
+    """\
 Do you want to delete the selected properties from all files and subdirectories
-beneath this directory?""")
+beneath this directory?"""
+)
 
 PROP_MENU_STRUCTURE = [
     (rabbitvcs.util.contextmenuitems.PropMenuEdit, None),
     (rabbitvcs.util.contextmenuitems.PropMenuRevert, None),
     (rabbitvcs.util.contextmenuitems.PropMenuRevertRecursive, None),
     (rabbitvcs.util.contextmenuitems.PropMenuDelete, None),
-    (rabbitvcs.util.contextmenuitems.PropMenuDeleteRecursive, None)]
+    (rabbitvcs.util.contextmenuitems.PropMenuDeleteRecursive, None),
+]
 
 
 class PropEditor(InterfaceView, GtkContextMenuCaller):
-    '''
+    """
     User interface for the property editor.
 
     The UI is basically an "instant update" editor, that is as soon as you add a
     property in the dialog, it is actually added in the WC. Each row has a
     context menu available to perform other actions.
-    '''
+    """
 
     def __init__(self, path):
-        '''
+        """
         Initialises the UI.
-        '''
+        """
         InterfaceView.__init__(self, "property_editor", "PropertyEditor")
 
         note = rabbitvcs.ui.wraplabel.WrapLabel(PROP_EDITOR_NOTE)
@@ -100,47 +106,45 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
         self.path = path
 
         self.get_widget("wc_text").set_text(
-            S(self.get_local_path(os.path.realpath(path))).display())
+            S(self.get_local_path(os.path.realpath(path))).display()
+        )
 
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
 
         if not self.svn.is_versioned(self.path):
-            rabbitvcs.ui.dialog.MessageBox(
-                _("File is not under version control."))
+            rabbitvcs.ui.dialog.MessageBox(_("File is not under version control."))
             self.close()
             return
 
         self.get_widget("remote_uri_text").set_text(
-            S(self.svn.get_repo_url(path)).display())
+            S(self.svn.get_repo_url(path)).display()
+        )
 
         self.table = rabbitvcs.ui.widget.Table(
             self.get_widget("table"),
-            [GObject.TYPE_STRING, rabbitvcs.ui.widget.TYPE_ELLIPSIZED,
-             GObject.TYPE_STRING, rabbitvcs.ui.widget.TYPE_STATUS],
+            [
+                GObject.TYPE_STRING,
+                rabbitvcs.ui.widget.TYPE_ELLIPSIZED,
+                GObject.TYPE_STRING,
+                rabbitvcs.ui.widget.TYPE_STATUS,
+            ],
             [_("Name"), _("Value"), _("Reserved"), _("Status")],
-
             filters=[
                 {
                     "callback": rabbitvcs.ui.widget.long_text_filter,
-                    "user_data": {
-                        "cols": 0,
-                        "column": 1
-                    }
+                    "user_data": {"cols": 0, "column": 1},
                 },
-
                 {
                     "callback": rabbitvcs.ui.widget.translate_filter,
-                    "user_data": {
-                        "column": 3
-                    }
-                }],
-
+                    "user_data": {"column": 3},
+                },
+            ],
             callbacks={
-                "row-activated":  self.on_table_row_activated,
-                "mouse-event":   self.on_table_mouse_event,
-                "key-event":     self.on_table_key_event
-            }
+                "row-activated": self.on_table_row_activated,
+                "mouse-event": self.on_table_mouse_event,
+                "key-event": self.on_table_key_event,
+            },
         )
         self.table.allow_multiple()
 
@@ -162,14 +166,11 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
 
         except Exception as e:
             log.exception(e)
-            rabbitvcs.ui.dialog.MessageBox(
-                _("Unable to retrieve properties list"))
+            rabbitvcs.ui.dialog.MessageBox(_("Unable to retrieve properties list"))
 
         for propname, details in list(propdets.items()):
 
-            self.table.append(
-                [propname, details["value"], "N/A", details["status"]]
-            )
+            self.table.append([propname, details["value"], "N/A", details["status"]])
 
     def on_refresh_clicked(self, widget):
         self.refresh()
@@ -186,10 +187,12 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
         name, value, recurse = dialog.run()
         if name:
             success = self.svn.propset(
-                self.path, name, value, overwrite=True, recurse=False)
+                self.path, name, value, overwrite=True, recurse=False
+            )
             if not success:
                 rabbitvcs.ui.dialog.MessageBox(
-                    _("Unable to set new value for property."))
+                    _("Unable to set new value for property.")
+                )
 
         self.refresh()
 
@@ -197,7 +200,7 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
 
         recursive = False
 
-        if(os.path.isdir(self.path)):
+        if os.path.isdir(self.path):
             dialog = rabbitvcs.ui.dialog.Confirmation(RECURSIVE_DELETE_MSG)
             recursive = dialog.run()
 
@@ -230,14 +233,12 @@ class PropEditor(InterfaceView, GtkContextMenuCaller):
                 filtered_details[propname] = detail
 
         conditions = PropMenuConditions(self.path, filtered_details)
-        callbacks = PropMenuCallbacks(self, self.path, filtered_details,
-                                      self.vcs)
+        callbacks = PropMenuCallbacks(self, self.path, filtered_details, self.vcs)
 
         GtkContextMenu(PROP_MENU_STRUCTURE, conditions, callbacks).show(event)
 
 
 class PropMenuCallbacks(object):
-
     def __init__(self, caller, path, propdetails, vcs):
         self.path = path
         self.caller = caller
@@ -268,18 +269,25 @@ class PropMenuCallbacks(object):
 
 
 class PropMenuConditions(object):
-
     def __init__(self, path, propdetails):
         self.path = path
         self.propdetails = propdetails
 
     def all_modified(self):
-        return all([detail["status"] != "unchanged"
-                    for (propname, detail) in list(self.propdetails.items())])
+        return all(
+            [
+                detail["status"] != "unchanged"
+                for (propname, detail) in list(self.propdetails.items())
+            ]
+        )
 
     def all_not_deleted(self):
-        return all([detail["status"] != "deleted"
-                    for (propname, detail) in list(self.propdetails.items())])
+        return all(
+            [
+                detail["status"] != "deleted"
+                for (propname, detail) in list(self.propdetails.items())
+            ]
+        )
 
     def property_revert(self):
         return False
@@ -295,6 +303,7 @@ class PropMenuConditions(object):
 if __name__ == "__main__":
     # These are some dumb tests before I add any functionality.
     from rabbitvcs.ui import main
+
     (options, paths) = main(usage="Usage: rabbitvcs propedit [url_or_path]")
 
     window = PropEditor(paths[0])

--- a/rabbitvcs/ui/property_page.py
+++ b/rabbitvcs/ui/property_page.py
@@ -9,6 +9,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui
 from collections import defaultdict
 from gi.repository import Gtk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -33,6 +34,7 @@ import os
 import os.path
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 
 
@@ -47,31 +49,28 @@ class PropertyPage(rabbitvcs.ui.GtkBuilderWidgetWrapper):
     gtkbuilder_id = "prop_page_scroller"
 
     def __init__(self, paths, vcs=None, claim_domain=True):
-        rabbitvcs.ui.GtkBuilderWidgetWrapper.__init__(self,
-                                                      claim_domain=claim_domain)
+        rabbitvcs.ui.GtkBuilderWidgetWrapper.__init__(self, claim_domain=claim_domain)
         self.paths = paths
         self.vcs = vcs or rabbitvcs.vcs.VCS()
 
         self.info_pane = rabbitvcs.ui.widget.Box(
-            self.get_widget("property_page"), vertical=True)
+            self.get_widget("property_page"), vertical=True
+        )
 
         if len(paths) == 1:
-            file_info = FileInfoPane(paths[0], self.vcs,
-                                     claim_domain=self.claim_domain)
-            self.info_pane.pack_start(file_info.get_widget(),
-                                      expand=False,
-                                      fill=False,
-                                      padding=0)
+            file_info = FileInfoPane(paths[0], self.vcs, claim_domain=self.claim_domain)
+            self.info_pane.pack_start(
+                file_info.get_widget(), expand=False, fill=False, padding=0
+            )
         elif len(paths) > 1:
             try:
                 for path in paths:
-                    expander = FileInfoExpander(path, self.vcs,
-                                                claim_domain=self.claim_domain,
-                                                indent=12)
-                    self.info_pane.pack_start(expander.get_widget(),
-                                              expand=False,
-                                              fill=False,
-                                              padding=0)
+                    expander = FileInfoExpander(
+                        path, self.vcs, claim_domain=self.claim_domain, indent=12
+                    )
+                    self.info_pane.pack_start(
+                        expander.get_widget(), expand=False, fill=False, padding=0
+                    )
             except Exception as ex:
                 log.exception(ex)
                 raise
@@ -83,60 +82,61 @@ class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
     gtkbuilder_id = "file_info_table"
 
     def __init__(self, path, vcs=None, claim_domain=True):
-        rabbitvcs.ui.GtkBuilderWidgetWrapper.__init__(self,
-                                                      claim_domain=claim_domain)
+        rabbitvcs.ui.GtkBuilderWidgetWrapper.__init__(self, claim_domain=claim_domain)
 
         self.path = path
         self.vcs = vcs or rabbitvcs.vcs.VCS()
         self.checker = StatusChecker()
 
-        self.get_widget("file_name").set_text(
-            S(os.path.basename(path)).display())
+        self.get_widget("file_name").set_text(S(os.path.basename(path)).display())
 
-        self.status = self.checker.check_status(path,
-                                                recurse=False,
-                                                invalidate=False,
-                                                summary=False)
+        self.status = self.checker.check_status(
+            path, recurse=False, invalidate=False, summary=False
+        )
 
         self.get_widget("vcs_type").set_text(S(self.status.vcs_type).display())
 
         self.get_widget("content_status").set_text(
-            S(self.status.simple_content_status()).display())
+            S(self.status.simple_content_status()).display()
+        )
         self.get_widget("prop_status").set_text(
-            S(self.status.simple_metadata_status()).display())
+            S(self.status.simple_metadata_status()).display()
+        )
 
-        self.set_icon_from_status(self.get_widget("content_status_icon"),
-                                  self.status.simple_content_status())
+        self.set_icon_from_status(
+            self.get_widget("content_status_icon"), self.status.simple_content_status()
+        )
 
-        self.set_icon_from_status(self.get_widget("prop_status_icon"),
-                                  self.status.simple_metadata_status())
+        self.set_icon_from_status(
+            self.get_widget("prop_status_icon"), self.status.simple_metadata_status()
+        )
 
-        self.set_icon_from_status(self.get_widget("vcs_icon"),
-                                  self.status.single, Gtk.IconSize.DIALOG)
+        self.set_icon_from_status(
+            self.get_widget("vcs_icon"), self.status.single, Gtk.IconSize.DIALOG
+        )
 
         additional_info = self.get_additional_info()
         if additional_info:
-            additional_props_table = rabbitvcs.ui.widget.KeyValueTable(
-                additional_info)
+            additional_props_table = rabbitvcs.ui.widget.KeyValueTable(additional_info)
             additional_props_table.show()
 
             file_info_table = rabbitvcs.ui.widget.Box(
-                self.get_widget("file_info_table"), vertical=True)
-            file_info_table.pack_start(additional_props_table,
-                                       expand=False,
-                                       fill=False,
-                                       padding=0)
+                self.get_widget("file_info_table"), vertical=True
+            )
+            file_info_table.pack_start(
+                additional_props_table, expand=False, fill=False, padding=0
+            )
 
     def set_icon_from_status(self, icon, status, size=Gtk.IconSize.BUTTON):
         if status in rabbitvcs.ui.STATUS_EMBLEMS:
             icon.set_from_icon_name("emblem-" + STATUS_EMBLEMS[status], size)
 
     def get_additional_info(self):
-        vcs_type = rabbitvcs.vcs.guess_vcs(self.path)['vcs']
+        vcs_type = rabbitvcs.vcs.guess_vcs(self.path)["vcs"]
 
-        if(vcs_type == rabbitvcs.vcs.VCS_SVN):
+        if vcs_type == rabbitvcs.vcs.VCS_SVN:
             return self.get_additional_info_svn()
-        elif(vcs_type == rabbitvcs.vcs.VCS_GIT):
+        elif vcs_type == rabbitvcs.vcs.VCS_GIT:
             return self.get_additional_info_git()
         else:
             return []
@@ -145,14 +145,12 @@ class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
 
         repo_url = S(self.vcs.svn().get_repo_url(self.path))
 
-        return [
-            (_("Repository URL"), repo_url)]
+        return [(_("Repository URL"), repo_url)]
 
     def get_additional_info_git(self):
 
         repo_url = S(self.vcs.git().config_get(("remote", "origin"), "url"))
-        return [
-            (_("Repository URL"), repo_url)]
+        return [(_("Repository URL"), repo_url)]
 
 
 class FileInfoExpander(rabbitvcs.ui.GtkBuilderWidgetWrapper):
@@ -165,8 +163,7 @@ class FileInfoExpander(rabbitvcs.ui.GtkBuilderWidgetWrapper):
         # Might be None, but that's okay, only subclasses use it
         self.vcs = vcs
 
-        rabbitvcs.ui.GtkBuilderWidgetWrapper.__init__(self,
-                                                      claim_domain=claim_domain)
+        rabbitvcs.ui.GtkBuilderWidgetWrapper.__init__(self, claim_domain=claim_domain)
         self.path = path
         self.get_widget("file_expander_path").set_label(path)
 
@@ -181,9 +178,9 @@ class FileInfoExpander(rabbitvcs.ui.GtkBuilderWidgetWrapper):
 
     def on_expand(self, param_spec, user_data):
         if self.expander.get_expanded() and not self.file_info:
-            self.file_info = FileInfoPane(self.path, self.vcs,
-                                          claim_domain=self.claim_domain
-                                          ).get_widget()
+            self.file_info = FileInfoPane(
+                self.path, self.vcs, claim_domain=self.claim_domain
+            ).get_widget()
             self.file_info.set_margin_start(self.indent)
             self.expander.add(self.file_info)
 

--- a/rabbitvcs/ui/property_page.py
+++ b/rabbitvcs/ui/property_page.py
@@ -1,4 +1,14 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+from rabbitvcs.ui import STATUS_EMBLEMS
+from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
+import rabbitvcs.vcs
+import rabbitvcs.ui.widget
+import rabbitvcs.ui
+from collections import defaultdict
+from gi.repository import Gtk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -24,22 +34,12 @@ import os.path
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 
-from collections import defaultdict
-import rabbitvcs.ui
-import rabbitvcs.ui.widget
 
-import rabbitvcs.vcs
-from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
-from rabbitvcs.ui import STATUS_EMBLEMS
-
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.ui.property_page")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class PropertyPage(rabbitvcs.ui.GtkBuilderWidgetWrapper):
 
@@ -48,19 +48,20 @@ class PropertyPage(rabbitvcs.ui.GtkBuilderWidgetWrapper):
 
     def __init__(self, paths, vcs=None, claim_domain=True):
         rabbitvcs.ui.GtkBuilderWidgetWrapper.__init__(self,
-                                                 claim_domain=claim_domain)
+                                                      claim_domain=claim_domain)
         self.paths = paths
         self.vcs = vcs or rabbitvcs.vcs.VCS()
 
-        self.info_pane = rabbitvcs.ui.widget.Box(self.get_widget("property_page"), vertical = True)
+        self.info_pane = rabbitvcs.ui.widget.Box(
+            self.get_widget("property_page"), vertical=True)
 
         if len(paths) == 1:
             file_info = FileInfoPane(paths[0], self.vcs,
                                      claim_domain=self.claim_domain)
             self.info_pane.pack_start(file_info.get_widget(),
-                                        expand=False,
-                                        fill=False,
-                                        padding=0)
+                                      expand=False,
+                                      fill=False,
+                                      padding=0)
         elif len(paths) > 1:
             try:
                 for path in paths:
@@ -68,12 +69,13 @@ class PropertyPage(rabbitvcs.ui.GtkBuilderWidgetWrapper):
                                                 claim_domain=self.claim_domain,
                                                 indent=12)
                     self.info_pane.pack_start(expander.get_widget(),
-                                        expand=False,
-                                        fill=False,
-                                        padding=0)
+                                              expand=False,
+                                              fill=False,
+                                              padding=0)
             except Exception as ex:
                 log.exception(ex)
                 raise
+
 
 class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
 
@@ -82,32 +84,32 @@ class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
 
     def __init__(self, path, vcs=None, claim_domain=True):
         rabbitvcs.ui.GtkBuilderWidgetWrapper.__init__(self,
-                                                 claim_domain=claim_domain)
+                                                      claim_domain=claim_domain)
 
         self.path = path
         self.vcs = vcs or rabbitvcs.vcs.VCS()
         self.checker = StatusChecker()
 
-        self.get_widget("file_name").set_text(S(os.path.basename(path)).display())
+        self.get_widget("file_name").set_text(
+            S(os.path.basename(path)).display())
 
         self.status = self.checker.check_status(path,
-                                                recurse = False,
-                                                invalidate = False,
-                                                summary = False)
+                                                recurse=False,
+                                                invalidate=False,
+                                                summary=False)
 
         self.get_widget("vcs_type").set_text(S(self.status.vcs_type).display())
 
-        self.get_widget("content_status").set_text(S(self.status.simple_content_status()).display())
-        self.get_widget("prop_status").set_text(S(self.status.simple_metadata_status()).display())
-
+        self.get_widget("content_status").set_text(
+            S(self.status.simple_content_status()).display())
+        self.get_widget("prop_status").set_text(
+            S(self.status.simple_metadata_status()).display())
 
         self.set_icon_from_status(self.get_widget("content_status_icon"),
-                                                  self.status.simple_content_status())
+                                  self.status.simple_content_status())
 
         self.set_icon_from_status(self.get_widget("prop_status_icon"),
-                                                  self.status.simple_metadata_status())
-
-
+                                  self.status.simple_metadata_status())
 
         self.set_icon_from_status(self.get_widget("vcs_icon"),
                                   self.status.single, Gtk.IconSize.DIALOG)
@@ -115,10 +117,11 @@ class FileInfoPane(rabbitvcs.ui.GtkBuilderWidgetWrapper):
         additional_info = self.get_additional_info()
         if additional_info:
             additional_props_table = rabbitvcs.ui.widget.KeyValueTable(
-                                        additional_info)
+                additional_info)
             additional_props_table.show()
 
-            file_info_table = rabbitvcs.ui.widget.Box(self.get_widget("file_info_table"), vertical = True)
+            file_info_table = rabbitvcs.ui.widget.Box(
+                self.get_widget("file_info_table"), vertical=True)
             file_info_table.pack_start(additional_props_table,
                                        expand=False,
                                        fill=False,
@@ -163,7 +166,7 @@ class FileInfoExpander(rabbitvcs.ui.GtkBuilderWidgetWrapper):
         self.vcs = vcs
 
         rabbitvcs.ui.GtkBuilderWidgetWrapper.__init__(self,
-                                                 claim_domain=claim_domain)
+                                                      claim_domain=claim_domain)
         self.path = path
         self.get_widget("file_expander_path").set_label(path)
 
@@ -183,6 +186,7 @@ class FileInfoExpander(rabbitvcs.ui.GtkBuilderWidgetWrapper):
                                           ).get_widget()
             self.file_info.set_margin_start(self.indent)
             self.expander.add(self.file_info)
+
 
 class PropertyPageLabel(rabbitvcs.ui.GtkBuilderWidgetWrapper):
     gtkbuilder_filename = "property_page"

--- a/rabbitvcs/ui/push.py
+++ b/rabbitvcs/ui/push.py
@@ -8,6 +8,7 @@ import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -37,6 +38,7 @@ from datetime import datetime
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -72,19 +74,14 @@ class GitPush(Push):
         self.git = self.vcs.git(path)
 
         self.repository_selector = rabbitvcs.ui.widget.GitRepositorySelector(
-            self.get_widget("repository_container"),
-            self.git,
-            self.on_branch_changed
+            self.get_widget("repository_container"), self.git, self.on_branch_changed
         )
 
         self.log_table = rabbitvcs.ui.widget.Table(
             self.get_widget("log"),
             [GObject.TYPE_STRING, GObject.TYPE_STRING],
             [_("Date"), _("Message")],
-            flags={
-                "sortable": True,
-                "sort_on": 0
-            }
+            flags={"sortable": True, "sort_on": 0},
         )
 
         # Set default for checkboxes.
@@ -102,14 +99,11 @@ class GitPush(Push):
         force_with_lease = self.get_widget("force_with_lease").get_active()
 
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Push"))
-        self.action.append(self.action.set_status,
-                           _("Running Push Command..."))
-        self.action.append(self.git.push, repository,
-                           branch, tags, force_with_lease)
+        self.action.append(self.action.set_status, _("Running Push Command..."))
+        self.action.append(self.git.push, repository, branch, tags, force_with_lease)
         self.action.append(self.action.set_status, _("Completed Push"))
         self.action.append(self.action.finish)
         self.action.schedule()
@@ -129,8 +123,7 @@ class GitPush(Push):
         self.update_widgets()
 
     def load_logs(self):
-        helper.run_in_main_thread(self.get_widget(
-            "status").set_text, _("Loading..."))
+        helper.run_in_main_thread(self.get_widget("status").set_text, _("Loading..."))
 
         self.load_push_log()
         helper.run_in_main_thread(self.load_logs_exit)
@@ -141,7 +134,8 @@ class GitPush(Push):
 
         refspec = "refs/remotes/%s/%s" % (repository, branch)
         self.push_log = self.git.log(
-            revision=self.git.revision(refspec), showtype="push")
+            revision=self.git.revision(refspec), showtype="push"
+        )
 
     def on_branch_changed(self, repository, branch):
         self.load_push_log()
@@ -159,10 +153,12 @@ class GitPush(Push):
 
         has_commits = False
         for item in self.push_log:
-            self.log_table.append([
-                helper.format_datetime(item.date, self.datetime_format),
-                helper.format_long_text(item.message.rstrip("\n"))
-            ])
+            self.log_table.append(
+                [
+                    helper.format_datetime(item.date, self.datetime_format),
+                    helper.format_long_text(item.message.rstrip("\n")),
+                ]
+            )
             has_commits = True
 
         self.get_widget("ok").set_sensitive(True)
@@ -170,9 +166,7 @@ class GitPush(Push):
             self.get_widget("status").set_text(_("No commits found"))
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_GIT: GitPush
-}
+classes_map = {rabbitvcs.vcs.VCS_GIT: GitPush}
 
 
 def push_factory(path):
@@ -182,9 +176,8 @@ def push_factory(path):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
-    (options, paths) = main(
-        usage="Usage: rabbitvcs push [path]"
-    )
+
+    (options, paths) = main(usage="Usage: rabbitvcs push [path]")
 
     window = push_factory(paths[0])
     window.register_gtk_quit()

--- a/rabbitvcs/ui/push.py
+++ b/rabbitvcs/ui/push.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+import six
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+import rabbitvcs.util.settings
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -30,21 +39,13 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-import rabbitvcs.util.settings
-import rabbitvcs.vcs
 
-from rabbitvcs import gettext
-import six
 _ = gettext.gettext
 
 helper.gobject_threads_init()
+
 
 class Push(InterfaceView):
     def __init__(self, path):
@@ -105,8 +106,10 @@ class GitPush(Push):
             register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Push"))
-        self.action.append(self.action.set_status, _("Running Push Command..."))
-        self.action.append(self.git.push, repository, branch, tags, force_with_lease)
+        self.action.append(self.action.set_status,
+                           _("Running Push Command..."))
+        self.action.append(self.git.push, repository,
+                           branch, tags, force_with_lease)
         self.action.append(self.action.set_status, _("Completed Push"))
         self.action.append(self.action.finish)
         self.action.schedule()
@@ -126,7 +129,8 @@ class GitPush(Push):
         self.update_widgets()
 
     def load_logs(self):
-        helper.run_in_main_thread(self.get_widget("status").set_text, _("Loading..."))
+        helper.run_in_main_thread(self.get_widget(
+            "status").set_text, _("Loading..."))
 
         self.load_push_log()
         helper.run_in_main_thread(self.load_logs_exit)
@@ -136,7 +140,8 @@ class GitPush(Push):
         branch = self.repository_selector.branch_opt.get_active_text()
 
         refspec = "refs/remotes/%s/%s" % (repository, branch)
-        self.push_log = self.git.log(revision=self.git.revision(refspec), showtype="push")
+        self.push_log = self.git.log(
+            revision=self.git.revision(refspec), showtype="push")
 
     def on_branch_changed(self, repository, branch):
         self.load_push_log()
@@ -164,9 +169,11 @@ class GitPush(Push):
         if not has_commits:
             self.get_widget("status").set_text(_("No commits found"))
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_GIT: GitPush
 }
+
 
 def push_factory(path):
     guess = rabbitvcs.vcs.guess(path)

--- a/rabbitvcs/ui/relocate.py
+++ b/rabbitvcs/ui/relocate.py
@@ -1,4 +1,11 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.strings import S
+import rabbitvcs.vcs
+from rabbitvcs.ui.dialog import MessageBox
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,17 +33,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import SVNAction
-from rabbitvcs.ui.dialog import MessageBox
-import rabbitvcs.vcs
-from rabbitvcs.util.strings import S
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class Relocate(InterfaceView):
     """
@@ -52,7 +53,6 @@ class Relocate(InterfaceView):
         """
 
         InterfaceView.__init__(self, "relocate", "Relocate")
-
 
         self.path = path
         self.vcs = rabbitvcs.vcs.VCS()
@@ -84,7 +84,8 @@ class Relocate(InterfaceView):
         )
 
         self.action.append(self.action.set_header, _("Relocate"))
-        self.action.append(self.action.set_status, _("Running Relocate Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Relocate Command..."))
         self.action.append(
             self.svn.relocate,
             from_url,

--- a/rabbitvcs/ui/relocate.py
+++ b/rabbitvcs/ui/relocate.py
@@ -6,6 +6,7 @@ from rabbitvcs.ui.dialog import MessageBox
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -31,6 +32,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -63,8 +65,7 @@ class Relocate(InterfaceView):
         self.get_widget("to_url").set_text(repo)
 
         self.repositories = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("to_urls"),
-            helper.get_repository_paths()
+            self.get_widget("to_urls"), helper.get_repository_paths()
         )
 
     def on_ok_clicked(self, widget):
@@ -78,20 +79,11 @@ class Relocate(InterfaceView):
 
         self.hide()
 
-        self.action = SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
-        )
+        self.action = SVNAction(self.svn, register_gtk_quit=self.gtk_quit_is_set())
 
         self.action.append(self.action.set_header, _("Relocate"))
-        self.action.append(self.action.set_status,
-                           _("Running Relocate Command..."))
-        self.action.append(
-            self.svn.relocate,
-            from_url,
-            to_url,
-            self.path
-        )
+        self.action.append(self.action.set_status, _("Running Relocate Command..."))
+        self.action.append(self.svn.relocate, from_url, to_url, self.path)
         self.action.append(self.action.set_status, _("Completed Relocate"))
         self.action.append(self.action.finish)
         self.action.schedule()
@@ -99,6 +91,7 @@ class Relocate(InterfaceView):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
+
     (options, paths) = main(usage="Usage: rabbitvcs relocate [path]")
 
     window = Relocate(paths[0])

--- a/rabbitvcs/ui/remotes.py
+++ b/rabbitvcs/ui/remotes.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.ui.dialog import DeleteConfirmation
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import GitAction
+from rabbitvcs.ui import InterfaceView
+import time
+from datetime import datetime
+from gi.repository import Gtk, GObject, Gdk, Pango
 from __future__ import print_function
 #
 # This is an extension to the Nautilus file manager to allow better
@@ -29,23 +38,14 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk, Pango
 sa.restore()
 
-from datetime import datetime
-import time
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import GitAction
-import rabbitvcs.ui.widget
-from rabbitvcs.ui.dialog import DeleteConfirmation
-import rabbitvcs.vcs
-
-from rabbitvcs import gettext
 _ = gettext.gettext
 
 STATE_ADD = 0
 STATE_EDIT = 1
+
 
 class GitRemotes(InterfaceView):
     """
@@ -62,7 +62,8 @@ class GitRemotes(InterfaceView):
 
         self.get_widget("right_side").hide()
         self.get_widget("Manager").set_title(_("Remote Repository Manager"))
-        self.get_widget("items_label").set_markup(_("<b>Remote Repositories</b>"))
+        self.get_widget("items_label").set_markup(
+            _("<b>Remote Repositories</b>"))
 
         self.selected_branch = None
         self.items_treeview = rabbitvcs.ui.widget.Table(
@@ -77,7 +78,7 @@ class GitRemotes(InterfaceView):
             flags={
                 "sortable": False,
                 "sort_on": 0,
-                "editable": [0,1]
+                "editable": [0, 1]
             }
         )
 
@@ -123,7 +124,8 @@ class GitRemotes(InterfaceView):
     def on_delete_clicked(self, widget):
         selected = self.items_treeview.get_selected_row_items(0)
 
-        confirm = rabbitvcs.ui.dialog.Confirmation(_("Are you sure you want to delete %s?" % ", ".join(selected)))
+        confirm = rabbitvcs.ui.dialog.Confirmation(
+            _("Are you sure you want to delete %s?" % ", ".join(selected)))
         result = confirm.run()
 
         if result == Gtk.ResponseType.OK or result == True:

--- a/rabbitvcs/ui/remotes.py
+++ b/rabbitvcs/ui/remotes.py
@@ -9,6 +9,7 @@ import time
 from datetime import datetime
 from gi.repository import Gtk, GObject, Gdk, Pango
 from __future__ import print_function
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -36,6 +37,7 @@ import os
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -62,8 +64,7 @@ class GitRemotes(InterfaceView):
 
         self.get_widget("right_side").hide()
         self.get_widget("Manager").set_title(_("Remote Repository Manager"))
-        self.get_widget("items_label").set_markup(
-            _("<b>Remote Repositories</b>"))
+        self.get_widget("items_label").set_markup(_("<b>Remote Repositories</b>"))
 
         self.selected_branch = None
         self.items_treeview = rabbitvcs.ui.widget.Table(
@@ -71,15 +72,11 @@ class GitRemotes(InterfaceView):
             [GObject.TYPE_STRING, GObject.TYPE_STRING],
             [_("Name"), _("Host")],
             callbacks={
-                "mouse-event":   self.on_treeview_mouse_event,
-                "key-event":     self.on_treeview_key_event,
-                "cell-edited":   self.on_treeview_cell_edited_event
+                "mouse-event": self.on_treeview_mouse_event,
+                "key-event": self.on_treeview_key_event,
+                "cell-edited": self.on_treeview_cell_edited_event,
             },
-            flags={
-                "sortable": False,
-                "sort_on": 0,
-                "editable": [0, 1]
-            }
+            flags={"sortable": False, "sort_on": 0, "editable": [0, 1]},
         )
 
         self.load()
@@ -125,7 +122,8 @@ class GitRemotes(InterfaceView):
         selected = self.items_treeview.get_selected_row_items(0)
 
         confirm = rabbitvcs.ui.dialog.Confirmation(
-            _("Are you sure you want to delete %s?" % ", ".join(selected)))
+            _("Are you sure you want to delete %s?" % ", ".join(selected))
+        )
         result = confirm.run()
 
         if result == Gtk.ResponseType.OK or result == True:
@@ -165,6 +163,7 @@ class GitRemotes(InterfaceView):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
+
     (options, paths) = main(usage="Usage: rabbitvcs branch-manager path")
 
     window = GitRemotes(paths[0])

--- a/rabbitvcs/ui/rename.py
+++ b/rabbitvcs/ui/rename.py
@@ -5,6 +5,7 @@ from rabbitvcs.ui.dialog import MessageBox, OneLineTextChange
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui import InterfaceNonView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -32,6 +33,7 @@ import os.path
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -80,8 +82,7 @@ class SVNRename(Rename):
         self.svn = self.vcs.svn()
 
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         dirname = os.path.dirname(self.new_path)
@@ -90,13 +91,8 @@ class SVNRename(Rename):
             self.svn.add(dirname)
 
         self.action.append(self.action.set_header, _("Rename"))
-        self.action.append(self.action.set_status,
-                           _("Running Rename Command..."))
-        self.action.append(
-            self.svn.move,
-            self.path,
-            self.new_path
-        )
+        self.action.append(self.action.set_status, _("Running Rename Command..."))
+        self.action.append(self.svn.move, self.path, self.new_path)
         self.action.append(self.action.set_status, _("Completed Rename"))
         self.action.append(self.action.finish)
         self.action.append(self.close)
@@ -113,31 +109,22 @@ class GitRename(Rename):
         self.git = self.vcs.git(path)
 
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
         dirname = os.path.dirname(os.path.realpath(self.new_path))
         if not os.path.exists(dirname):
             os.mkdir(dirname)
 
         self.action.append(self.action.set_header, _("Rename"))
-        self.action.append(self.action.set_status,
-                           _("Running Rename Command..."))
-        self.action.append(
-            self.git.move,
-            self.path,
-            self.new_path
-        )
+        self.action.append(self.action.set_status, _("Running Rename Command..."))
+        self.action.append(self.git.move, self.path, self.new_path)
         self.action.append(self.action.set_status, _("Completed Rename"))
         self.action.append(self.action.finish)
         self.action.append(self.close)
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNRename,
-    rabbitvcs.vcs.VCS_GIT: GitRename
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNRename, rabbitvcs.vcs.VCS_GIT: GitRename}
 
 
 def rename_factory(path):
@@ -147,6 +134,7 @@ def rename_factory(path):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
+
     (options, paths) = main(usage="Usage: rabbitvcs rename [path]")
 
     window = rename_factory(os.path.abspath(paths[0]))

--- a/rabbitvcs/ui/rename.py
+++ b/rabbitvcs/ui/rename.py
@@ -1,4 +1,10 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.ui.dialog import MessageBox, OneLineTextChange
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui import InterfaceNonView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,16 +34,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceNonView
-from rabbitvcs.ui.action import SVNAction
-from rabbitvcs.ui.dialog import MessageBox, OneLineTextChange
-import rabbitvcs.vcs
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class Rename(InterfaceNonView):
     DO_RENAME = False
@@ -68,6 +69,7 @@ class Rename(InterfaceNonView):
         self.new_path = new_path
         self.DO_RENAME = True
 
+
 class SVNRename(Rename):
     def __init__(self, path):
         Rename.__init__(self, path)
@@ -88,7 +90,8 @@ class SVNRename(Rename):
             self.svn.add(dirname)
 
         self.action.append(self.action.set_header, _("Rename"))
-        self.action.append(self.action.set_status, _("Running Rename Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Rename Command..."))
         self.action.append(
             self.svn.move,
             self.path,
@@ -98,6 +101,7 @@ class SVNRename(Rename):
         self.action.append(self.action.finish)
         self.action.append(self.close)
         self.action.schedule()
+
 
 class GitRename(Rename):
     def __init__(self, path):
@@ -117,7 +121,8 @@ class GitRename(Rename):
             os.mkdir(dirname)
 
         self.action.append(self.action.set_header, _("Rename"))
-        self.action.append(self.action.set_status, _("Running Rename Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Rename Command..."))
         self.action.append(
             self.git.move,
             self.path,
@@ -128,10 +133,12 @@ class GitRename(Rename):
         self.action.append(self.close)
         self.action.schedule()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNRename,
     rabbitvcs.vcs.VCS_GIT: GitRename
 }
+
 
 def rename_factory(path):
     guess = rabbitvcs.vcs.guess(path)

--- a/rabbitvcs/ui/renderers/graphcell.py
+++ b/rabbitvcs/ui/renderers/graphcell.py
@@ -11,11 +11,12 @@ just be for the background.
 from __future__ import absolute_import
 
 __copyright__ = "Copyright 2005 Canonical Ltd."
-__author__    = "Scott James Remnant <scott@ubuntu.com>"
+__author__ = "Scott James Remnant <scott@ubuntu.com>"
 
 import math
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GObject, Pango
 
@@ -24,6 +25,7 @@ import cairo
 # Styles used when rendering revision graph edges
 style_SOLID = 0
 style_DASHED = 1
+
 
 class CellRendererGraph(Gtk.CellRenderer):
     """Cell renderer for directed graph.
@@ -41,11 +43,13 @@ class CellRendererGraph(Gtk.CellRenderer):
     out_lines = []
 
     __gproperties__ = {
-        "graph":         ( GObject.TYPE_PYOBJECT, "graph",
-                          "revision node instruction",
-                          GObject.PARAM_WRITABLE
-                        )
-        }
+        "graph": (
+            GObject.TYPE_PYOBJECT,
+            "graph",
+            "revision node instruction",
+            GObject.PARAM_WRITABLE,
+        )
+    }
 
     def do_set_property(self, property, value):
         """Set properties from GObject properties."""
@@ -80,16 +84,16 @@ class CellRendererGraph(Gtk.CellRenderer):
 
         if isinstance(colour, str):
             r, g, b = colour[1:3], colour[3:5], colour[5:7]
-            colour_rgb = int(r, 16) / 255., int(g, 16) / 255., int(b, 16) / 255.
+            colour_rgb = int(r, 16) / 255.0, int(g, 16) / 255.0, int(b, 16) / 255.0
         else:
             if colour == 0:
                 colour_rgb = Gtklib.MAINLINE_COLOR
             else:
                 colour_rgb = Gtklib.LINE_COLORS[colour % len(Gtklib.LINE_COLORS)]
 
-        red   = (colour_rgb[0] * fg) or bg
+        red = (colour_rgb[0] * fg) or bg
         green = (colour_rgb[1] * fg) or bg
-        blue  = (colour_rgb[2] * fg) or bg
+        blue = (colour_rgb[2] * fg) or bg
 
         ctx.set_source_rgb(red, green, blue)
 
@@ -133,8 +137,8 @@ class CellRendererGraph(Gtk.CellRenderer):
         # Maybe draw branch head highlight under revision node
         if self.node:
             (column, colour) = self.node
-            arc_start_position_x = cell_area.x + box_size * column + box_size / 2;
-            arc_start_position_y = cell_area.y + cell_area.height / 2;
+            arc_start_position_x = cell_area.x + box_size * column + box_size / 2
+            arc_start_position_y = cell_area.y + cell_area.height / 2
 
         ctx.set_line_width(box_size / 8)
         ctx.set_line_cap(cairo.LINE_CAP_ROUND)
@@ -143,32 +147,50 @@ class CellRendererGraph(Gtk.CellRenderer):
         if self.in_lines:
             for start, end, lcolour in self.in_lines:
                 style = style_SOLID
-                self.render_line (ctx, cell_area, box_size,
-                             bg_area.y, bg_area.height,
-                             start, end, lcolour, style)
+                self.render_line(
+                    ctx,
+                    cell_area,
+                    box_size,
+                    bg_area.y,
+                    bg_area.height,
+                    start,
+                    end,
+                    lcolour,
+                    style,
+                )
 
         # Draw lines out of the cell
         if self.out_lines:
             for start, end, lcolour in self.out_lines:
                 style = style_SOLID
-                self.render_line (ctx, cell_area, box_size,
-                             bg_area.y + bg_area.height, bg_area.height,
-                             start, end, lcolour, style)
+                self.render_line(
+                    ctx,
+                    cell_area,
+                    box_size,
+                    bg_area.y + bg_area.height,
+                    bg_area.height,
+                    start,
+                    end,
+                    lcolour,
+                    style,
+                )
 
         # Draw the revision node in the right column
         if not self.node:
             return
 
-        ctx.arc(arc_start_position_x, arc_start_position_y,
-                    box_size / 5, 0, 2 * math.pi)
+        ctx.arc(
+            arc_start_position_x, arc_start_position_y, box_size / 5, 0, 2 * math.pi
+        )
         self.set_colour(ctx, colour, 0.0, 0.5)
         ctx.stroke_preserve()
         self.set_colour(ctx, colour, 0.5, 1.0)
         ctx.fill()
         ctx.save()
 
-    def render_line (self, ctx, cell_area, box_size, mid,
-            height, start, end, colour, style):
+    def render_line(
+        self, ctx, cell_area, box_size, mid, height, start, end, colour, style
+    ):
 
         if start is None:
             x = cell_area.x + box_size * end + box_size / 2
@@ -188,16 +210,26 @@ class CellRendererGraph(Gtk.CellRenderer):
 
             ctx.move_to(startx, mid - height / 2)
 
-            if start - end == 0 :
+            if start - end == 0:
                 ctx.line_to(endx, mid + height / 2)
             else:
-                ctx.curve_to(startx, mid - height / 5,
-                             startx, mid - height / 5,
-                             startx + (endx - startx) / 2, mid)
+                ctx.curve_to(
+                    startx,
+                    mid - height / 5,
+                    startx,
+                    mid - height / 5,
+                    startx + (endx - startx) / 2,
+                    mid,
+                )
 
-                ctx.curve_to(endx, mid + height / 5,
-                             endx, mid + height / 5 ,
-                             endx, mid + height / 2)
+                ctx.curve_to(
+                    endx,
+                    mid + height / 5,
+                    endx,
+                    mid + height / 5,
+                    endx,
+                    mid + height / 2,
+                )
 
         self.set_colour(ctx, colour, 0.0, 0.65)
         if style == style_DASHED:

--- a/rabbitvcs/ui/reset.py
+++ b/rabbitvcs/ui/reset.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import GitAction
+from rabbitvcs.ui import InterfaceView
+import time
+from datetime import datetime
+from gi.repository import Gtk, GObject, Gdk, Pango
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,20 +37,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk, Pango
 sa.restore()
 
-from datetime import datetime
-import time
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import GitAction
-import rabbitvcs.ui.widget
-from rabbitvcs.util.strings import S
-import rabbitvcs.vcs
-
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class GitReset(InterfaceView):
     """
@@ -98,7 +98,8 @@ class GitReset(InterfaceView):
             register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Reset"))
-        self.action.append(self.action.set_status, _("Running Reset Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Reset Command..."))
         self.action.append(
             self.git.reset,
             path,

--- a/rabbitvcs/ui/reset.py
+++ b/rabbitvcs/ui/reset.py
@@ -8,6 +8,7 @@ from rabbitvcs.ui import InterfaceView
 import time
 from datetime import datetime
 from gi.repository import Gtk, GObject, Gdk, Pango
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -35,6 +36,7 @@ import os
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -65,7 +67,7 @@ class GitReset(InterfaceView):
             self.git,
             revision=self.revision_obj,
             url=self.path,
-            expand=True
+            expand=True,
         )
 
         self.get_widget("none_opt").set_active(True)
@@ -94,18 +96,11 @@ class GitReset(InterfaceView):
 
         self.hide()
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
         self.action.append(self.action.set_header, _("Reset"))
-        self.action.append(self.action.set_status,
-                           _("Running Reset Command..."))
-        self.action.append(
-            self.git.reset,
-            path,
-            revision,
-            type
-        )
+        self.action.append(self.action.set_status, _("Running Reset Command..."))
+        self.action.append(self.git.reset, path, revision, type)
         self.action.append(self.action.set_status, _("Completed Reset"))
         self.action.append(self.action.finish)
         self.action.schedule()
@@ -128,9 +123,9 @@ class GitReset(InterfaceView):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT
+
     (options, paths) = main(
-        [REVISION_OPT, VCS_OPT],
-        usage="Usage: rabbitvcs reset [-r REVISION] path"
+        [REVISION_OPT, VCS_OPT], usage="Usage: rabbitvcs reset [-r REVISION] path"
     )
 
     window = GitReset(paths[0], options.revision)

--- a/rabbitvcs/ui/revert.py
+++ b/rabbitvcs/ui/revert.py
@@ -10,6 +10,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -39,6 +40,7 @@ from time import sleep
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -72,21 +74,24 @@ class Revert(InterfaceView, GtkContextMenuCaller):
         self.statuses = self.vcs.statuses_for_revert(paths)
         self.files_table = rabbitvcs.ui.widget.Table(
             self.get_widget("files_table"),
-            [GObject.TYPE_BOOLEAN, rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
-                rabbitvcs.ui.widget.TYPE_PATH, GObject.TYPE_STRING],
+            [
+                GObject.TYPE_BOOLEAN,
+                rabbitvcs.ui.widget.TYPE_HIDDEN_OBJECT,
+                rabbitvcs.ui.widget.TYPE_PATH,
+                GObject.TYPE_STRING,
+            ],
             [rabbitvcs.ui.widget.TOGGLE_BUTTON, "", _("Path"), _("Extension")],
-            filters=[{
-                "callback": rabbitvcs.ui.widget.path_filter,
-                "user_data": {
-                    "base_dir": base_dir,
-                    "column": 2
+            filters=[
+                {
+                    "callback": rabbitvcs.ui.widget.path_filter,
+                    "user_data": {"base_dir": base_dir, "column": 2},
                 }
-            }],
+            ],
             callbacks={
-                "row-activated":  self.on_files_table_row_activated,
-                "mouse-event":   self.on_files_table_mouse_event,
-                "key-event":     self.on_files_table_key_event
-            }
+                "row-activated": self.on_files_table_row_activated,
+                "mouse-event": self.on_files_table_mouse_event,
+                "key-event": self.on_files_table_key_event,
+            },
         )
 
         self.initialize_items()
@@ -99,18 +104,14 @@ class Revert(InterfaceView, GtkContextMenuCaller):
         self.items = self.vcs.get_items(self.paths, self.statuses)
 
         self.populate_files_table()
-        self.get_widget("status").set_text(
-            _("Found %d item(s)") % len(self.items))
+        self.get_widget("status").set_text(_("Found %d item(s)") % len(self.items))
 
     def populate_files_table(self):
         self.files_table.clear()
         for item in self.items:
-            self.files_table.append([
-                True,
-                S(item.path),
-                item.path,
-                helper.get_file_extension(item.path)
-            ])
+            self.files_table.append(
+                [True, S(item.path), item.path, helper.get_file_extension(item.path)]
+            )
 
     # Overrides the GtkContextMenuCaller method
     def on_context_menu_command_finished(self):
@@ -162,13 +163,11 @@ class SVNRevert(Revert):
         self.hide()
 
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.vcs.svn(),
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.vcs.svn(), register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Revert"))
-        self.action.append(self.action.set_status,
-                           _("Running Revert Command..."))
+        self.action.append(self.action.set_status, _("Running Revert Command..."))
         self.action.append(self.vcs.svn().revert, items, recurse=True)
         self.action.append(self.action.set_status, _("Completed Revert"))
         self.action.append(self.action.finish)
@@ -189,13 +188,11 @@ class GitRevert(Revert):
         self.hide()
 
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Revert"))
-        self.action.append(self.action.set_status,
-                           _("Running Revert Command..."))
+        self.action.append(self.action.set_status, _("Running Revert Command..."))
         self.action.append(self.git.checkout, items)
         self.action.append(self.action.set_status, _("Completed Revert"))
         self.action.append(self.action.finish)
@@ -205,10 +202,7 @@ class GitRevert(Revert):
 class SVNRevertQuiet(object):
     def __init__(self, paths, base_dir=None):
         self.vcs = rabbitvcs.vcs.VCS()
-        self.action = rabbitvcs.ui.action.SVNAction(
-            self.vcs.svn(),
-            run_in_thread=False
-        )
+        self.action = rabbitvcs.ui.action.SVNAction(self.vcs.svn(), run_in_thread=False)
 
         self.action.append(self.vcs.svn().revert, paths)
         self.action.schedule()
@@ -218,23 +212,17 @@ class GitRevertQuiet(object):
     def __init__(self, paths, base_dir=None):
         self.vcs = rabbitvcs.vcs.VCS()
         self.git = self.vcs.git(paths[0])
-        self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            run_in_thread=False
-        )
+        self.action = rabbitvcs.ui.action.GitAction(self.git, run_in_thread=False)
 
         self.action.append(self.git.checkout, paths)
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNRevert,
-    rabbitvcs.vcs.VCS_GIT: GitRevert
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNRevert, rabbitvcs.vcs.VCS_GIT: GitRevert}
 
 quiet_classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNRevertQuiet,
-    rabbitvcs.vcs.VCS_GIT: GitRevertQuiet
+    rabbitvcs.vcs.VCS_GIT: GitRevertQuiet,
 }
 
 
@@ -245,9 +233,9 @@ def revert_factory(classes_map, paths, base_dir=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT, QUIET_OPT],
-        usage="Usage: rabbitvcs revert [path1] [path2] ..."
+        [BASEDIR_OPT, QUIET_OPT], usage="Usage: rabbitvcs revert [path1] [path2] ..."
     )
 
     if options.quiet:

--- a/rabbitvcs/ui/revert.py
+++ b/rabbitvcs/ui/revert.py
@@ -1,4 +1,15 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.vcs.status import Status
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+import rabbitvcs.vcs
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -30,32 +41,20 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.util.contextmenu import GtkFilesContextMenu, GtkContextMenuCaller
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-import rabbitvcs.vcs
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
-from rabbitvcs.vcs.status import Status
 
 log = Log("rabbitvcs.ui.revert")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
 helper.gobject_threads_init()
 
-import rabbitvcs.vcs
 
 log = Log("rabbitvcs.ui.revert")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class Revert(InterfaceView, GtkContextMenuCaller):
 
@@ -100,7 +99,8 @@ class Revert(InterfaceView, GtkContextMenuCaller):
         self.items = self.vcs.get_items(self.paths, self.statuses)
 
         self.populate_files_table()
-        self.get_widget("status").set_text(_("Found %d item(s)") % len(self.items))
+        self.get_widget("status").set_text(
+            _("Found %d item(s)") % len(self.items))
 
     def populate_files_table(self):
         self.files_table.clear()
@@ -167,7 +167,8 @@ class SVNRevert(Revert):
         )
 
         self.action.append(self.action.set_header, _("Revert"))
-        self.action.append(self.action.set_status, _("Running Revert Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Revert Command..."))
         self.action.append(self.vcs.svn().revert, items, recurse=True)
         self.action.append(self.action.set_status, _("Completed Revert"))
         self.action.append(self.action.finish)
@@ -193,11 +194,13 @@ class GitRevert(Revert):
         )
 
         self.action.append(self.action.set_header, _("Revert"))
-        self.action.append(self.action.set_status, _("Running Revert Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Revert Command..."))
         self.action.append(self.git.checkout, items)
         self.action.append(self.action.set_status, _("Completed Revert"))
         self.action.append(self.action.finish)
         self.action.schedule()
+
 
 class SVNRevertQuiet(object):
     def __init__(self, paths, base_dir=None):
@@ -209,6 +212,7 @@ class SVNRevertQuiet(object):
 
         self.action.append(self.vcs.svn().revert, paths)
         self.action.schedule()
+
 
 class GitRevertQuiet(object):
     def __init__(self, paths, base_dir=None):
@@ -222,6 +226,7 @@ class GitRevertQuiet(object):
         self.action.append(self.git.checkout, paths)
         self.action.schedule()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNRevert,
     rabbitvcs.vcs.VCS_GIT: GitRevert
@@ -231,6 +236,7 @@ quiet_classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNRevertQuiet,
     rabbitvcs.vcs.VCS_GIT: GitRevertQuiet
 }
+
 
 def revert_factory(classes_map, paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])

--- a/rabbitvcs/ui/revprops.py
+++ b/rabbitvcs/ui/revprops.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.util.log import Log
+import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.properties import PropertiesBase
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,21 +35,13 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui.properties import PropertiesBase
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-from rabbitvcs.util.strings import S
-import rabbitvcs.vcs
-from rabbitvcs.util.log import Log
-from rabbitvcs.ui.action import SVNAction
 
 log = Log("rabbitvcs.ui.revprops")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNRevisionProperties(PropertiesBase):
     def __init__(self, path, revision=None):
@@ -68,12 +69,13 @@ class SVNRevisionProperties(PropertiesBase):
             )
         except Exception as e:
             log.exception(e)
-            rabbitvcs.ui.dialog.MessageBox(_("Unable to retrieve properties list"))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("Unable to retrieve properties list"))
             self.proplist = {}
 
         if self.proplist:
-            for key,val in list(self.proplist.items()):
-                self.table.append([False, key,val.rstrip()])
+            for key, val in list(self.proplist.items()):
+                self.table.append([False, key, val.rstrip()])
 
     def save(self):
         delete_recurse = self.get_widget("delete_recurse").get_active()

--- a/rabbitvcs/ui/revprops.py
+++ b/rabbitvcs/ui/revprops.py
@@ -8,6 +8,7 @@ import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.properties import PropertiesBase
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -33,6 +34,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -64,13 +66,11 @@ class SVNRevisionProperties(PropertiesBase):
         self.table.clear()
         try:
             self.proplist = self.svn.revproplist(
-                self.get_widget("path").get_text(),
-                self.revision_obj
+                self.get_widget("path").get_text(), self.revision_obj
             )
         except Exception as e:
             log.exception(e)
-            rabbitvcs.ui.dialog.MessageBox(
-                _("Unable to retrieve properties list"))
+            rabbitvcs.ui.dialog.MessageBox(_("Unable to retrieve properties list"))
             self.proplist = {}
 
         if self.proplist:
@@ -80,19 +80,11 @@ class SVNRevisionProperties(PropertiesBase):
     def save(self):
         delete_recurse = self.get_widget("delete_recurse").get_active()
 
-        self.action = SVNAction(
-            self.svn,
-            notification=False,
-            run_in_thread=False
-        )
+        self.action = SVNAction(self.svn, notification=False, run_in_thread=False)
 
         for row in self.delete_stack:
             self.action.append(
-                self.svn.revpropdel,
-                self.path,
-                row[1],
-                self.revision_obj,
-                force=True
+                self.svn.revpropdel, self.path, row[1], self.revision_obj, force=True
             )
 
         for row in self.table.get_items():
@@ -102,7 +94,7 @@ class SVNRevisionProperties(PropertiesBase):
                 row[2],
                 self.path,
                 self.revision_obj,
-                force=True
+                force=True,
             )
 
         self.action.schedule()
@@ -112,10 +104,8 @@ class SVNRevisionProperties(PropertiesBase):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, VCS_OPT
-    (options, args) = main(
-        [VCS_OPT],
-        usage="Usage: rabbitvcs revprops [url1@rev1]"
-    )
+
+    (options, args) = main([VCS_OPT], usage="Usage: rabbitvcs revprops [url1@rev1]")
 
     pathrev = helper.parse_path_revision_string(args.pop(0))
     window = SVNRevisionProperties(pathrev[0], pathrev[1])

--- a/rabbitvcs/ui/settings.py
+++ b/rabbitvcs/ui/settings.py
@@ -1,4 +1,14 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext, _gettext, APP_NAME, LOCALE_DIR
+from rabbitvcs.services.checkerservice import StatusCheckerStub
+import rabbitvcs.services.checkerservice
+from rabbitvcs.util.strings import S
+from rabbitvcs.util._locale import get_locale
+import rabbitvcs.util.settings
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk, Pango
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -30,42 +40,32 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk, Pango
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.util.settings
-from rabbitvcs.util._locale import get_locale
-from rabbitvcs.util.strings import S
 
-import rabbitvcs.services.checkerservice
-from rabbitvcs.services.checkerservice import StatusCheckerStub
-
-from rabbitvcs import gettext, _gettext, APP_NAME, LOCALE_DIR
 _ = gettext.gettext
 
 CHECKER_UNKNOWN_INFO = _("Unknown")
 CHECKER_SERVICE_ERROR = _(
-"There was an error communicating with the status checker service.")
+    "There was an error communicating with the status checker service.")
 
 
 class Settings(InterfaceView):
     dtformats = [
-                    ["", _("default")],
-                    ["%c", _("locale")],
-                    ["%Y-%m-%d %H:%M:%S", _("ISO")],
-                    ["%b %d, %Y %I:%M:%S %p", None],
-                    ["%B %d, %Y %I:%M:%S %p", None],
-                    ["%m/%d/%Y %I:%M:%S %p", None],
-                    ["%b %d, %Y %H:%M:%S", None],
-                    ["%B %d, %Y %H:%M:%S", None],
-                    ["%m/%d/%Y %H:%M:%S", None],
-                    ["%d %b %Y %H:%M:%S", None],
-                    ["%d %B %Y %H:%M:%S", None],
-                    ["%d/%m/%Y %H:%M:%S", None]
+        ["", _("default")],
+        ["%c", _("locale")],
+        ["%Y-%m-%d %H:%M:%S", _("ISO")],
+        ["%b %d, %Y %I:%M:%S %p", None],
+        ["%B %d, %Y %I:%M:%S %p", None],
+        ["%m/%d/%Y %I:%M:%S %p", None],
+        ["%b %d, %Y %H:%M:%S", None],
+        ["%B %d, %Y %H:%M:%S", None],
+        ["%m/%d/%Y %H:%M:%S", None],
+        ["%d %b %Y %H:%M:%S", None],
+        ["%d %B %Y %H:%M:%S", None],
+        ["%d/%m/%Y %H:%M:%S", None]
     ]
+
     def __init__(self, base_dir=None):
         """
         Provides an interface to the settings library.
@@ -86,13 +86,13 @@ class Settings(InterfaceView):
             int(self.settings.get("general", "enable_recursive"))
         )
         self.get_widget("enable_highlighting").set_active(
-            int(self.settings.get("general","enable_highlighting"))
+            int(self.settings.get("general", "enable_highlighting"))
         )
         self.get_widget("enable_colorize").set_active(
-            int(self.settings.get("general","enable_colorize"))
+            int(self.settings.get("general", "enable_colorize"))
         )
         self.get_widget("show_debug").set_active(
-            int(self.settings.get("general","show_debug"))
+            int(self.settings.get("general", "show_debug"))
         )
         self.get_widget("enable_subversion").set_active(
             int(self.settings.get("HideItem", "svn")) == 0
@@ -104,19 +104,22 @@ class Settings(InterfaceView):
         dt = datetime.datetime.today()
         # Disambiguate day.
         if dt.day <= 12:
-            dt =  datetime.datetime(dt.year, dt.month, dt.day + 12,
-                                    dt.hour, dt.minute, dt.second)
+            dt = datetime.datetime(dt.year, dt.month, dt.day + 12,
+                                   dt.hour, dt.minute, dt.second)
         for format, label in self.dtformats:
             if label is None:
                 label = helper.format_datetime(dt, format)
             dtfs.append([format, label])
-        self.datetime_format = rabbitvcs.ui.widget.ComboBox(self.get_widget("datetime_format"), dtfs, 2, 1)
+        self.datetime_format = rabbitvcs.ui.widget.ComboBox(
+            self.get_widget("datetime_format"), dtfs, 2, 1)
         self.datetime_format.set_active_from_value(
             self.settings.get("general", "datetime_format")
         )
-        self.default_commit_message = rabbitvcs.ui.widget.TextView(self.get_widget("default_commit_message"))
+        self.default_commit_message = rabbitvcs.ui.widget.TextView(
+            self.get_widget("default_commit_message"))
         self.default_commit_message.set_text(
-            S(self.settings.get_multiline("general", "default_commit_message")).display()
+            S(self.settings.get_multiline(
+                "general", "default_commit_message")).display()
         )
         self.get_widget("diff_tool").set_text(
             S(self.settings.get("external", "diff_tool")).display()
@@ -183,8 +186,8 @@ class Settings(InterfaceView):
             try:
                 session_bus = dbus.SessionBus()
                 self.checker_service = session_bus.get_object(
-                                    rabbitvcs.services.checkerservice.SERVICE,
-                                    rabbitvcs.services.checkerservice.OBJECT_PATH)
+                    rabbitvcs.services.checkerservice.SERVICE,
+                    rabbitvcs.services.checkerservice.OBJECT_PATH)
                 # Initialize service locale in case it just started.
                 self.checker_service.SetLocale(*get_locale())
             except dbus.DBusException as ex:
@@ -193,7 +196,7 @@ class Settings(InterfaceView):
 
         return self.checker_service
 
-    def _populate_checker_tab(self, report_failure = True, connect = True):
+    def _populate_checker_tab(self, report_failure=True, connect=True):
         # This is a limitation of GLADE, and can be removed when we migrate to
         # GTK2 Builder
 
@@ -204,7 +207,8 @@ class Settings(InterfaceView):
         self.get_widget("stop_checker").set_sensitive(bool(checker_service))
 
         if(checker_service):
-            self.get_widget("checker_type").set_text(S(checker_service.CheckerType()).display())
+            self.get_widget("checker_type").set_text(
+                S(checker_service.CheckerType()).display())
             self.get_widget("pid").set_text(S(checker_service.PID()).display())
 
             memory = checker_service.MemoryUsage()
@@ -214,7 +218,8 @@ class Settings(InterfaceView):
             else:
                 self.get_widget("memory_usage").set_text(CHECKER_UNKNOWN_INFO)
 
-            self.get_widget("locale").set_text(S(".".join(checker_service.SetLocale())).display())
+            self.get_widget("locale").set_text(
+                S(".".join(checker_service.SetLocale())).display())
 
             self._populate_info_table(checker_service.ExtraInformation())
 
@@ -237,7 +242,6 @@ class Settings(InterfaceView):
         table = rabbitvcs.ui.widget.KeyValueTable(info)
         table_place.add(table)
         table.show()
-
 
     def on_refresh_info_clicked(self, widget):
         self._populate_checker_tab()
@@ -265,7 +269,7 @@ class Settings(InterfaceView):
 
     def on_stop_checker_clicked(self, widget):
         self._stop_checker()
-        self._populate_checker_tab(report_failure = False, connect = False)
+        self._populate_checker_tab(report_failure=False, connect=False)
 
     def on_destroy(self, widget):
         Gtk.main_quit()
@@ -404,7 +408,8 @@ class Settings(InterfaceView):
                         filepath = "%s/%s" % (path, filename)
                         os.remove(filepath)
 
-            rabbitvcs.ui.dialog.MessageBox(_("Authentication information cleared"))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("Authentication information cleared"))
 
 
 if __name__ == "__main__":

--- a/rabbitvcs/ui/settings.py
+++ b/rabbitvcs/ui/settings.py
@@ -9,6 +9,7 @@ import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk, Pango
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -38,6 +39,7 @@ import datetime
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -47,7 +49,8 @@ _ = gettext.gettext
 
 CHECKER_UNKNOWN_INFO = _("Unknown")
 CHECKER_SERVICE_ERROR = _(
-    "There was an error communicating with the status checker service.")
+    "There was an error communicating with the status checker service."
+)
 
 
 class Settings(InterfaceView):
@@ -63,7 +66,7 @@ class Settings(InterfaceView):
         ["%m/%d/%Y %H:%M:%S", None],
         ["%d %b %Y %H:%M:%S", None],
         ["%d %B %Y %H:%M:%S", None],
-        ["%d/%m/%Y %H:%M:%S", None]
+        ["%d/%m/%Y %H:%M:%S", None],
     ]
 
     def __init__(self, base_dir=None):
@@ -104,22 +107,26 @@ class Settings(InterfaceView):
         dt = datetime.datetime.today()
         # Disambiguate day.
         if dt.day <= 12:
-            dt = datetime.datetime(dt.year, dt.month, dt.day + 12,
-                                   dt.hour, dt.minute, dt.second)
+            dt = datetime.datetime(
+                dt.year, dt.month, dt.day + 12, dt.hour, dt.minute, dt.second
+            )
         for format, label in self.dtformats:
             if label is None:
                 label = helper.format_datetime(dt, format)
             dtfs.append([format, label])
         self.datetime_format = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("datetime_format"), dtfs, 2, 1)
+            self.get_widget("datetime_format"), dtfs, 2, 1
+        )
         self.datetime_format.set_active_from_value(
             self.settings.get("general", "datetime_format")
         )
         self.default_commit_message = rabbitvcs.ui.widget.TextView(
-            self.get_widget("default_commit_message"))
+            self.get_widget("default_commit_message")
+        )
         self.default_commit_message.set_text(
-            S(self.settings.get_multiline(
-                "general", "default_commit_message")).display()
+            S(
+                self.settings.get_multiline("general", "default_commit_message")
+            ).display()
         )
         self.get_widget("diff_tool").set_text(
             S(self.settings.get("external", "diff_tool")).display()
@@ -138,8 +145,7 @@ class Settings(InterfaceView):
         )
 
         self.logging_type = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("logging_type"),
-            ["None", "Console", "File", "Both"]
+            self.get_widget("logging_type"), ["None", "Console", "File", "Both"]
         )
         val = self.settings.get("logging", "type")
         if not val:
@@ -148,7 +154,7 @@ class Settings(InterfaceView):
 
         self.logging_level = rabbitvcs.ui.widget.ComboBox(
             self.get_widget("logging_level"),
-            ["Debug", "Info", "Warning", "Error", "Critical"]
+            ["Debug", "Info", "Warning", "Error", "Critical"],
         )
         val = self.settings.get("logging", "level")
         if not val:
@@ -161,7 +167,10 @@ class Settings(InterfaceView):
         if base_dir:
             vcs = rabbitvcs.vcs.VCS()
             git_config_files = []
-            if vcs.is_in_a_or_a_working_copy(base_dir) and vcs.guess(base_dir)["vcs"] == rabbitvcs.vcs.VCS_GIT:
+            if (
+                vcs.is_in_a_or_a_working_copy(base_dir)
+                and vcs.guess(base_dir)["vcs"] == rabbitvcs.vcs.VCS_GIT
+            ):
                 git = vcs.git(base_dir)
                 git_config_files = git.get_config_files(base_dir)
 
@@ -170,7 +179,7 @@ class Settings(InterfaceView):
                     _("Config file:"),
                     git_config_files,
                     git_config_files,
-                    show_add_line=False
+                    show_add_line=False,
                 )
                 show_git = True
 
@@ -187,7 +196,8 @@ class Settings(InterfaceView):
                 session_bus = dbus.SessionBus()
                 self.checker_service = session_bus.get_object(
                     rabbitvcs.services.checkerservice.SERVICE,
-                    rabbitvcs.services.checkerservice.OBJECT_PATH)
+                    rabbitvcs.services.checkerservice.OBJECT_PATH,
+                )
                 # Initialize service locale in case it just started.
                 self.checker_service.SetLocale(*get_locale())
             except dbus.DBusException as ex:
@@ -206,9 +216,10 @@ class Settings(InterfaceView):
 
         self.get_widget("stop_checker").set_sensitive(bool(checker_service))
 
-        if(checker_service):
+        if checker_service:
             self.get_widget("checker_type").set_text(
-                S(checker_service.CheckerType()).display())
+                S(checker_service.CheckerType()).display()
+            )
             self.get_widget("pid").set_text(S(checker_service.PID()).display())
 
             memory = checker_service.MemoryUsage()
@@ -219,7 +230,8 @@ class Settings(InterfaceView):
                 self.get_widget("memory_usage").set_text(CHECKER_UNKNOWN_INFO)
 
             self.get_widget("locale").set_text(
-                S(".".join(checker_service.SetLocale())).display())
+                S(".".join(checker_service.SetLocale())).display()
+            )
 
             self._populate_info_table(checker_service.ExtraInformation())
 
@@ -286,82 +298,71 @@ class Settings(InterfaceView):
 
     def save(self):
         self.settings.set(
-            "general", "enable_attributes",
-            self.get_widget("enable_attributes").get_active()
+            "general",
+            "enable_attributes",
+            self.get_widget("enable_attributes").get_active(),
         )
         self.settings.set(
-            "general", "enable_emblems",
-            self.get_widget("enable_emblems").get_active()
+            "general", "enable_emblems", self.get_widget("enable_emblems").get_active()
         )
         self.settings.set(
-            "general", "enable_recursive",
-            self.get_widget("enable_recursive").get_active()
+            "general",
+            "enable_recursive",
+            self.get_widget("enable_recursive").get_active(),
         )
         self.settings.set(
-            "general", "enable_highlighting",
-            self.get_widget("enable_highlighting").get_active()
+            "general",
+            "enable_highlighting",
+            self.get_widget("enable_highlighting").get_active(),
         )
         self.settings.set(
-            "general", "enable_colorize",
-            self.get_widget("enable_colorize").get_active()
+            "general",
+            "enable_colorize",
+            self.get_widget("enable_colorize").get_active(),
         )
         self.settings.set(
-            "general", "show_debug",
-            self.get_widget("show_debug").get_active()
+            "general", "show_debug", self.get_widget("show_debug").get_active()
         )
         self.settings.set(
-            "HideItem", "svn",
-            not self.get_widget("enable_subversion").get_active()
+            "HideItem", "svn", not self.get_widget("enable_subversion").get_active()
         )
         self.settings.set(
-            "HideItem", "git",
-            not self.get_widget("enable_git").get_active()
+            "HideItem", "git", not self.get_widget("enable_git").get_active()
         )
         self.settings.set_multiline(
-            "general", "default_commit_message",
-            self.default_commit_message.get_text()
+            "general", "default_commit_message", self.default_commit_message.get_text()
         )
         self.settings.set(
-            "general", "datetime_format",
-            self.datetime_format.get_active_text()
+            "general", "datetime_format", self.datetime_format.get_active_text()
         )
         self.settings.set(
-            "external", "diff_tool",
-            self.get_widget("diff_tool").get_text()
+            "external", "diff_tool", self.get_widget("diff_tool").get_text()
         )
         self.settings.set(
-            "external", "diff_tool_swap",
-            self.get_widget("diff_tool_swap").get_active()
+            "external", "diff_tool_swap", self.get_widget("diff_tool_swap").get_active()
         )
         self.settings.set(
-            "external", "merge_tool",
-            self.get_widget("merge_tool").get_text()
+            "external", "merge_tool", self.get_widget("merge_tool").get_text()
         )
         self.settings.set(
-            "cache", "number_repositories",
-            self.get_widget("cache_number_repositories").get_text()
+            "cache",
+            "number_repositories",
+            self.get_widget("cache_number_repositories").get_text(),
         )
         self.settings.set(
-            "cache", "number_messages",
-            self.get_widget("cache_number_messages").get_text()
+            "cache",
+            "number_messages",
+            self.get_widget("cache_number_messages").get_text(),
         )
-        self.settings.set(
-            "logging", "type",
-            self.logging_type.get_active_text()
-        )
-        self.settings.set(
-            "logging", "level",
-            self.logging_level.get_active_text()
-        )
+        self.settings.set("logging", "type", self.logging_type.get_active_text())
+        self.settings.set("logging", "level", self.logging_level.get_active_text())
         self.settings.write()
 
         if self.file_editor:
             self.file_editor.save()
 
     def on_external_diff_tool_browse_clicked(self, widget):
-        chooser = rabbitvcs.ui.dialog.FileChooser(
-            _("Select a program"), "/usr/bin"
-        )
+        chooser = rabbitvcs.ui.dialog.FileChooser(_("Select a program"), "/usr/bin")
         path = chooser.run()
         if not path is None:
             path = path.replace("file://", "")
@@ -396,9 +397,9 @@ class Settings(InterfaceView):
         if confirmation.run() == Gtk.ResponseType.OK:
             home_dir = helper.get_user_path()
             subpaths = [
-                '/.subversion/auth/svn.simple',
-                '/.subversion/auth/svn.ssl.server',
-                '/.subversion/auth/svn.username'
+                "/.subversion/auth/svn.simple",
+                "/.subversion/auth/svn.ssl.server",
+                "/.subversion/auth/svn.username",
             ]
             for subpath in subpaths:
                 path = "%s%s" % (home_dir, subpath)
@@ -408,16 +409,13 @@ class Settings(InterfaceView):
                         filepath = "%s/%s" % (path, filename)
                         os.remove(filepath)
 
-            rabbitvcs.ui.dialog.MessageBox(
-                _("Authentication information cleared"))
+            rabbitvcs.ui.dialog.MessageBox(_("Authentication information cleared"))
 
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT
-    (options, paths) = main(
-        [BASEDIR_OPT],
-        usage="Usage: rabbitvcs settings"
-    )
+
+    (options, paths) = main([BASEDIR_OPT], usage="Usage: rabbitvcs settings")
 
     window = Settings(options.base_dir)
     window.register_gtk_quit()

--- a/rabbitvcs/ui/stage.py
+++ b/rabbitvcs/ui/stage.py
@@ -10,6 +10,7 @@ from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui.add import Add
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -37,6 +38,7 @@ import six.moves._thread
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -56,12 +58,9 @@ class GitStage(Add):
     def populate_files_table(self):
         self.files_table.clear()
         for item in self.items:
-            self.files_table.append([
-                True,
-                S(item.path),
-                item.path,
-                helper.get_file_extension(item.path)
-            ])
+            self.files_table.append(
+                [True, S(item.path), item.path, helper.get_file_extension(item.path)]
+            )
 
     def on_ok_clicked(self, widget):
         items = self.files_table.get_activated_rows(1)
@@ -71,13 +70,11 @@ class GitStage(Add):
         self.hide()
 
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Stage"))
-        self.action.append(self.action.set_status,
-                           _("Running Stage Command..."))
+        self.action.append(self.action.set_status, _("Running Stage Command..."))
         for item in items:
             self.action.append(self.git.stage, item)
         self.action.append(self.action.set_status, _("Completed Stage"))
@@ -89,23 +86,16 @@ class GitStageQuiet(object):
     def __init__(self, paths, base_dir=None):
         self.vcs = rabbitvcs.vcs.VCS()
         self.git = self.vcs.git(paths[0])
-        self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            run_in_thread=False
-        )
+        self.action = rabbitvcs.ui.action.GitAction(self.git, run_in_thread=False)
 
         for path in paths:
             self.action.append(self.git.stage, path)
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_GIT: GitStage
-}
+classes_map = {rabbitvcs.vcs.VCS_GIT: GitStage}
 
-quiet_classes_map = {
-    rabbitvcs.vcs.VCS_GIT: GitStageQuiet
-}
+quiet_classes_map = {rabbitvcs.vcs.VCS_GIT: GitStageQuiet}
 
 
 def stage_factory(classes_map, paths, base_dir=None):
@@ -115,9 +105,9 @@ def stage_factory(classes_map, paths, base_dir=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT, QUIET_OPT],
-        usage="Usage: rabbitvcs stage [path1] [path2] ..."
+        [BASEDIR_OPT, QUIET_OPT], usage="Usage: rabbitvcs stage [path1] [path2] ..."
     )
 
     if options.quiet:

--- a/rabbitvcs/ui/stage.py
+++ b/rabbitvcs/ui/stage.py
@@ -1,4 +1,15 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui.add import Add
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,24 +39,13 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.add import Add
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
-
-import rabbitvcs.vcs
 
 log = Log("rabbitvcs.ui.stage")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class GitStage(Add):
     def setup(self, window, columns):
@@ -76,12 +76,14 @@ class GitStage(Add):
         )
 
         self.action.append(self.action.set_header, _("Stage"))
-        self.action.append(self.action.set_status, _("Running Stage Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Stage Command..."))
         for item in items:
             self.action.append(self.git.stage, item)
         self.action.append(self.action.set_status, _("Completed Stage"))
         self.action.append(self.action.finish)
         self.action.schedule()
+
 
 class GitStageQuiet(object):
     def __init__(self, paths, base_dir=None):
@@ -96,6 +98,7 @@ class GitStageQuiet(object):
             self.action.append(self.git.stage, path)
         self.action.schedule()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_GIT: GitStage
 }
@@ -103,6 +106,7 @@ classes_map = {
 quiet_classes_map = {
     rabbitvcs.vcs.VCS_GIT: GitStageQuiet
 }
+
 
 def stage_factory(classes_map, paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])

--- a/rabbitvcs/ui/switch.py
+++ b/rabbitvcs/ui/switch.py
@@ -6,6 +6,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -31,6 +32,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -49,8 +51,7 @@ class SVNSwitch(InterfaceView):
 
         self.get_widget("path").set_text(S(self.path).display())
         self.repositories = rabbitvcs.ui.widget.ComboBox(
-            self.get_widget("repositories"),
-            helper.get_repository_paths()
+            self.get_widget("repositories"), helper.get_repository_paths()
         )
 
         self.revision_selector = rabbitvcs.ui.widget.RevisionSelector(
@@ -58,45 +59,40 @@ class SVNSwitch(InterfaceView):
             self.svn,
             revision=revision,
             url_combobox=self.repositories,
-            expand=True
+            expand=True,
         )
 
         self.repositories.set_child_text(
-            helper.unquote_url(self.svn.get_repo_url(self.path)))
+            helper.unquote_url(self.svn.get_repo_url(self.path))
+        )
 
     def on_ok_clicked(self, widget):
         url = self.repositories.get_active_text()
 
         if not url or not self.path:
             rabbitvcs.ui.dialog.MessageBox(
-                _("The repository location is a required field."))
+                _("The repository location is a required field.")
+            )
             return
 
         revision = self.revision_selector.get_revision_object()
         self.hide()
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Switch"))
-        self.action.append(self.action.set_status,
-                           _("Running Switch Command..."))
+        self.action.append(self.action.set_status, _("Running Switch Command..."))
         self.action.append(helper.save_repository_path, url)
         self.action.append(
-            self.svn.switch,
-            self.path,
-            helper.quote_url(url),
-            revision=revision
+            self.svn.switch, self.path, helper.quote_url(url), revision=revision
         )
         self.action.append(self.action.set_status, _("Completed Switch"))
         self.action.append(self.action.finish)
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNSwitch
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNSwitch}
 
 
 def switch_factory(path, revision=None):
@@ -106,10 +102,8 @@ def switch_factory(path, revision=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT
-    (options, args) = main(
-        [REVISION_OPT],
-        usage="Usage: rabbitvcs switch [url]"
-    )
+
+    (options, args) = main([REVISION_OPT], usage="Usage: rabbitvcs switch [url]")
 
     window = switch_factory(args[0], revision=options.revision)
     window.register_gtk_quit()

--- a/rabbitvcs/ui/switch.py
+++ b/rabbitvcs/ui/switch.py
@@ -1,4 +1,11 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.strings import *
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,17 +33,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-from rabbitvcs.util.strings import *
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNSwitch(InterfaceView):
     def __init__(self, path, revision=None):
@@ -60,13 +61,15 @@ class SVNSwitch(InterfaceView):
             expand=True
         )
 
-        self.repositories.set_child_text(helper.unquote_url(self.svn.get_repo_url(self.path)))
+        self.repositories.set_child_text(
+            helper.unquote_url(self.svn.get_repo_url(self.path)))
 
     def on_ok_clicked(self, widget):
         url = self.repositories.get_active_text()
 
         if not url or not self.path:
-            rabbitvcs.ui.dialog.MessageBox(_("The repository location is a required field."))
+            rabbitvcs.ui.dialog.MessageBox(
+                _("The repository location is a required field."))
             return
 
         revision = self.revision_selector.get_revision_object()
@@ -77,7 +80,8 @@ class SVNSwitch(InterfaceView):
         )
 
         self.action.append(self.action.set_header, _("Switch"))
-        self.action.append(self.action.set_status, _("Running Switch Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Switch Command..."))
         self.action.append(helper.save_repository_path, url)
         self.action.append(
             self.svn.switch,
@@ -89,9 +93,11 @@ class SVNSwitch(InterfaceView):
         self.action.append(self.action.finish)
         self.action.schedule()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNSwitch
 }
+
 
 def switch_factory(path, revision=None):
     guess = rabbitvcs.vcs.guess(path)

--- a/rabbitvcs/ui/tags.py
+++ b/rabbitvcs/ui/tags.py
@@ -1,4 +1,14 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+import rabbitvcs.util.settings
+from rabbitvcs.util.strings import S
+from rabbitvcs.ui.log import log_dialog_factory
+from rabbitvcs.ui.dialog import DeleteConfirmation
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import GitAction
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk, Pango
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -30,23 +40,14 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk, Pango
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.action import GitAction
-import rabbitvcs.ui.widget
-from rabbitvcs.ui.dialog import DeleteConfirmation
-from rabbitvcs.ui.log import log_dialog_factory
-from rabbitvcs.util.strings import S
-import rabbitvcs.util.settings
-import rabbitvcs.vcs
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
 STATE_ADD = 0
 STATE_EDIT = 1
+
 
 class GitTagManager(InterfaceView):
     """
@@ -91,7 +92,6 @@ class GitTagManager(InterfaceView):
         self.initialize_detail()
         self.load(self.show_add)
 
-
     def initialize_detail(self):
         self.detail_container = self.get_widget("detail_container")
 
@@ -102,7 +102,7 @@ class GitTagManager(InterfaceView):
         row = 0
 
         # Set up the Tag line
-        label = Gtk.Label(label = _("Name:"))
+        label = Gtk.Label(label=_("Name:"))
         label.set_properties(xalign=0, yalign=.5)
         self.tag_entry = Gtk.Entry()
         self.tag_entry.set_hexpand(True)
@@ -112,7 +112,7 @@ class GitTagManager(InterfaceView):
         row = row + 1
 
         # Set up the Commit-sha line
-        label = Gtk.Label(label = _("Revision:"))
+        label = Gtk.Label(label=_("Revision:"))
         label.set_properties(xalign=0, yalign=.5)
         self.start_point_entry = Gtk.Entry()
         self.start_point_entry.set_size_request(300, -1)
@@ -120,9 +120,11 @@ class GitTagManager(InterfaceView):
         if self.revision_obj.value:
             self.start_point_entry.set_text(S(self.revision_obj).display())
         self.log_dialog_button = Gtk.Button()
-        self.log_dialog_button.connect("clicked", self.on_log_dialog_button_clicked)
+        self.log_dialog_button.connect(
+            "clicked", self.on_log_dialog_button_clicked)
         image = Gtk.Image()
-        image.set_from_icon_name("rabbitvcs-show_log", Gtk.IconSize.SMALL_TOOLBAR)
+        image.set_from_icon_name("rabbitvcs-show_log",
+                                 Gtk.IconSize.SMALL_TOOLBAR)
         self.log_dialog_button.set_image(image)
         self.detail_grid.attach(label, 0, row, 1, 1)
         self.detail_grid.attach(self.start_point_entry, 1, row, 1, 1)
@@ -131,7 +133,7 @@ class GitTagManager(InterfaceView):
         row = row + 1
 
         # Set up the Log Message Entry line
-        label = Gtk.Label(label = _("Message:"))
+        label = Gtk.Label(label=_("Message:"))
         label.set_properties(xalign=0, yalign=0)
         self.message_entry = rabbitvcs.ui.widget.TextView()
         self.message_entry.view.set_size_request(300, 75)
@@ -157,9 +159,9 @@ class GitTagManager(InterfaceView):
         row = row + 1
 
         # Set up the tagger line
-        label = Gtk.Label(label = _("Tagger:"))
+        label = Gtk.Label(label=_("Tagger:"))
         label.set_properties(xalign=0, yalign=0)
-        self.tagger_label = Gtk.Label(label = "")
+        self.tagger_label = Gtk.Label(label="")
         self.tagger_label.set_properties(xalign=0, yalign=0, selectable=True)
         self.tagger_label.set_hexpand(True)
         self.tagger_label.set_line_wrap(True)
@@ -169,9 +171,9 @@ class GitTagManager(InterfaceView):
         row = row + 1
 
         # Set up the Date line
-        label = Gtk.Label(label = _("Date:"))
+        label = Gtk.Label(label=_("Date:"))
         label.set_properties(xalign=0, yalign=0)
-        self.date_label = Gtk.Label(label = "")
+        self.date_label = Gtk.Label(label="")
         self.date_label.set_properties(xalign=0, yalign=0, selectable=True)
         self.date_label.set_hexpand(True)
         self.detail_grid.attach(label, 0, row, 1, 1)
@@ -180,9 +182,9 @@ class GitTagManager(InterfaceView):
         row = row + 1
 
         # Set up the Revision line
-        label = Gtk.Label(label = _("Revision:"))
+        label = Gtk.Label(label=_("Revision:"))
         label.set_properties(xalign=0, yalign=0)
-        self.revision_label = Gtk.Label(label = "")
+        self.revision_label = Gtk.Label(label="")
         self.revision_label.set_properties(xalign=0, selectable=True)
         self.revision_label.set_hexpand(True)
         self.revision_label.set_line_wrap(True)
@@ -192,9 +194,9 @@ class GitTagManager(InterfaceView):
         row = row + 1
 
         # Set up the Log Message line
-        label = Gtk.Label(label = _("Message:"))
+        label = Gtk.Label(label=_("Message:"))
         label.set_properties(xalign=0, yalign=0)
-        self.message_label = Gtk.Label(label = "")
+        self.message_label = Gtk.Label(label="")
         self.message_label.set_properties(xalign=0, yalign=0, selectable=True)
         self.message_label.set_hexpand(True)
         self.message_label.set_vexpand(True)
@@ -217,10 +219,10 @@ class GitTagManager(InterfaceView):
         row = row + 1
 
         self.add_rows = [tag_name_row, message_entry_row,
-            start_point_row, save_row]
+                         start_point_row, save_row]
 
         self.view_rows = [tag_name_row, tagger_row,
-            date_row, revision_row, message_row]
+                          date_row, revision_row, message_row]
 
         self.detail_grid.show()
         self.detail_container.add(self.detail_grid)
@@ -242,7 +244,8 @@ class GitTagManager(InterfaceView):
     def on_delete_clicked(self, widget):
         selected = self.items_treeview.get_selected_row_items(0)
 
-        confirm = rabbitvcs.ui.dialog.Confirmation(_("Are you sure you want to delete %s?" % ", ".join(selected)))
+        confirm = rabbitvcs.ui.dialog.Confirmation(
+            _("Are you sure you want to delete %s?" % ", ".join(selected)))
         result = confirm.run()
 
         if result == Gtk.ResponseType.OK or result == True:
@@ -303,13 +306,14 @@ class GitTagManager(InterfaceView):
         if self.selected_tag:
             self.tag_entry.set_text(S(self.selected_tag.name).display())
             self.revision_label.set_text(S(self.selected_tag.sha).display())
-            self.message_label.set_text(S(self.selected_tag.message).display().rstrip("\n"))
+            self.message_label.set_text(
+                S(self.selected_tag.message).display().rstrip("\n"))
             self.tagger_label.set_text(S(self.selected_tag.tagger).display())
-            self.date_label.set_text(helper.format_datetime(datetime.fromtimestamp(self.selected_tag.tag_time), self.datetime_format))
+            self.date_label.set_text(helper.format_datetime(
+                datetime.fromtimestamp(self.selected_tag.tag_time), self.datetime_format))
 
             self.show_rows(self.view_rows)
             self.get_widget("detail_label").set_markup(_("<b>Tag Detail</b>"))
-
 
     def on_log_dialog_button_clicked(self, widget):
         log_dialog_factory(

--- a/rabbitvcs/ui/tags.py
+++ b/rabbitvcs/ui/tags.py
@@ -9,6 +9,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.ui.action import GitAction
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk, Pango
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -38,6 +39,7 @@ import time
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -81,13 +83,10 @@ class GitTagManager(InterfaceView):
             [GObject.TYPE_STRING],
             [_("Tag")],
             callbacks={
-                "mouse-event":   self.on_treeview_mouse_event,
-                "key-event":     self.on_treeview_key_event
+                "mouse-event": self.on_treeview_mouse_event,
+                "key-event": self.on_treeview_key_event,
             },
-            flags={
-                "sortable": True,
-                "sort_on": 0
-            }
+            flags={"sortable": True, "sort_on": 0},
         )
         self.initialize_detail()
         self.load(self.show_add)
@@ -103,7 +102,7 @@ class GitTagManager(InterfaceView):
 
         # Set up the Tag line
         label = Gtk.Label(label=_("Name:"))
-        label.set_properties(xalign=0, yalign=.5)
+        label.set_properties(xalign=0, yalign=0.5)
         self.tag_entry = Gtk.Entry()
         self.tag_entry.set_hexpand(True)
         self.detail_grid.attach(label, 0, row, 1, 1)
@@ -113,18 +112,16 @@ class GitTagManager(InterfaceView):
 
         # Set up the Commit-sha line
         label = Gtk.Label(label=_("Revision:"))
-        label.set_properties(xalign=0, yalign=.5)
+        label.set_properties(xalign=0, yalign=0.5)
         self.start_point_entry = Gtk.Entry()
         self.start_point_entry.set_size_request(300, -1)
         self.start_point_entry.set_hexpand(True)
         if self.revision_obj.value:
             self.start_point_entry.set_text(S(self.revision_obj).display())
         self.log_dialog_button = Gtk.Button()
-        self.log_dialog_button.connect(
-            "clicked", self.on_log_dialog_button_clicked)
+        self.log_dialog_button.connect("clicked", self.on_log_dialog_button_clicked)
         image = Gtk.Image()
-        image.set_from_icon_name("rabbitvcs-show_log",
-                                 Gtk.IconSize.SMALL_TOOLBAR)
+        image.set_from_icon_name("rabbitvcs-show_log", Gtk.IconSize.SMALL_TOOLBAR)
         self.log_dialog_button.set_image(image)
         self.detail_grid.attach(label, 0, row, 1, 1)
         self.detail_grid.attach(self.start_point_entry, 1, row, 1, 1)
@@ -218,11 +215,9 @@ class GitTagManager(InterfaceView):
         message_row = row
         row = row + 1
 
-        self.add_rows = [tag_name_row, message_entry_row,
-                         start_point_row, save_row]
+        self.add_rows = [tag_name_row, message_entry_row, start_point_row, save_row]
 
-        self.view_rows = [tag_name_row, tagger_row,
-                          date_row, revision_row, message_row]
+        self.view_rows = [tag_name_row, tagger_row, date_row, revision_row, message_row]
 
         self.detail_grid.show()
         self.detail_container.add(self.detail_grid)
@@ -245,7 +240,8 @@ class GitTagManager(InterfaceView):
         selected = self.items_treeview.get_selected_row_items(0)
 
         confirm = rabbitvcs.ui.dialog.Confirmation(
-            _("Are you sure you want to delete %s?" % ", ".join(selected)))
+            _("Are you sure you want to delete %s?" % ", ".join(selected))
+        )
         result = confirm.run()
 
         if result == Gtk.ResponseType.OK or result == True:
@@ -307,19 +303,21 @@ class GitTagManager(InterfaceView):
             self.tag_entry.set_text(S(self.selected_tag.name).display())
             self.revision_label.set_text(S(self.selected_tag.sha).display())
             self.message_label.set_text(
-                S(self.selected_tag.message).display().rstrip("\n"))
+                S(self.selected_tag.message).display().rstrip("\n")
+            )
             self.tagger_label.set_text(S(self.selected_tag.tagger).display())
-            self.date_label.set_text(helper.format_datetime(
-                datetime.fromtimestamp(self.selected_tag.tag_time), self.datetime_format))
+            self.date_label.set_text(
+                helper.format_datetime(
+                    datetime.fromtimestamp(self.selected_tag.tag_time),
+                    self.datetime_format,
+                )
+            )
 
             self.show_rows(self.view_rows)
             self.get_widget("detail_label").set_markup(_("<b>Tag Detail</b>"))
 
     def on_log_dialog_button_clicked(self, widget):
-        log_dialog_factory(
-            self.path,
-            ok_callback=self.on_log_dialog_closed
-        )
+        log_dialog_factory(self.path, ok_callback=self.on_log_dialog_closed)
 
     def on_log_dialog_closed(self, data):
         if data:
@@ -328,9 +326,9 @@ class GitTagManager(InterfaceView):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT
+
     (options, paths) = main(
-        [REVISION_OPT, VCS_OPT],
-        usage="Usage: rabbitvcs tag-manager path"
+        [REVISION_OPT, VCS_OPT], usage="Usage: rabbitvcs tag-manager path"
     )
 
     window = GitTagManager(paths[0], options.revision)

--- a/rabbitvcs/ui/unlock.py
+++ b/rabbitvcs/ui/unlock.py
@@ -1,4 +1,14 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui.add import Add
+from rabbitvcs.ui import InterfaceView, InterfaceNonView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,22 +38,13 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView, InterfaceNonView
-from rabbitvcs.ui.add import Add
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
 
 log = Log("rabbitvcs.ui.unlock")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNUnlock(Add):
     def setup(self, window, columns):
@@ -111,12 +112,14 @@ class SVNUnlock(Add):
         )
 
         self.action.append(self.action.set_header, _("Unlock"))
-        self.action.append(self.action.set_status, _("Running Unlock Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Unlock Command..."))
         for item in items:
             self.action.append(self.svn.unlock, item, force=True)
         self.action.append(self.action.set_status, _("Completed Unlock"))
         self.action.append(self.action.finish)
         self.action.schedule()
+
 
 class SVNUnlockQuiet(object):
     """
@@ -132,6 +135,7 @@ class SVNUnlockQuiet(object):
         for path in self.paths:
             self.svn.unlock(path, force=True)
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNUnlock
 }
@@ -139,6 +143,7 @@ classes_map = {
 quiet_classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNUnlockQuiet
 }
+
 
 def unlock_factory(cmap, paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])

--- a/rabbitvcs/ui/unlock.py
+++ b/rabbitvcs/ui/unlock.py
@@ -9,6 +9,7 @@ from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui.add import Add
 from rabbitvcs.ui import InterfaceView, InterfaceNonView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -36,6 +37,7 @@ import six.moves._thread
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -79,18 +81,18 @@ class SVNUnlock(Add):
         found = 0
         for item in self.items:
             # FIXME: ...
-            if item.simple_content_status() in (rabbitvcs.vcs.status.status_unversioned, rabbitvcs.vcs.status.status_ignored):
+            if item.simple_content_status() in (
+                rabbitvcs.vcs.status.status_unversioned,
+                rabbitvcs.vcs.status.status_ignored,
+            ):
                 continue
 
             if not self.svn.is_locked(item.path):
                 continue
 
-            self.files_table.append([
-                True,
-                S(item.path),
-                item.path,
-                helper.get_file_extension(item.path)
-            ])
+            self.files_table.append(
+                [True, S(item.path), item.path, helper.get_file_extension(item.path)]
+            )
             found += 1
 
         self.get_widget("status").set_text(_("Found %d item(s)") % found)
@@ -107,13 +109,11 @@ class SVNUnlock(Add):
         self.hide()
 
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Unlock"))
-        self.action.append(self.action.set_status,
-                           _("Running Unlock Command..."))
+        self.action.append(self.action.set_status, _("Running Unlock Command..."))
         for item in items:
             self.action.append(self.svn.unlock, item, force=True)
         self.action.append(self.action.set_status, _("Completed Unlock"))
@@ -136,13 +136,9 @@ class SVNUnlockQuiet(object):
             self.svn.unlock(path, force=True)
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNUnlock
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNUnlock}
 
-quiet_classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNUnlockQuiet
-}
+quiet_classes_map = {rabbitvcs.vcs.VCS_SVN: SVNUnlockQuiet}
 
 
 def unlock_factory(cmap, paths, base_dir=None):
@@ -152,9 +148,9 @@ def unlock_factory(cmap, paths, base_dir=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT, QUIET_OPT],
-        usage="Usage: rabbitvcs unlock [path1] [path2] ..."
+        [BASEDIR_OPT, QUIET_OPT], usage="Usage: rabbitvcs unlock [path1] [path2] ..."
     )
 
     if options.quiet:

--- a/rabbitvcs/ui/unstage.py
+++ b/rabbitvcs/ui/unstage.py
@@ -10,6 +10,7 @@ from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.ui.add import Add
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -37,6 +38,7 @@ import six.moves._thread
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -56,12 +58,9 @@ class GitUnstage(Add):
     def populate_files_table(self):
         self.files_table.clear()
         for item in self.items:
-            self.files_table.append([
-                True,
-                S(item.path),
-                item.path,
-                helper.get_file_extension(item.path)
-            ])
+            self.files_table.append(
+                [True, S(item.path), item.path, helper.get_file_extension(item.path)]
+            )
 
     def on_ok_clicked(self, widget):
         items = self.files_table.get_activated_rows(1)
@@ -71,13 +70,11 @@ class GitUnstage(Add):
         self.hide()
 
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Unstage"))
-        self.action.append(self.action.set_status,
-                           _("Running Unstage Command..."))
+        self.action.append(self.action.set_status, _("Running Unstage Command..."))
         for item in items:
             self.action.append(self.git.unstage, item)
         self.action.append(self.action.set_status, _("Completed Unstage"))
@@ -89,23 +86,16 @@ class GitUnstageQuiet(object):
     def __init__(self, paths, base_dir=None):
         self.vcs = rabbitvcs.vcs.VCS()
         self.git = self.vcs.git(paths[0])
-        self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            run_in_thread=False
-        )
+        self.action = rabbitvcs.ui.action.GitAction(self.git, run_in_thread=False)
 
         for path in paths:
             self.action.append(self.git.unstage, path)
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_GIT: GitUnstage
-}
+classes_map = {rabbitvcs.vcs.VCS_GIT: GitUnstage}
 
-quiet_classes_map = {
-    rabbitvcs.vcs.VCS_GIT: GitUnstageQuiet
-}
+quiet_classes_map = {rabbitvcs.vcs.VCS_GIT: GitUnstageQuiet}
 
 
 def unstage_factory(classes_map, paths, base_dir=None):
@@ -115,9 +105,9 @@ def unstage_factory(classes_map, paths, base_dir=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, BASEDIR_OPT, QUIET_OPT
+
     (options, paths) = main(
-        [BASEDIR_OPT, QUIET_OPT],
-        usage="Usage: rabbitvcs unstage [path1] [path2] ..."
+        [BASEDIR_OPT, QUIET_OPT], usage="Usage: rabbitvcs unstage [path1] [path2] ..."
     )
 
     if options.quiet:

--- a/rabbitvcs/ui/unstage.py
+++ b/rabbitvcs/ui/unstage.py
@@ -1,4 +1,15 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.util.log import Log
+from rabbitvcs.util.strings import S
+import rabbitvcs.ui.action
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import SVNAction
+from rabbitvcs.ui.add import Add
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -28,24 +39,13 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-from rabbitvcs.ui.add import Add
-from rabbitvcs.ui.action import SVNAction
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.action
-from rabbitvcs.util.strings import S
-from rabbitvcs.util.log import Log
-
-import rabbitvcs.vcs
 
 log = Log("rabbitvcs.ui.unstage")
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class GitUnstage(Add):
     def setup(self, window, columns):
@@ -76,12 +76,14 @@ class GitUnstage(Add):
         )
 
         self.action.append(self.action.set_header, _("Unstage"))
-        self.action.append(self.action.set_status, _("Running Unstage Command..."))
+        self.action.append(self.action.set_status,
+                           _("Running Unstage Command..."))
         for item in items:
             self.action.append(self.git.unstage, item)
         self.action.append(self.action.set_status, _("Completed Unstage"))
         self.action.append(self.action.finish)
         self.action.schedule()
+
 
 class GitUnstageQuiet(object):
     def __init__(self, paths, base_dir=None):
@@ -96,6 +98,7 @@ class GitUnstageQuiet(object):
             self.action.append(self.git.unstage, path)
         self.action.schedule()
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_GIT: GitUnstage
 }
@@ -103,6 +106,7 @@ classes_map = {
 quiet_classes_map = {
     rabbitvcs.vcs.VCS_GIT: GitUnstageQuiet
 }
+
 
 def unstage_factory(classes_map, paths, base_dir=None):
     guess = rabbitvcs.vcs.guess(paths[0])

--- a/rabbitvcs/ui/update.py
+++ b/rabbitvcs/ui/update.py
@@ -1,4 +1,10 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+from rabbitvcs.ui.action import SVNAction, GitAction
+from rabbitvcs.ui import InterfaceNonView, InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,16 +32,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceNonView, InterfaceView
-from rabbitvcs.ui.action import SVNAction, GitAction
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class SVNUpdate(InterfaceNonView):
     """
@@ -63,6 +64,7 @@ class SVNUpdate(InterfaceNonView):
         self.action.append(self.action.finish)
         self.action.schedule()
 
+
 class GitUpdate(InterfaceView):
     """
     This class provides an interface to generate an "update".
@@ -84,8 +86,10 @@ class GitUpdate(InterfaceView):
         )
 
     def on_apply_changes_toggled(self, widget, data=None):
-        self.get_widget("merge").set_sensitive(self.get_widget("apply_changes").get_active())
-        self.get_widget("rebase").set_sensitive(self.get_widget("apply_changes").get_active())
+        self.get_widget("merge").set_sensitive(
+            self.get_widget("apply_changes").get_active())
+        self.get_widget("rebase").set_sensitive(
+            self.get_widget("apply_changes").get_active())
 
     def on_ok_clicked(self, widget, data=None):
         self.hide()
@@ -117,7 +121,8 @@ class GitUpdate(InterfaceView):
                 repository = ""
                 branch = ""
 
-            self.action.append(self.git.pull, repository, branch, git_function_params)
+            self.action.append(self.git.pull, repository,
+                               branch, git_function_params)
         else:
             if fetch_all:
                 self.action.append(self.git.fetch_all)
@@ -134,6 +139,7 @@ classes_map = {
     rabbitvcs.vcs.VCS_GIT: GitUpdate
 }
 
+
 def update_factory(paths):
     guess = rabbitvcs.vcs.guess(paths[0])
     return classes_map[guess["vcs"]](paths)
@@ -141,7 +147,8 @@ def update_factory(paths):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
-    (options, paths) = main(usage="Usage: rabbitvcs update [path1] [path2] ...")
+    (options, paths) = main(
+        usage="Usage: rabbitvcs update [path1] [path2] ...")
 
     window = update_factory(paths)
     window.register_gtk_quit()

--- a/rabbitvcs/ui/update.py
+++ b/rabbitvcs/ui/update.py
@@ -5,6 +5,7 @@ import rabbitvcs.ui.widget
 from rabbitvcs.ui.action import SVNAction, GitAction
 from rabbitvcs.ui import InterfaceNonView, InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -30,6 +31,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -53,9 +55,7 @@ class SVNUpdate(InterfaceNonView):
 
     def start(self):
         self.action = SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set(),
-            run_in_thread=False
+            self.svn, register_gtk_quit=self.gtk_quit_is_set(), run_in_thread=False
         )
         self.action.append(self.action.set_header, _("Update"))
         self.action.append(self.action.set_status, _("Updating..."))
@@ -81,15 +81,16 @@ class GitUpdate(InterfaceView):
         self.git = self.vcs.git(paths[0])
 
         self.repository_selector = rabbitvcs.ui.widget.GitRepositorySelector(
-            self.get_widget("repository_container"),
-            self.git
+            self.get_widget("repository_container"), self.git
         )
 
     def on_apply_changes_toggled(self, widget, data=None):
         self.get_widget("merge").set_sensitive(
-            self.get_widget("apply_changes").get_active())
+            self.get_widget("apply_changes").get_active()
+        )
         self.get_widget("rebase").set_sensitive(
-            self.get_widget("apply_changes").get_active())
+            self.get_widget("apply_changes").get_active()
+        )
 
     def on_ok_clicked(self, widget, data=None):
         self.hide()
@@ -105,9 +106,7 @@ class GitUpdate(InterfaceView):
         fetch_all = self.get_widget("all").get_active()
 
         self.action = GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set(),
-            run_in_thread=False
+            self.git, register_gtk_quit=self.gtk_quit_is_set(), run_in_thread=False
         )
         self.action.append(self.action.set_header, _("Update"))
         self.action.append(self.action.set_status, _("Updating..."))
@@ -121,8 +120,7 @@ class GitUpdate(InterfaceView):
                 repository = ""
                 branch = ""
 
-            self.action.append(self.git.pull, repository,
-                               branch, git_function_params)
+            self.action.append(self.git.pull, repository, branch, git_function_params)
         else:
             if fetch_all:
                 self.action.append(self.git.fetch_all)
@@ -134,10 +132,7 @@ class GitUpdate(InterfaceView):
         self.action.schedule()
 
 
-classes_map = {
-    rabbitvcs.vcs.VCS_SVN: SVNUpdate,
-    rabbitvcs.vcs.VCS_GIT: GitUpdate
-}
+classes_map = {rabbitvcs.vcs.VCS_SVN: SVNUpdate, rabbitvcs.vcs.VCS_GIT: GitUpdate}
 
 
 def update_factory(paths):
@@ -147,8 +142,8 @@ def update_factory(paths):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main
-    (options, paths) = main(
-        usage="Usage: rabbitvcs update [path1] [path2] ...")
+
+    (options, paths) = main(usage="Usage: rabbitvcs update [path1] [path2] ...")
 
     window = update_factory(paths)
     window.register_gtk_quit()

--- a/rabbitvcs/ui/updateto.py
+++ b/rabbitvcs/ui/updateto.py
@@ -5,6 +5,7 @@ import rabbitvcs.ui.widget
 import rabbitvcs.ui.action
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -30,6 +31,7 @@ from gi.repository import Gtk, GObject, Gdk
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 sa.restore()
@@ -65,7 +67,7 @@ class SVNUpdateToRevision(UpdateToRevision):
             revision=revision,
             url=self.path,
             expand=True,
-            revision_changed_callback=self.on_revision_changed
+            revision_changed_callback=self.on_revision_changed,
         )
 
     def on_ok_clicked(self, widget):
@@ -76,20 +78,18 @@ class SVNUpdateToRevision(UpdateToRevision):
         rollback = self.get_widget("rollback").get_active()
 
         self.action = rabbitvcs.ui.action.SVNAction(
-            self.svn,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.svn, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         if rollback:
-            self.action.append(self.action.set_header,
-                               _("Rollback To Revision"))
+            self.action.append(self.action.set_header, _("Rollback To Revision"))
             self.action.append(self.action.set_status, _("Rolling Back..."))
             self.action.append(
                 self.svn.merge_ranges,
                 self.svn.get_repo_url(self.path),
                 [(self.svn.revision("HEAD").primitive(), revision.primitive())],
                 self.svn.revision("head"),
-                self.path
+                self.path,
             )
             self.action.append(self.action.set_status, _("Completed Rollback"))
         else:
@@ -100,7 +100,7 @@ class SVNUpdateToRevision(UpdateToRevision):
                 self.path,
                 revision=revision,
                 recurse=recursive,
-                ignore_externals=omit_externals
+                ignore_externals=omit_externals,
             )
             self.action.append(self.action.set_status, _("Completed Update"))
 
@@ -109,8 +109,10 @@ class SVNUpdateToRevision(UpdateToRevision):
 
     def on_revision_changed(self, revision_selector):
         # Only allow rollback when a revision number is specified
-        if (revision_selector.revision_kind_opt.get_active() == 1
-                and revision_selector.revision_entry.get_text() != ""):
+        if (
+            revision_selector.revision_kind_opt.get_active() == 1
+            and revision_selector.revision_entry.get_text() != ""
+        ):
             self.get_widget("rollback").set_sensitive(True)
         else:
             self.get_widget("rollback").set_sensitive(False)
@@ -121,7 +123,8 @@ class GitUpdateToRevision(UpdateToRevision):
         UpdateToRevision.__init__(self, path, revision)
 
         self.get_widget("revision_label").set_text(
-            _("What revision/branch do you want to checkout?"))
+            _("What revision/branch do you want to checkout?")
+        )
 
         self.git = self.vcs.git(path)
 
@@ -131,25 +134,19 @@ class GitUpdateToRevision(UpdateToRevision):
             revision=revision,
             url=self.path,
             expand=True,
-            revision_changed_callback=self.on_revision_changed
+            revision_changed_callback=self.on_revision_changed,
         )
 
     def on_ok_clicked(self, widget):
         revision = self.revision_selector.get_revision_object()
 
         self.action = rabbitvcs.ui.action.GitAction(
-            self.git,
-            register_gtk_quit=self.gtk_quit_is_set()
+            self.git, register_gtk_quit=self.gtk_quit_is_set()
         )
 
         self.action.append(self.action.set_header, _("Checkout"))
-        self.action.append(self.action.set_status, _(
-            "Checking out %s..." % revision))
-        self.action.append(
-            self.git.checkout,
-            [self.path],
-            revision
-        )
+        self.action.append(self.action.set_status, _("Checking out %s..." % revision))
+        self.action.append(self.git.checkout, [self.path], revision)
         self.action.append(self.action.set_status, _("Completed Checkout"))
         self.action.append(self.action.finish)
         self.action.schedule()
@@ -174,9 +171,9 @@ def updateto_factory(vcs, path, revision=None):
 
 if __name__ == "__main__":
     from rabbitvcs.ui import main, REVISION_OPT, VCS_OPT
+
     (options, args) = main(
-        [REVISION_OPT, VCS_OPT],
-        usage="Usage: rabbitvcs updateto [path]"
+        [REVISION_OPT, VCS_OPT], usage="Usage: rabbitvcs updateto [path]"
     )
 
     window = updateto_factory(options.vcs, args[0], revision=options.revision)

--- a/rabbitvcs/ui/updateto.py
+++ b/rabbitvcs/ui/updateto.py
@@ -1,4 +1,10 @@
 from __future__ import absolute_import
+from rabbitvcs import gettext
+import rabbitvcs.ui.dialog
+import rabbitvcs.ui.widget
+import rabbitvcs.ui.action
+from rabbitvcs.ui import InterfaceView
+from gi.repository import Gtk, GObject, Gdk
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -26,16 +32,11 @@ from rabbitvcs.util import helper
 import gi
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
-from gi.repository import Gtk, GObject, Gdk
 sa.restore()
 
-from rabbitvcs.ui import InterfaceView
-import rabbitvcs.ui.action
-import rabbitvcs.ui.widget
-import rabbitvcs.ui.dialog
 
-from rabbitvcs import gettext
 _ = gettext.gettext
+
 
 class UpdateToRevision(InterfaceView):
     """
@@ -49,7 +50,6 @@ class UpdateToRevision(InterfaceView):
         self.path = path
         self.revision = revision
         self.vcs = rabbitvcs.vcs.VCS()
-
 
 
 class SVNUpdateToRevision(UpdateToRevision):
@@ -81,7 +81,8 @@ class SVNUpdateToRevision(UpdateToRevision):
         )
 
         if rollback:
-            self.action.append(self.action.set_header, _("Rollback To Revision"))
+            self.action.append(self.action.set_header,
+                               _("Rollback To Revision"))
             self.action.append(self.action.set_status, _("Rolling Back..."))
             self.action.append(
                 self.svn.merge_ranges,
@@ -114,11 +115,13 @@ class SVNUpdateToRevision(UpdateToRevision):
         else:
             self.get_widget("rollback").set_sensitive(False)
 
+
 class GitUpdateToRevision(UpdateToRevision):
     def __init__(self, path, revision):
         UpdateToRevision.__init__(self, path, revision)
 
-        self.get_widget("revision_label").set_text(_("What revision/branch do you want to checkout?"))
+        self.get_widget("revision_label").set_text(
+            _("What revision/branch do you want to checkout?"))
 
         self.git = self.vcs.git(path)
 
@@ -140,7 +143,8 @@ class GitUpdateToRevision(UpdateToRevision):
         )
 
         self.action.append(self.action.set_header, _("Checkout"))
-        self.action.append(self.action.set_status, _("Checking out %s..." % revision))
+        self.action.append(self.action.set_status, _(
+            "Checking out %s..." % revision))
         self.action.append(
             self.git.checkout,
             [self.path],
@@ -153,10 +157,12 @@ class GitUpdateToRevision(UpdateToRevision):
     def on_revision_changed(self, revision_selector):
         pass
 
+
 classes_map = {
     rabbitvcs.vcs.VCS_SVN: SVNUpdateToRevision,
     rabbitvcs.vcs.VCS_GIT: GitUpdateToRevision,
 }
+
 
 def updateto_factory(vcs, path, revision=None):
     if not vcs:

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -10,6 +10,7 @@ from rabbitvcs.util import helper
 from rabbitvcs.util.decorators import gtk_unsafe
 from gi.repository import Gtk, Gdk, GObject, Pango
 from six.moves import range
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -37,12 +38,14 @@ import os.path
 from locale import strxfrm
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 
 HAS_GTKSPELL = False
 try:
     gi.require_version("GtkSpell", "3.0")
     from gi.repository import GtkSpell
+
     HAS_GTKSPELL = True
 except (ImportError, ValueError):
     pass
@@ -53,19 +56,19 @@ _ = gettext.gettext
 log = Log("rabbitvcs.ui.widget")
 
 
-TOGGLE_BUTTON = 'TOGGLE_BUTTON'
-TYPE_PATH = 'TYPE_PATH'
-TYPE_STATUS = 'TYPE_STATUS'
-TYPE_ELLIPSIZED = 'TYPE_ELLIPSIZED'
-TYPE_GRAPH = 'TYPE_GRAPH'
-TYPE_MARKUP = 'TYPE_MARKUP'
-TYPE_HIDDEN = 'TYPE_HIDDEN'
-TYPE_HIDDEN_OBJECT = 'TYPE_HIDDEN_OBJECT'
+TOGGLE_BUTTON = "TOGGLE_BUTTON"
+TYPE_PATH = "TYPE_PATH"
+TYPE_STATUS = "TYPE_STATUS"
+TYPE_ELLIPSIZED = "TYPE_ELLIPSIZED"
+TYPE_GRAPH = "TYPE_GRAPH"
+TYPE_MARKUP = "TYPE_MARKUP"
+TYPE_HIDDEN = "TYPE_HIDDEN"
+TYPE_HIDDEN_OBJECT = "TYPE_HIDDEN_OBJECT"
 
 ELLIPSIZE_COLUMN_CHARS = 20
 
-PATH_ENTRY = 'PATH_ENTRY'
-SEPARATOR = u'\u2015' * 10
+PATH_ENTRY = "PATH_ENTRY"
+SEPARATOR = "\u2015" * 10
 
 
 def filter_router(model, iter, column, filters):
@@ -213,8 +216,17 @@ def compare_items(model, iter1, iter2, user_data=None):
 
 
 class TableBase(object):
-    def __init__(self, treeview, coltypes, colnames, values=[], filters=None,
-                 filter_types=None, callbacks={}, flags={}):
+    def __init__(
+        self,
+        treeview,
+        coltypes,
+        colnames,
+        values=[],
+        filters=None,
+        filter_types=None,
+        callbacks={},
+        flags={},
+    ):
         """
         @type   treeview: Gtk.Treeview
         @param  treeview: The treeview widget to use
@@ -284,8 +296,8 @@ class TableBase(object):
         for name in colnames:
             if coltypes[i] == GObject.TYPE_BOOLEAN:
                 cell = Gtk.CellRendererToggle()
-                cell.set_property('activatable', True)
-                cell.set_property('xalign', 0)
+                cell.set_property("activatable", True)
+                cell.set_property("xalign", 0)
                 cell.connect("toggled", self.toggled_cb, i)
 
                 colname = ""
@@ -305,25 +317,19 @@ class TableBase(object):
                 col = Gtk.TreeViewColumn(name)
 
                 cellpb = Gtk.CellRendererPixbuf()
-                cellpb.set_property('xalign', 0)
-                cellpb.set_property('yalign', 0)
+                cellpb.set_property("xalign", 0)
+                cellpb.set_property("yalign", 0)
                 col.pack_start(cellpb, False)
                 data = None
                 if "file-column-callback" in callbacks:
-                    data = {
-                        "callback": callbacks["file-column-callback"],
-                        "column": i
-                    }
+                    data = {"callback": callbacks["file-column-callback"], "column": i}
                 else:
-                    data = {
-                        "callback": helper.get_node_kind,
-                        "column": i
-                    }
+                    data = {"callback": helper.get_node_kind, "column": i}
                 col.set_cell_data_func(cellpb, self.file_pixbuf, data)
 
                 cell = Gtk.CellRendererText()
-                cell.set_property('xalign', 0)
-                cell.set_property('yalign', 0)
+                cell.set_property("xalign", 0)
+                cell.set_property("yalign", 0)
                 col.pack_start(cell, False)
                 col.set_attributes(cell, text=i)
             elif coltypes[i] == TYPE_STATUS:
@@ -332,8 +338,8 @@ class TableBase(object):
                 col = Gtk.TreeViewColumn(name)
 
                 cellpb = Gtk.CellRendererPixbuf()
-                cellpb.set_property('xalign', 0)
-                cellpb.set_property('yalign', 0)
+                cellpb.set_property("xalign", 0)
+                cellpb.set_property("yalign", 0)
 
                 col.pack_start(cellpb, False)
 
@@ -342,8 +348,8 @@ class TableBase(object):
                 col.set_cell_data_func(cellpb, self.status_pixbuf, i)
 
                 cell = Gtk.CellRendererText()
-                cell.set_property('xalign', 0)
-                cell.set_property('yalign', 0)
+                cell.set_property("xalign", 0)
+                cell.set_property("yalign", 0)
                 col.pack_start(cell, False)
                 col.set_attributes(cell, text=i)
             elif coltypes[i] == TYPE_HIDDEN:
@@ -357,10 +363,10 @@ class TableBase(object):
             elif coltypes[i] == TYPE_ELLIPSIZED:
                 coltypes[i] = str
                 cell = Gtk.CellRendererText()
-                cell.set_property('yalign', 0)
-                cell.set_property('xalign', 0)
-                cell.set_property('ellipsize', Pango.EllipsizeMode.END)
-                cell.set_property('width-chars', ELLIPSIZE_COLUMN_CHARS)
+                cell.set_property("yalign", 0)
+                cell.set_property("xalign", 0)
+                cell.set_property("ellipsize", Pango.EllipsizeMode.END)
+                cell.set_property("width-chars", ELLIPSIZE_COLUMN_CHARS)
                 col = Gtk.TreeViewColumn(name, cell)
                 col.set_attributes(cell, text=i)
             elif coltypes[i] == TYPE_GRAPH:
@@ -370,10 +376,10 @@ class TableBase(object):
                 col.add_attribute(cell, "graph", i)
             else:
                 cell = Gtk.CellRendererText()
-                cell.set_property('yalign', 0)
-                cell.set_property('xalign', 0)
+                cell.set_property("yalign", 0)
+                cell.set_property("xalign", 0)
                 if i in flags["editable"]:
-                    cell.set_property('editable', True)
+                    cell.set_property("editable", True)
                     cell.connect("edited", self.__cell_edited, i)
 
                 if coltypes[i] == TYPE_MARKUP:
@@ -401,11 +407,8 @@ class TableBase(object):
         # The filter is there to change the way data is displayed. The data
         # should always be accessed via self.data, NOT self.filter.
         self.filter = self.data.filter_new()
-        types = (filter_types and filter_types or coltypes)
-        self.filter.set_modify_func(
-            types,
-            filter_router,
-            filters)
+        types = filter_types and filter_types or coltypes
+        self.filter.set_modify_func(types, filter_router, filters)
 
         # This runs through the columns, and sets the "compare_items" comparator
         # as needed. Note that the user data tells which column to sort on.
@@ -415,12 +418,9 @@ class TableBase(object):
             self.sorted.set_default_sort_func(compare_items, None)
 
             for idx in range(0, i):
-                self.sorted.set_sort_func(idx,
-                                          compare_items,
-                                          (idx, coltypes[idx]))
+                self.sorted.set_sort_func(idx, compare_items, (idx, coltypes[idx]))
 
-            self.sorted.set_sort_column_id(
-                flags["sort_on"], Gtk.SortType.ASCENDING)
+            self.sorted.set_sort_column_id(flags["sort_on"], Gtk.SortType.ASCENDING)
 
             self.treeview.set_model(self.sorted)
 
@@ -439,8 +439,7 @@ class TableBase(object):
         self.treeview.connect("cursor-changed", self.__cursor_changed_event)
         self.treeview.connect("row-activated", self.__row_activated_event)
         self.treeview.connect("button-press-event", self.__button_press_event)
-        self.treeview.connect("button-release-event",
-                              self.__button_release_event)
+        self.treeview.connect("button-release-event", self.__button_release_event)
         self.treeview.connect("key-press-event", self.__key_press_event)
         self.treeview.connect("select-cursor-row", self.__row_selected)
         # Necessary for self.selected_rows to remain sane
@@ -479,8 +478,7 @@ class TableBase(object):
         model = self.data
         realpath = self._realpath(Gtk.TreePath.new_from_string(path))
         # User has clicked a checkbox on a selected item.
-        toggleMulti = realpath in self.selected_rows and len(
-            self.selected_rows) > 1
+        toggleMulti = realpath in self.selected_rows and len(self.selected_rows) > 1
         model[realpath][column] = not model[realpath][column]
         if "row-toggled" in self.callbacks:
             self.callbacks["row-toggled"](model[realpath], column)
@@ -646,8 +644,7 @@ class TableBase(object):
             # keep the selection, otherwise, use the new selection
             result = any(index == info[0] for index in indexes)
         if "mouse-event" in self.callbacks:
-            result = self.callbacks["mouse-event"](
-                treeview, event, *args) or result
+            result = self.callbacks["mouse-event"](treeview, event, *args) or result
         return result
 
     def __row_activated_event(self, treeview, data, col):
@@ -695,8 +692,8 @@ class TableBase(object):
         if "cell-edited" in self.callbacks:
             self.callbacks["cell-edited"](cell, row, data, column)
 
-#    def __column_header_clicked(self, column, column_idx):
-#        self.data.set_sort_column_id(column_idx, )
+    #    def __column_header_clicked(self, column, column_idx):
+    #        self.data.set_sort_column_id(column_idx, )
 
     def status_pixbuf(self, column, cell, model, iter, colnum):
 
@@ -739,10 +736,28 @@ class Table(TableBase):
 
     """
 
-    def __init__(self, treeview, coltypes, colnames, values=[], filters=None,
-                 filter_types=None, callbacks={}, flags={}):
-        TableBase.__init__(self, treeview, coltypes, colnames, values, filters,
-                           filter_types, callbacks, flags)
+    def __init__(
+        self,
+        treeview,
+        coltypes,
+        colnames,
+        values=[],
+        filters=None,
+        filter_types=None,
+        callbacks={},
+        flags={},
+    ):
+        TableBase.__init__(
+            self,
+            treeview,
+            coltypes,
+            colnames,
+            values,
+            filters,
+            filter_types,
+            callbacks,
+            flags,
+        )
 
     def get_store(self, coltypes):
         return Gtk.ListStore(*coltypes)
@@ -778,10 +793,28 @@ class Tree(TableBase):
 
     """
 
-    def __init__(self, treeview, coltypes, colnames, values=[], filters=None,
-                 filter_types=None, callbacks={}, flags={}):
-        TableBase.__init__(self, treeview, coltypes, colnames, values, filters,
-                           filter_types, callbacks, flags)
+    def __init__(
+        self,
+        treeview,
+        coltypes,
+        colnames,
+        values=[],
+        filters=None,
+        filter_types=None,
+        callbacks={},
+        flags={},
+    ):
+        TableBase.__init__(
+            self,
+            treeview,
+            coltypes,
+            colnames,
+            values,
+            filters,
+            filter_types,
+            callbacks,
+            flags,
+        )
 
     def get_store(self, coltypes):
         return Gtk.TreeStore(*coltypes)
@@ -803,10 +836,20 @@ class Box(object):
             box.set_column_spacing(spacing)
         self.middle = 0
         # Determine pack start/end indexes.
-        ch = [(box.child_get_property(c, "left-attach"),
-               box.child_get_property(c, "width")) for c in box.get_children()]
-        cv = [(box.child_get_property(c, "top-attach"),
-               box.child_get_property(c, "height")) for c in box.get_children()]
+        ch = [
+            (
+                box.child_get_property(c, "left-attach"),
+                box.child_get_property(c, "width"),
+            )
+            for c in box.get_children()
+        ]
+        cv = [
+            (
+                box.child_get_property(c, "top-attach"),
+                box.child_get_property(c, "height"),
+            )
+            for c in box.get_children()
+        ]
         if ch:
             ch.sort(key=lambda x: x[0])
             cv.sort(key=lambda x: x[0])
@@ -830,15 +873,18 @@ class Box(object):
         self.set_expand = lambda child, expand: child.set_hexpand(expand)
         self.set_align = lambda child, align: child.set_halign(align)
         self.set_padding = lambda child, padding: (
-            child.set_margin_start(padding), child.set_margin_end(padding))
+            child.set_margin_start(padding),
+            child.set_margin_end(padding),
+        )
         if vertical:
             self.insert = self.box.insert_row
-            self.attach = lambda child, pos: self.box.attach(
-                child, 0, pos, 1, 1)
+            self.attach = lambda child, pos: self.box.attach(child, 0, pos, 1, 1)
             self.set_expand = lambda child, expand: child.set_vexpand(expand)
             self.set_align = lambda child, align: child.set_valign(align)
             self.set_padding = lambda child, padding: (
-                child.set_margin_top(padding), child.set_margin_bottom(padding))
+                child.set_margin_top(padding),
+                child.set_margin_bottom(padding),
+            )
 
     def add(self, child):
         if isinstance(child, Box):
@@ -885,7 +931,7 @@ class ComboBox(object):
 
         self.cell = Gtk.CellRendererText()
         self.cb.pack_start(self.cell, True)
-        self.cb.add_attribute(self.cell, 'text', textcolumn)
+        self.cb.add_attribute(self.cell, "text", textcolumn)
 
     def append(self, item):
         if not isinstance(item, list):
@@ -941,7 +987,7 @@ class TextView(object):
                 try:
                     checker.set_language(get_locale()[0])
                 except:
-                    checker = None          # Language not available.
+                    checker = None  # Language not available.
                 if checker:
                     checker.attach(self.view)
             except Exception as e:
@@ -949,9 +995,7 @@ class TextView(object):
 
     def get_text(self):
         return self.buffer.get_text(
-            self.buffer.get_start_iter(),
-            self.buffer.get_end_iter(),
-            True
+            self.buffer.get_start_iter(), self.buffer.get_end_iter(), True
         )
 
     @gtk_unsafe
@@ -1039,8 +1083,7 @@ class Clickable(object):
             self._signals[self._2BUTTON_PRESS] = self._signal_data(func, args)
         elif signal == "triple-click":
             self._signals[self._3BUTTON_PRESS] = self._signal_data(func, args)
-        elif signal in ("long-click",
-                        "button-press-event", "button-release-event"):
+        elif signal in ("long-click", "button-press-event", "button-release-event"):
             self._signals[signal] = self._signal_data(func, args)
         else:
             self.widget.connect(signal, func, *args)
@@ -1104,9 +1147,17 @@ class RevisionSelector(object):
 
     """
 
-    def __init__(self, container, client, revision=None,
-                 url_combobox=None, url_entry=None, url=None, expand=False,
-                 revision_changed_callback=None):
+    def __init__(
+        self,
+        container,
+        client,
+        revision=None,
+        url_combobox=None,
+        url_entry=None,
+        url=None,
+        expand=False,
+        revision_changed_callback=None,
+    ):
         """
         @type   container: A Gtk container object (i.e. HBox, VBox, Box)
         @param  container: The container that to add this widget
@@ -1142,27 +1193,18 @@ class RevisionSelector(object):
         hbox.set_hexpand(expand)
 
         if self.url_combobox:
-            self.url_combobox.cb.connect(
-                "changed", self.__on_url_combobox_changed)
+            self.url_combobox.cb.connect("changed", self.__on_url_combobox_changed)
 
         if client.vcs == rabbitvcs.vcs.VCS_GIT:
-            self.OPTIONS = [
-                _("HEAD"),
-                _("Revision"),
-                _("Branch")
-            ]
+            self.OPTIONS = [_("HEAD"), _("Revision"), _("Branch")]
         elif client.vcs == rabbitvcs.vcs.VCS_SVN:
-            self.OPTIONS = [
-                _("HEAD"),
-                _("Number")
-            ]
+            self.OPTIONS = [_("HEAD"), _("Number")]
             if not client.is_path_repository_url(self.get_url()):
                 self.OPTIONS.append(_("Working Copy"))
 
         self.revision_kind_opt = ComboBox(Gtk.ComboBox(), self.OPTIONS)
         self.revision_kind_opt.set_active(0)
-        self.revision_kind_opt.cb.connect(
-            "changed", self.__revision_kind_changed)
+        self.revision_kind_opt.cb.connect("changed", self.__revision_kind_changed)
         hbox.pack_start(self.revision_kind_opt.cb, False, False, 0)
 
         self.revision_entry = Gtk.Entry()
@@ -1172,13 +1214,13 @@ class RevisionSelector(object):
         self.branch_selector = None
         if client.vcs == rabbitvcs.vcs.VCS_GIT:
             self.branch_selector = GitBranchSelector(
-                hbox, client, self.__branch_selector_changed)
+                hbox, client, self.__branch_selector_changed
+            )
             self.branch_selector.hide()
 
         self.revision_browse = Gtk.Button()
         revision_browse_image = Gtk.Image()
-        revision_browse_image.set_from_icon_name(
-            "edit-find", Gtk.IconSize.MENU)
+        revision_browse_image.set_from_icon_name("edit-find", Gtk.IconSize.MENU)
         revision_browse_image.show()
         self.revision_browse.add(revision_browse_image)
         self.revision_browse.connect("clicked", self.__revision_browse_clicked)
@@ -1198,6 +1240,7 @@ class RevisionSelector(object):
 
     def __revision_browse_clicked(self, widget):
         from rabbitvcs.ui.log import SVNLogDialog, GitLogDialog
+
         if self.client.vcs == rabbitvcs.vcs.VCS_GIT:
             GitLogDialog(self.get_url(), ok_callback=self.__log_closed)
         elif self.client.vcs == rabbitvcs.vcs.VCS_SVN:
@@ -1353,9 +1396,9 @@ class KeyValueTable(Gtk.Grid):
                 label_key.set_properties(xalign=0, use_markup=True)
 
                 label_value = Gtk.Label(label="%s" % value)
-                label_value.set_properties(xalign=0,
-                                           ellipsize=Pango.EllipsizeMode.MIDDLE,
-                                           selectable=True)
+                label_value.set_properties(
+                    xalign=0, ellipsize=Pango.EllipsizeMode.MIDDLE, selectable=True
+                )
                 label_value.set_hexpand(True)
                 label_value.set_halign(Gtk.Align.START)
 
@@ -1389,8 +1432,7 @@ class GitRepositorySelector(object):
         tmp_repos = []
         for item in self.git.remote_list():
             tmp_repos.append(item["name"])
-        self.repository_opt = ComboBox(
-            Gtk.ComboBoxText.new_with_entry(), tmp_repos)
+        self.repository_opt = ComboBox(Gtk.ComboBoxText.new_with_entry(), tmp_repos)
         self.repository_opt.set_active(0)
         self.repository_opt.cb.connect("changed", self.__repository_changed)
         self.repository_opt.cb.set_size_request(175, -1)
@@ -1415,8 +1457,7 @@ class GitRepositorySelector(object):
 
             index += 1
 
-        self.branch_opt = ComboBox(
-            Gtk.ComboBoxText.new_with_entry(), tmp_branches)
+        self.branch_opt = ComboBox(Gtk.ComboBoxText.new_with_entry(), tmp_branches)
         self.branch_opt.set_active(active_branch_index)
         self.branch_opt.cb.connect("changed", self.__branch_changed)
         self.branch_opt.cb.set_size_request(175, -1)
@@ -1445,21 +1486,24 @@ class GitRepositorySelector(object):
     def __update_host(self):
         repo = self.repository_opt.get_active_text()
         try:
-            self.host.set_text(S(self.git.config_get(
-                ("remote", repo), "url")).display())
+            self.host.set_text(
+                S(self.git.config_get(("remote", repo), "url")).display()
+            )
         except KeyError as e:
             log.error("Missing remote %s config key" % repo)
 
     def __repository_changed(self, repository_opt):
         if self.changed_callback:
             self.changed_callback(
-                repository_opt.get_active_text(), self.branch_opt.get_active_text())
+                repository_opt.get_active_text(), self.branch_opt.get_active_text()
+            )
         self.__update_host()
 
     def __branch_changed(self, branch_opt):
         if self.changed_callback:
             self.changed_callback(
-                self.repository_opt.get_active_text(), self.branch_opt.get_active_text())
+                self.repository_opt.get_active_text(), self.branch_opt.get_active_text()
+            )
 
 
 class GitBranchSelector(object):
@@ -1478,8 +1522,7 @@ class GitBranchSelector(object):
                 active = index
             index += 1
 
-        self.branch_opt = ComboBox(
-            Gtk.ComboBoxText.new_with_entry(), tmp_branches)
+        self.branch_opt = ComboBox(Gtk.ComboBoxText.new_with_entry(), tmp_branches)
         self.branch_opt.set_active(active)
         self.branch_opt.cb.connect("changed", self.__branch_changed)
         self.branch_opt.cb.set_size_request(175, -1)
@@ -1512,7 +1555,15 @@ class MultiFileTextEditor(object):
     Edit a set of text/config/ignore files
     """
 
-    def __init__(self, container, label, combobox_labels, combobox_paths, show_add_line=True, line_content=""):
+    def __init__(
+        self,
+        container,
+        label,
+        combobox_labels,
+        combobox_paths,
+        show_add_line=True,
+        line_content="",
+    ):
         self.container = container
         self.label = label
         self.combobox_labels = combobox_labels
@@ -1539,8 +1590,7 @@ class MultiFileTextEditor(object):
         scrolled_window = Gtk.ScrolledWindow()
         scrolled_window.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
         scrolled_window.add(self.textview.view)
-        scrolled_window.set_policy(
-            Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scrolled_window.set_size_request(320, 150)
         scrolled_window.set_hexpand(True)
         scrolled_window.set_vexpand(True)

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -1,4 +1,14 @@
 from __future__ import absolute_import
+from pprint import pformat
+from rabbitvcs.ui import STATUS_EMBLEMS
+from rabbitvcs.util.log import Log
+from rabbitvcs import gettext
+import rabbitvcs.vcs
+from rabbitvcs.util.strings import S
+from rabbitvcs.util._locale import get_locale
+from rabbitvcs.util import helper
+from rabbitvcs.util.decorators import gtk_unsafe
+from gi.repository import Gtk, Gdk, GObject, Pango
 from six.moves import range
 #
 # This is an extension to the Nautilus file manager to allow better
@@ -28,7 +38,6 @@ from locale import strxfrm
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk, GObject, Pango
 
 HAS_GTKSPELL = False
 try:
@@ -38,19 +47,11 @@ try:
 except (ImportError, ValueError):
     pass
 
-from rabbitvcs.util.decorators import gtk_unsafe
-from rabbitvcs.util import helper
-from rabbitvcs.util._locale import get_locale
-from rabbitvcs.util.strings import S
-import rabbitvcs.vcs
 
-from rabbitvcs import gettext
 _ = gettext.gettext
 
-from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.ui.widget")
 
-from rabbitvcs.ui import STATUS_EMBLEMS
 
 TOGGLE_BUTTON = 'TOGGLE_BUTTON'
 TYPE_PATH = 'TYPE_PATH'
@@ -66,7 +67,7 @@ ELLIPSIZE_COLUMN_CHARS = 20
 PATH_ENTRY = 'PATH_ENTRY'
 SEPARATOR = u'\u2015' * 10
 
-from pprint import pformat
+
 def filter_router(model, iter, column, filters):
     """
     Route filter requests for a table's columns.  This function is called for
@@ -116,6 +117,7 @@ def filter_router(model, iter, column, filters):
 
     return row[column]
 
+
 def path_filter(row, column, user_data=None):
     """
     A common filter function that is used in many tables.  Changes the displayed
@@ -144,6 +146,7 @@ def path_filter(row, column, user_data=None):
     else:
         return row[column]
 
+
 def long_text_filter(row, column, user_data=None):
     """
     Uses the format_long_text helper function to trim and prettify some text.
@@ -152,11 +155,11 @@ def long_text_filter(row, column, user_data=None):
 
     cols = user_data["cols"]
 
-
     if text:
         text = helper.format_long_text(text, cols)
 
     return text
+
 
 def git_revision_filter(row, column, user_data=None):
     """
@@ -172,12 +175,15 @@ def git_revision_filter(row, column, user_data=None):
 
     return text
 
+
 def translate_filter(row, column, user_data=None):
     """
     Translates text as needed.
     """
     text = row[column]
-    if text: return _(text)
+    if text:
+        return _(text)
+
 
 def compare_items(model, iter1, iter2, user_data=None):
 
@@ -204,6 +210,7 @@ def compare_items(model, iter1, iter2, user_data=None):
         return -1
     else:
         return 1
+
 
 class TableBase(object):
     def __init__(self, treeview, coltypes, colnames, values=[], filters=None,
@@ -396,10 +403,9 @@ class TableBase(object):
         self.filter = self.data.filter_new()
         types = (filter_types and filter_types or coltypes)
         self.filter.set_modify_func(
-                        types,
-                        filter_router,
-                        filters)
-
+            types,
+            filter_router,
+            filters)
 
         # This runs through the columns, and sets the "compare_items" comparator
         # as needed. Note that the user data tells which column to sort on.
@@ -413,7 +419,8 @@ class TableBase(object):
                                           compare_items,
                                           (idx, coltypes[idx]))
 
-            self.sorted.set_sort_column_id(flags["sort_on"], Gtk.SortType.ASCENDING)
+            self.sorted.set_sort_column_id(
+                flags["sort_on"], Gtk.SortType.ASCENDING)
 
             self.treeview.set_model(self.sorted)
 
@@ -421,7 +428,6 @@ class TableBase(object):
             self.treeview.set_model(self.filter)
         else:
             self.treeview.set_model(self.data)
-
 
         if len(values) > 0:
             self.populate(values)
@@ -433,7 +439,8 @@ class TableBase(object):
         self.treeview.connect("cursor-changed", self.__cursor_changed_event)
         self.treeview.connect("row-activated", self.__row_activated_event)
         self.treeview.connect("button-press-event", self.__button_press_event)
-        self.treeview.connect("button-release-event", self.__button_release_event)
+        self.treeview.connect("button-release-event",
+                              self.__button_release_event)
         self.treeview.connect("key-press-event", self.__key_press_event)
         self.treeview.connect("select-cursor-row", self.__row_selected)
         # Necessary for self.selected_rows to remain sane
@@ -455,7 +462,6 @@ class TableBase(object):
             path = self.filter.convert_child_path_to_path(real_path)
         return path
 
-
     def _realpath(self, visible_path):
         """
         Converts a path (ie. row number) that we get from what the user selects
@@ -473,7 +479,8 @@ class TableBase(object):
         model = self.data
         realpath = self._realpath(Gtk.TreePath.new_from_string(path))
         # User has clicked a checkbox on a selected item.
-        toggleMulti = realpath in self.selected_rows and len(self.selected_rows) > 1
+        toggleMulti = realpath in self.selected_rows and len(
+            self.selected_rows) > 1
         model[realpath][column] = not model[realpath][column]
         if "row-toggled" in self.callbacks:
             self.callbacks["row-toggled"](model[realpath], column)
@@ -639,7 +646,8 @@ class TableBase(object):
             # keep the selection, otherwise, use the new selection
             result = any(index == info[0] for index in indexes)
         if "mouse-event" in self.callbacks:
-            result = self.callbacks["mouse-event"](treeview, event, *args) or result
+            result = self.callbacks["mouse-event"](
+                treeview, event, *args) or result
         return result
 
     def __row_activated_event(self, treeview, data, col):
@@ -705,7 +713,6 @@ class TableBase(object):
 
         cell.set_property("icon-name", icon)
 
-
     def file_pixbuf(self, column, cell, model, iter, data=None):
         icon_name = None
 
@@ -733,9 +740,9 @@ class Table(TableBase):
     """
 
     def __init__(self, treeview, coltypes, colnames, values=[], filters=None,
-            filter_types=None, callbacks={}, flags={}):
+                 filter_types=None, callbacks={}, flags={}):
         TableBase.__init__(self, treeview, coltypes, colnames, values, filters,
-            filter_types, callbacks, flags)
+                           filter_types, callbacks, flags)
 
     def get_store(self, coltypes):
         return Gtk.ListStore(*coltypes)
@@ -770,10 +777,11 @@ class Tree(TableBase):
     See the TableBase documentation for parameter information
 
     """
+
     def __init__(self, treeview, coltypes, colnames, values=[], filters=None,
-            filter_types=None, callbacks={}, flags={}):
+                 filter_types=None, callbacks={}, flags={}):
         TableBase.__init__(self, treeview, coltypes, colnames, values, filters,
-            filter_types, callbacks, flags)
+                           filter_types, callbacks, flags)
 
     def get_store(self, coltypes):
         return Gtk.TreeStore(*coltypes)
@@ -798,10 +806,10 @@ class Box(object):
         ch = [(box.child_get_property(c, "left-attach"),
                box.child_get_property(c, "width")) for c in box.get_children()]
         cv = [(box.child_get_property(c, "top-attach"),
-              box.child_get_property(c, "height")) for c in box.get_children()]
+               box.child_get_property(c, "height")) for c in box.get_children()]
         if ch:
-            ch.sort(key = lambda x: x[0])
-            cv.sort(key = lambda x: x[0])
+            ch.sort(key=lambda x: x[0])
+            cv.sort(key=lambda x: x[0])
             if ch[-1][0] - ch[0][0] > 0:
                 vertical = False
             elif cv[-1][0] - cv[0][0] > 0:
@@ -821,13 +829,16 @@ class Box(object):
         self.attach = lambda child, pos: self.box.attach(child, pos, 0, 1, 1)
         self.set_expand = lambda child, expand: child.set_hexpand(expand)
         self.set_align = lambda child, align: child.set_halign(align)
-        self.set_padding = lambda child, padding: (child.set_margin_start(padding), child.set_margin_end(padding))
+        self.set_padding = lambda child, padding: (
+            child.set_margin_start(padding), child.set_margin_end(padding))
         if vertical:
             self.insert = self.box.insert_row
-            self.attach = lambda child, pos: self.box.attach(child, 0, pos, 1, 1)
+            self.attach = lambda child, pos: self.box.attach(
+                child, 0, pos, 1, 1)
             self.set_expand = lambda child, expand: child.set_vexpand(expand)
             self.set_align = lambda child, align: child.set_valign(align)
-            self.set_padding = lambda child, padding: (child.set_margin_top(padding), child.set_margin_bottom(padding))
+            self.set_padding = lambda child, padding: (
+                child.set_margin_top(padding), child.set_margin_bottom(padding))
 
     def add(self, child):
         if isinstance(child, Box):
@@ -855,6 +866,7 @@ class Box(object):
 
     def __getattr__(self, name):
         return getattr(self.box, name)
+
 
 class ComboBox(object):
     def __init__(self, cb, items=None, columns=1, textcolumn=0):
@@ -912,6 +924,7 @@ class ComboBox(object):
     def set_child_signal(self, signal, callback, userdata=None):
         self.cb.get_child().connect(signal, callback, userdata)
 
+
 class TextView(object):
     def __init__(self, widget=None, value="", spellcheck=True):
         if widget is None:
@@ -948,6 +961,7 @@ class TextView(object):
     @gtk_unsafe
     def append_text(self, text):
         self.buffer.set_text(S(self.get_text() + text).display())
+
 
 class ProgressBar(object):
     def __init__(self, pbar):
@@ -1091,8 +1105,8 @@ class RevisionSelector(object):
     """
 
     def __init__(self, container, client, revision=None,
-            url_combobox=None, url_entry=None, url=None, expand=False,
-            revision_changed_callback=None):
+                 url_combobox=None, url_entry=None, url=None, expand=False,
+                 revision_changed_callback=None):
         """
         @type   container: A Gtk container object (i.e. HBox, VBox, Box)
         @param  container: The container that to add this widget
@@ -1124,11 +1138,12 @@ class RevisionSelector(object):
         self.url = url
         self.revision_changed_callback = revision_changed_callback
         self.revision_change_inprogress = False
-        hbox = Box(spacing = 4)
+        hbox = Box(spacing=4)
         hbox.set_hexpand(expand)
 
         if self.url_combobox:
-            self.url_combobox.cb.connect("changed", self.__on_url_combobox_changed)
+            self.url_combobox.cb.connect(
+                "changed", self.__on_url_combobox_changed)
 
         if client.vcs == rabbitvcs.vcs.VCS_GIT:
             self.OPTIONS = [
@@ -1146,7 +1161,8 @@ class RevisionSelector(object):
 
         self.revision_kind_opt = ComboBox(Gtk.ComboBox(), self.OPTIONS)
         self.revision_kind_opt.set_active(0)
-        self.revision_kind_opt.cb.connect("changed", self.__revision_kind_changed)
+        self.revision_kind_opt.cb.connect(
+            "changed", self.__revision_kind_changed)
         hbox.pack_start(self.revision_kind_opt.cb, False, False, 0)
 
         self.revision_entry = Gtk.Entry()
@@ -1155,13 +1171,14 @@ class RevisionSelector(object):
 
         self.branch_selector = None
         if client.vcs == rabbitvcs.vcs.VCS_GIT:
-            self.branch_selector = GitBranchSelector(hbox, client, self.__branch_selector_changed)
+            self.branch_selector = GitBranchSelector(
+                hbox, client, self.__branch_selector_changed)
             self.branch_selector.hide()
-
 
         self.revision_browse = Gtk.Button()
         revision_browse_image = Gtk.Image()
-        revision_browse_image.set_from_icon_name("edit-find", Gtk.IconSize.MENU)
+        revision_browse_image.set_from_icon_name(
+            "edit-find", Gtk.IconSize.MENU)
         revision_browse_image.show()
         self.revision_browse.add(revision_browse_image)
         self.revision_browse.connect("clicked", self.__revision_browse_clicked)
@@ -1311,6 +1328,7 @@ class RevisionSelector(object):
     def __branch_selector_changed(self, branch):
         self.__revision_entry_changed(self.revision_entry)
 
+
 class KeyValueTable(Gtk.Grid):
     """
     Simple extension of a GTK grid to display a two-column table of information
@@ -1331,12 +1349,12 @@ class KeyValueTable(Gtk.Grid):
             row = 0
 
             for key, value in stuff:
-                label_key = Gtk.Label(label = "<b>%s:</b>" % key)
+                label_key = Gtk.Label(label="<b>%s:</b>" % key)
                 label_key.set_properties(xalign=0, use_markup=True)
 
-                label_value = Gtk.Label(label = "%s" % value)
-                label_value.set_properties(xalign=0,                    \
-                                           ellipsize=Pango.EllipsizeMode.MIDDLE, \
+                label_value = Gtk.Label(label="%s" % value)
+                label_value.set_properties(xalign=0,
+                                           ellipsize=Pango.EllipsizeMode.MIDDLE,
                                            selectable=True)
                 label_value.set_hexpand(True)
                 label_value.set_halign(Gtk.Align.START)
@@ -1352,6 +1370,7 @@ class KeyValueTable(Gtk.Grid):
         self.set_column_spacing(self.default_col_spacing)
         self.set_row_spacing(self.default_row_spacing)
 
+
 class GitRepositorySelector(object):
     def __init__(self, container, git, changed_callback=None):
         self.git = git
@@ -1363,14 +1382,15 @@ class GitRepositorySelector(object):
         grid.set_hexpand(True)
 
         # Set up the Repository Line
-        label = Gtk.Label(label = _("Repository:"))
+        label = Gtk.Label(label=_("Repository:"))
         label.set_justify(Gtk.Justification.LEFT)
         label.set_halign(Gtk.Align.START)
 
         tmp_repos = []
         for item in self.git.remote_list():
             tmp_repos.append(item["name"])
-        self.repository_opt = ComboBox(Gtk.ComboBoxText.new_with_entry(), tmp_repos)
+        self.repository_opt = ComboBox(
+            Gtk.ComboBoxText.new_with_entry(), tmp_repos)
         self.repository_opt.set_active(0)
         self.repository_opt.cb.connect("changed", self.__repository_changed)
         self.repository_opt.cb.set_size_request(175, -1)
@@ -1380,7 +1400,7 @@ class GitRepositorySelector(object):
         grid.attach(self.repository_opt.cb, 1, 0, 1, 1)
 
         # Set up the Branch line
-        label = Gtk.Label(label = _("Branch:"))
+        label = Gtk.Label(label=_("Branch:"))
         label.set_justify(Gtk.Justification.LEFT)
         label.set_halign(Gtk.Align.START)
 
@@ -1395,7 +1415,8 @@ class GitRepositorySelector(object):
 
             index += 1
 
-        self.branch_opt = ComboBox(Gtk.ComboBoxText.new_with_entry(), tmp_branches)
+        self.branch_opt = ComboBox(
+            Gtk.ComboBoxText.new_with_entry(), tmp_branches)
         self.branch_opt.set_active(active_branch_index)
         self.branch_opt.cb.connect("changed", self.__branch_changed)
         self.branch_opt.cb.set_size_request(175, -1)
@@ -1405,7 +1426,7 @@ class GitRepositorySelector(object):
         grid.attach(self.branch_opt.cb, 1, 1, 1, 1)
 
         # Set up the Host line
-        label = Gtk.Label(label = _("Host:"))
+        label = Gtk.Label(label=_("Host:"))
         label.set_justify(Gtk.Justification.LEFT)
         label.set_halign(Gtk.Align.START)
         self.host = Gtk.Label()
@@ -1424,25 +1445,29 @@ class GitRepositorySelector(object):
     def __update_host(self):
         repo = self.repository_opt.get_active_text()
         try:
-            self.host.set_text(S(self.git.config_get(("remote", repo), "url")).display())
+            self.host.set_text(S(self.git.config_get(
+                ("remote", repo), "url")).display())
         except KeyError as e:
             log.error("Missing remote %s config key" % repo)
 
     def __repository_changed(self, repository_opt):
         if self.changed_callback:
-            self.changed_callback(repository_opt.get_active_text(), self.branch_opt.get_active_text())
+            self.changed_callback(
+                repository_opt.get_active_text(), self.branch_opt.get_active_text())
         self.__update_host()
 
     def __branch_changed(self, branch_opt):
         if self.changed_callback:
-            self.changed_callback(self.repository_opt.get_active_text(), self.branch_opt.get_active_text())
+            self.changed_callback(
+                self.repository_opt.get_active_text(), self.branch_opt.get_active_text())
+
 
 class GitBranchSelector(object):
     def __init__(self, container, git, changed_callback=None):
         self.git = git
         self.changed_callback = changed_callback
 
-        self.vbox = Box(vertical = True, spacing = 4)
+        self.vbox = Box(vertical=True, spacing=4)
 
         tmp_branches = []
         active = 0
@@ -1453,7 +1478,8 @@ class GitBranchSelector(object):
                 active = index
             index += 1
 
-        self.branch_opt = ComboBox(Gtk.ComboBoxText.new_with_entry(), tmp_branches)
+        self.branch_opt = ComboBox(
+            Gtk.ComboBoxText.new_with_entry(), tmp_branches)
         self.branch_opt.set_active(active)
         self.branch_opt.cb.connect("changed", self.__branch_changed)
         self.branch_opt.cb.set_size_request(175, -1)
@@ -1479,6 +1505,7 @@ class GitBranchSelector(object):
 
     def hide(self):
         self.vbox.hide()
+
 
 class MultiFileTextEditor(object):
     """
@@ -1507,12 +1534,13 @@ class MultiFileTextEditor(object):
         grid.set_hexpand(True)
         grid.set_vexpand(True)
 
-        combo_label = Gtk.Label(label = label)
+        combo_label = Gtk.Label(label=label)
         combo_label.set_alignment(0, 0.5)
         scrolled_window = Gtk.ScrolledWindow()
         scrolled_window.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
         scrolled_window.add(self.textview.view)
-        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled_window.set_policy(
+            Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scrolled_window.set_size_request(320, 150)
         scrolled_window.set_hexpand(True)
         scrolled_window.set_vexpand(True)
@@ -1521,7 +1549,7 @@ class MultiFileTextEditor(object):
         grid.attach(self.combobox.cb, 1, 0, 2, 1)
 
         if show_add_line:
-            add_label = Gtk.Label(label = _("Add line:"))
+            add_label = Gtk.Label(label=_("Add line:"))
             add_label.set_alignment(0, 0.5)
             self.add_entry = Gtk.Entry()
             self.add_entry.set_text(S(line_content).display())

--- a/rabbitvcs/ui/wraplabel.py
+++ b/rabbitvcs/ui/wraplabel.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from rabbitvcs.util.strings import S
 from gi.repository import Gtk, GObject, Pango
+
 # This file was originally obtained from:
 # http://git.gnome.org/cgit/meld/tree/meld/ui/wraplabel.py
 # ...and added here by Jason
@@ -27,11 +28,12 @@ from gi.repository import Gtk, GObject, Pango
 
 # Python translation from wrapLabel.{cc|h} by Gian Mario Tagliaretti
 import gi
+
 gi.require_version("Gtk", "3.0")
 
 
 class WrapLabel(Gtk.Label):
-    __gtype_name__ = 'WrapLabel'
+    __gtype_name__ = "WrapLabel"
 
     def __init__(self, str=None):
         Gtk.Label.__init__(self)

--- a/rabbitvcs/ui/wraplabel.py
+++ b/rabbitvcs/ui/wraplabel.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from rabbitvcs.util.strings import S
+from gi.repository import Gtk, GObject, Pango
 # This file was originally obtained from:
 # http://git.gnome.org/cgit/meld/tree/meld/ui/wraplabel.py
 # ...and added here by Jason
@@ -26,9 +28,7 @@ from __future__ import absolute_import
 # Python translation from wrapLabel.{cc|h} by Gian Mario Tagliaretti
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GObject, Pango
 
-from rabbitvcs.util.strings import S
 
 class WrapLabel(Gtk.Label):
     __gtype_name__ = 'WrapLabel'

--- a/rabbitvcs/util/__init__.py
+++ b/rabbitvcs/util/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -24,6 +25,7 @@ from __future__ import absolute_import
 from rabbitvcs.util.log import Log
 
 logger = Log("rabbitvcs.util.__init__")
+
 
 class Function(object):
     """
@@ -53,6 +55,7 @@ class Function(object):
 
     def get_result(self):
         return self.result
+
 
 class FunctionQueue(object):
     """

--- a/rabbitvcs/util/_locale.py
+++ b/rabbitvcs/util/_locale.py
@@ -9,13 +9,15 @@ from rabbitvcs import gettext
 
 log = Log("rabbitvcs.util.locale")
 
+
 def get_locale():
     loc = locale.getlocale(locale.LC_MESSAGES)
     if loc[0] is None and loc[1] is None:
-        locale.setlocale(locale.LC_MESSAGES, '')
+        locale.setlocale(locale.LC_MESSAGES, "")
         loc = locale.getlocale(locale.LC_MESSAGES)
         locale.setlocale(locale.LC_MESSAGES, (None, None))
-    return (loc[0] or '', loc[1] or '')
+    return (loc[0] or "", loc[1] or "")
+
 
 def set_locale(language, encoding):
     sane_default = get_locale()
@@ -51,7 +53,8 @@ def set_locale(language, encoding):
     gettext.set_language(langs)
     return loc
 
+
 def initialize_locale():
-    sane_default = locale.getdefaultlocale(['LANG', 'LANGUAGE'])
+    sane_default = locale.getdefaultlocale(["LANG", "LANGUAGE"])
     # Just try to set the default locale for the user
     set_locale(*sane_default)

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -34,12 +35,20 @@ from .contextmenuitems import *
 from rabbitvcs.util import helper
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 sa = helper.SanitizeArgv()
 from gi.repository import Gtk, GLib
+
 sa.restore()
 
-from rabbitvcs.vcs import create_vcs_instance, VCS_SVN, VCS_GIT, VCS_DUMMY, VCS_MERCURIAL
+from rabbitvcs.vcs import (
+    create_vcs_instance,
+    VCS_SVN,
+    VCS_GIT,
+    VCS_DUMMY,
+    VCS_MERCURIAL,
+)
 from rabbitvcs.util.log import Log
 from rabbitvcs import gettext
 from rabbitvcs.util.settings import SettingsManager
@@ -49,6 +58,7 @@ log = Log("rabbitvcs.util.contextmenu")
 _ = gettext.gettext
 
 settings = SettingsManager()
+
 
 class MenuBuilder(object):
     """
@@ -106,12 +116,13 @@ class MenuBuilder(object):
         last_level = -1
         last_item = last_menuitem = None
 
-        stack = [] # ([items], last_item, last_menuitem)
+        stack = []  # ([items], last_item, last_menuitem)
         flat_structure = helper.walk_tree_depth_first(
-                                structure,
-                                show_levels=True,
-                                preprocess=lambda x: x(conditions, callbacks),
-                                filter=lambda x: x.show())
+            structure,
+            show_levels=True,
+            preprocess=lambda x: x(conditions, callbacks),
+            filter=lambda x: x.show(),
+        )
 
         # Here's how this works: we walk the tree, which is a series of (level,
         # MenuItem instance) tuples. We accumulate items in the list in
@@ -140,15 +151,15 @@ class MenuBuilder(object):
             # Have we gone up a level? Save the context and create a submenu
             if level > last_level:
                 # Skip separators at the start of a menu
-                if type(item) == MenuSeparator: continue
+                if type(item) == MenuSeparator:
+                    continue
 
                 stack.append(([], last_item, last_menuitem))
 
                 last_item = last_menuitem = None
 
             # Skip duplicate separators
-            if (type(last_item) == type(item) == MenuSeparator and
-                level == last_level):
+            if type(last_item) == type(item) == MenuSeparator and level == last_level:
                 continue
 
             menuitem = self.make_menu_item(item, index)
@@ -245,7 +256,7 @@ class GtkContextMenuCaller(object):
 
             log.debug("%s" % retval)
 
-            still_going = (retval is None)
+            still_going = retval is None
 
             if not still_going and callable(callback):
                 callback()
@@ -296,8 +307,9 @@ class ContextMenuCallbacks(object):
         window.set_resizable(True)
         window.set_position(Gtk.WindowPosition.CENTER)
         console = PythonConsole(exit, namespace={"extension": self.caller})
-        console.eval("print(\"You can access the extension through "
-                            "'extension'\")", False)
+        console.eval(
+            'print("You can access the extension through ' "'extension'\")", False
+        )
         window.add(console)
         window.show_all()
 
@@ -324,7 +336,13 @@ class ContextMenuCallbacks(object):
     def debug_add_emblem(self, widget, data1=None, data2=None):
         def add_emblem_dialog():
             from subprocess import Popen, PIPE
-            command = ["zenity", "--entry", "--title=RabbitVCS", "--text=Emblem to add:"]
+
+            command = [
+                "zenity",
+                "--entry",
+                "--title=RabbitVCS",
+                "--text=Emblem to add:",
+            ]
             emblem = S(Popen(command, stdout=PIPE).communicate()[0]).replace("\n", "")
 
             rabbitvcs_extension = self.caller
@@ -377,28 +395,26 @@ class ContextMenuCallbacks(object):
     def diff_previous_revision(self, widget, data1=None, data2=None):
         guess = self.vcs_client.guess(self.paths[0])
         if guess["vcs"] == rabbitvcs.vcs.VCS_SVN:
-            previous_revision_number = self.vcs_client.svn().get_revision(self.paths[0]) - 1
+            previous_revision_number = (
+                self.vcs_client.svn().get_revision(self.paths[0]) - 1
+            )
 
-            pathrev1 = helper.create_path_revision_string(self.vcs_client.svn().get_repo_url(self.paths[0]), previous_revision_number)
+            pathrev1 = helper.create_path_revision_string(
+                self.vcs_client.svn().get_repo_url(self.paths[0]),
+                previous_revision_number,
+            )
             pathrev2 = helper.create_path_revision_string(self.paths[0], "working")
 
-            proc = helper.launch_ui_window("diff", [
-                "-s",
-                pathrev1,
-                pathrev2,
-                "--vcs=%s" % rabbitvcs.vcs.VCS_SVN
-            ])
+            proc = helper.launch_ui_window(
+                "diff", ["-s", pathrev1, pathrev2, "--vcs=%s" % rabbitvcs.vcs.VCS_SVN]
+            )
             self.caller.rescan_after_process_exit(proc, self.paths)
 
     def compare_tool(self, widget, data1=None, data2=None):
         pathrev1 = helper.create_path_revision_string(self.paths[0], "base")
         pathrev2 = helper.create_path_revision_string(self.paths[0], "working")
 
-        proc = helper.launch_ui_window("diff", [
-            "-s",
-            pathrev1,
-            pathrev2
-        ])
+        proc = helper.launch_ui_window("diff", ["-s", pathrev1, pathrev2])
         self.caller.rescan_after_process_exit(proc, self.paths)
 
     def compare_tool_multiple(self, widget, data1=None, data2=None):
@@ -408,17 +424,19 @@ class ContextMenuCallbacks(object):
     def compare_tool_previous_revision(self, widget, data1=None, data2=None):
         guess = self.vcs_client.guess(self.paths[0])
         if guess["vcs"] == rabbitvcs.vcs.VCS_SVN:
-            previous_revision_number = self.vcs_client.svn().get_revision(self.paths[0]) - 1
+            previous_revision_number = (
+                self.vcs_client.svn().get_revision(self.paths[0]) - 1
+            )
 
-            pathrev1 = helper.create_path_revision_string(self.vcs_client.svn().get_repo_url(self.paths[0]), previous_revision_number)
+            pathrev1 = helper.create_path_revision_string(
+                self.vcs_client.svn().get_repo_url(self.paths[0]),
+                previous_revision_number,
+            )
             pathrev2 = helper.create_path_revision_string(self.paths[0], "working")
 
-            proc = helper.launch_ui_window("diff", [
-                "-s",
-                pathrev1,
-                pathrev2,
-                "--vcs=%s" % rabbitvcs.vcs.VCS_SVN
-            ])
+            proc = helper.launch_ui_window(
+                "diff", ["-s", pathrev1, pathrev2, "--vcs=%s" % rabbitvcs.vcs.VCS_SVN]
+            )
             self.caller.rescan_after_process_exit(proc, self.paths)
 
     def show_changes(self, widget, data1=None, data2=None):
@@ -538,7 +556,9 @@ class ContextMenuCallbacks(object):
         if guess["vcs"] == rabbitvcs.vcs.VCS_SVN:
             proc = helper.launch_ui_window("update", self.paths)
         elif guess["vcs"] == rabbitvcs.vcs.VCS_GIT:
-            proc = helper.launch_ui_window("checkout", ["-q", "--vcs", "git"] + self.paths)
+            proc = helper.launch_ui_window(
+                "checkout", ["-q", "--vcs", "git"] + self.paths
+            )
 
         self.caller.rescan_after_process_exit(proc, self.paths)
 
@@ -595,6 +615,7 @@ class ContextMenuCallbacks(object):
         proc = helper.launch_ui_window("editconflicts", [self.paths[0]])
         self.caller.rescan_after_process_exit(proc, [self.paths[0]])
 
+
 class ContextMenuConditions(object):
     """
     Provides a standard interface to checking conditions for menu items.
@@ -604,44 +625,56 @@ class ContextMenuConditions(object):
     should be called.
 
     """
+
     def __init__(self):
         pass
 
     def generate_path_dict(self, paths):
-        self.path_dict = {
-            "length": len(paths)
-        }
+        self.path_dict = {"length": len(paths)}
 
         checks = {
-            "is_svn"                        : lambda path: (self.vcs_client.guess(path)["vcs"] == VCS_SVN),
-            "is_git"                        : lambda path: (self.vcs_client.guess(path)["vcs"] == VCS_GIT),
-            "is_mercurial"                  : lambda path: (self.vcs_client.guess(path)["vcs"] == VCS_MERCURIAL),
-            "is_dir"                        : os.path.isdir,
-            "is_file"                       : os.path.isfile,
-            "exists"                        : os.path.exists,
-            "is_working_copy"               : self.vcs_client.is_working_copy,
-            "is_in_a_or_a_working_copy"     : self.vcs_client.is_in_a_or_a_working_copy,
-            "is_versioned"                  : self.vcs_client.is_versioned,
-            "is_normal"                     : lambda path: self.statuses[path].simple_content_status() == "unchanged" and self.statuses[path].simple_metadata_status() == "normal",
-            "is_added"                      : lambda path: self.statuses[path].simple_content_status() == "added",
-            "is_modified"                   : lambda path: self.statuses[path].simple_content_status() == "modified" or self.statuses[path].simple_metadata_status() == "modified",
-            "is_deleted"                    : lambda path: self.statuses[path].simple_content_status() == "deleted",
-            "is_ignored"                    : lambda path: self.statuses[path].simple_content_status() == "ignored",
-            "is_locked"                     : self.vcs_client.is_locked,
-            "is_missing"                    : lambda path: self.statuses[path].simple_content_status() == "missing",
-            "is_conflicted"                 : lambda path: self.statuses[path].simple_content_status() == "complicated",
-            "is_obstructed"                 : lambda path: self.statuses[path].simple_content_status() == "obstructed",
-            "has_unversioned"               : lambda path: "unversioned" in self.text_statuses,
-            "has_added"                     : lambda path: "added" in self.text_statuses,
-            "has_modified"                  : lambda path: "modified" in self.text_statuses or "modified" in self.prop_statuses,
-            "has_deleted"                   : lambda path: "deleted" in self.text_statuses,
-            "has_ignored"                   : lambda path: "ignored" in self.text_statuses,
-            "has_missing"                   : lambda path: "missing" in self.text_statuses,
-            "has_conflicted"                : lambda path: "complicated" in self.text_statuses,
-            "has_obstructed"                : lambda path: "obstructed" in self.text_statuses
+            "is_svn": lambda path: (self.vcs_client.guess(path)["vcs"] == VCS_SVN),
+            "is_git": lambda path: (self.vcs_client.guess(path)["vcs"] == VCS_GIT),
+            "is_mercurial": lambda path: (
+                self.vcs_client.guess(path)["vcs"] == VCS_MERCURIAL
+            ),
+            "is_dir": os.path.isdir,
+            "is_file": os.path.isfile,
+            "exists": os.path.exists,
+            "is_working_copy": self.vcs_client.is_working_copy,
+            "is_in_a_or_a_working_copy": self.vcs_client.is_in_a_or_a_working_copy,
+            "is_versioned": self.vcs_client.is_versioned,
+            "is_normal": lambda path: self.statuses[path].simple_content_status()
+            == "unchanged"
+            and self.statuses[path].simple_metadata_status() == "normal",
+            "is_added": lambda path: self.statuses[path].simple_content_status()
+            == "added",
+            "is_modified": lambda path: self.statuses[path].simple_content_status()
+            == "modified"
+            or self.statuses[path].simple_metadata_status() == "modified",
+            "is_deleted": lambda path: self.statuses[path].simple_content_status()
+            == "deleted",
+            "is_ignored": lambda path: self.statuses[path].simple_content_status()
+            == "ignored",
+            "is_locked": self.vcs_client.is_locked,
+            "is_missing": lambda path: self.statuses[path].simple_content_status()
+            == "missing",
+            "is_conflicted": lambda path: self.statuses[path].simple_content_status()
+            == "complicated",
+            "is_obstructed": lambda path: self.statuses[path].simple_content_status()
+            == "obstructed",
+            "has_unversioned": lambda path: "unversioned" in self.text_statuses,
+            "has_added": lambda path: "added" in self.text_statuses,
+            "has_modified": lambda path: "modified" in self.text_statuses
+            or "modified" in self.prop_statuses,
+            "has_deleted": lambda path: "deleted" in self.text_statuses,
+            "has_ignored": lambda path: "ignored" in self.text_statuses,
+            "has_missing": lambda path: "missing" in self.text_statuses,
+            "has_conflicted": lambda path: "complicated" in self.text_statuses,
+            "has_obstructed": lambda path: "obstructed" in self.text_statuses,
         }
 
-        for key,func in list(checks.items()):
+        for key, func in list(checks.items()):
             self.path_dict[key] = False
 
         # Each path gets tested for each check
@@ -656,28 +689,39 @@ class ContextMenuConditions(object):
     def checkout(self, data=None):
         if self.path_dict["length"] == 1:
             if self.path_dict["is_git"]:
-                return (self.path_dict["is_in_a_or_a_working_copy"] and
-                    self.path_dict["is_versioned"])
+                return (
+                    self.path_dict["is_in_a_or_a_working_copy"]
+                    and self.path_dict["is_versioned"]
+                )
             else:
-                return (self.path_dict["is_dir"] and
-                        not self.path_dict["is_working_copy"])
+                return (
+                    self.path_dict["is_dir"] and not self.path_dict["is_working_copy"]
+                )
 
         return False
 
     def update(self, data=None):
-        return (self.path_dict["is_in_a_or_a_working_copy"] and
-                self.path_dict["is_versioned"] and
-                not self.path_dict["is_added"])
+        return (
+            self.path_dict["is_in_a_or_a_working_copy"]
+            and self.path_dict["is_versioned"]
+            and not self.path_dict["is_added"]
+        )
 
     def commit(self, data=None):
-        if self.path_dict["is_svn"] or self.path_dict["is_git"] or self.path_dict["is_mercurial"]:
+        if (
+            self.path_dict["is_svn"]
+            or self.path_dict["is_git"]
+            or self.path_dict["is_mercurial"]
+        ):
             if self.path_dict["is_in_a_or_a_working_copy"]:
-                if (self.path_dict["is_added"] or
-                        self.path_dict["is_modified"] or
-                        self.path_dict["is_deleted"] or
-                        not self.path_dict["is_versioned"]):
+                if (
+                    self.path_dict["is_added"]
+                    or self.path_dict["is_modified"]
+                    or self.path_dict["is_deleted"]
+                    or not self.path_dict["is_versioned"]
+                ):
                     return True
-                elif (self.path_dict["is_dir"]):
+                elif self.path_dict["is_dir"]:
                     return True
         return False
 
@@ -685,127 +729,164 @@ class ContextMenuConditions(object):
         return self.path_dict["is_in_a_or_a_working_copy"]
 
     def diff_multiple(self, data=None):
-        if (self.path_dict["length"] == 2 and
-                self.path_dict["is_versioned"] and
-                self.path_dict["is_in_a_or_a_working_copy"]):
+        if (
+            self.path_dict["length"] == 2
+            and self.path_dict["is_versioned"]
+            and self.path_dict["is_in_a_or_a_working_copy"]
+        ):
             return True
         return False
 
     def compare_tool_multiple(self, data=None):
-        if (self.path_dict["length"] == 2 and
-                self.path_dict["is_versioned"] and
-                self.path_dict["is_in_a_or_a_working_copy"]):
+        if (
+            self.path_dict["length"] == 2
+            and self.path_dict["is_versioned"]
+            and self.path_dict["is_in_a_or_a_working_copy"]
+        ):
             return True
         return False
 
     def diff(self, data=None):
-        if (self.path_dict["length"] == 1 and
-                self.path_dict["is_in_a_or_a_working_copy"] and
-                (self.path_dict["is_modified"] or self.path_dict["has_modified"] or
-                self.path_dict["is_conflicted"] or self.path_dict["has_conflicted"])):
+        if (
+            self.path_dict["length"] == 1
+            and self.path_dict["is_in_a_or_a_working_copy"]
+            and (
+                self.path_dict["is_modified"]
+                or self.path_dict["has_modified"]
+                or self.path_dict["is_conflicted"]
+                or self.path_dict["has_conflicted"]
+            )
+        ):
             return True
         return False
 
     def diff_previous_revision(self, data=None):
-        if (self.path_dict["is_svn"] and
-                self.path_dict["length"] == 1 and
-                self.path_dict["is_in_a_or_a_working_copy"]):
+        if (
+            self.path_dict["is_svn"]
+            and self.path_dict["length"] == 1
+            and self.path_dict["is_in_a_or_a_working_copy"]
+        ):
             return True
         return False
 
     def compare_tool(self, data=None):
-        if (self.path_dict["length"] == 1 and
-                self.path_dict["is_in_a_or_a_working_copy"] and
-                (self.path_dict["is_modified"] or self.path_dict["has_modified"] or
-                self.path_dict["is_conflicted"] or self.path_dict["has_conflicted"])):
+        if (
+            self.path_dict["length"] == 1
+            and self.path_dict["is_in_a_or_a_working_copy"]
+            and (
+                self.path_dict["is_modified"]
+                or self.path_dict["has_modified"]
+                or self.path_dict["is_conflicted"]
+                or self.path_dict["has_conflicted"]
+            )
+        ):
             return True
         return False
 
     def compare_tool_previous_revision(self, data=None):
-        if (self.path_dict["is_svn"] and
-                self.path_dict["length"] == 1 and
-                self.path_dict["is_in_a_or_a_working_copy"]):
+        if (
+            self.path_dict["is_svn"]
+            and self.path_dict["length"] == 1
+            and self.path_dict["is_in_a_or_a_working_copy"]
+        ):
             return True
         return False
 
     def show_changes(self, data=None):
-        return (self.path_dict["is_in_a_or_a_working_copy"] and
-            self.path_dict["is_versioned"] and
-            self.path_dict["length"] in (1,2))
+        return (
+            self.path_dict["is_in_a_or_a_working_copy"]
+            and self.path_dict["is_versioned"]
+            and self.path_dict["length"] in (1, 2)
+        )
 
     def show_log(self, data=None):
-        return (self.path_dict["length"] == 1 and
-                self.path_dict["is_in_a_or_a_working_copy"] and
-                self.path_dict["is_versioned"] and
-                not self.path_dict["is_added"])
+        return (
+            self.path_dict["length"] == 1
+            and self.path_dict["is_in_a_or_a_working_copy"]
+            and self.path_dict["is_versioned"]
+            and not self.path_dict["is_added"]
+        )
 
     def add(self, data=None):
         if not self.path_dict["is_svn"]:
             return False
 
-        if (self.path_dict["is_dir"] and
-                self.path_dict["is_in_a_or_a_working_copy"]):
+        if self.path_dict["is_dir"] and self.path_dict["is_in_a_or_a_working_copy"]:
             return True
-        elif (not self.path_dict["is_dir"] and
-                self.path_dict["is_in_a_or_a_working_copy"] and
-                not self.path_dict["is_versioned"]):
+        elif (
+            not self.path_dict["is_dir"]
+            and self.path_dict["is_in_a_or_a_working_copy"]
+            and not self.path_dict["is_versioned"]
+        ):
             return True
         return False
 
     def check_for_modifications(self, data=None):
-        return (self.path_dict["is_working_copy"] or
-            self.path_dict["is_versioned"])
+        return self.path_dict["is_working_copy"] or self.path_dict["is_versioned"]
 
     def rename(self, data=None):
-        return (self.path_dict["length"] == 1 and
-                self.path_dict["is_in_a_or_a_working_copy"] and
-                not self.path_dict["is_working_copy"] and
-                self.path_dict["is_versioned"])
+        return (
+            self.path_dict["length"] == 1
+            and self.path_dict["is_in_a_or_a_working_copy"]
+            and not self.path_dict["is_working_copy"]
+            and self.path_dict["is_versioned"]
+        )
 
     def delete(self, data=None):
-        return (self.path_dict["exists"] or self.path_dict["is_versioned"]) and \
-            not self.path_dict["is_deleted"]
+        return (
+            self.path_dict["exists"] or self.path_dict["is_versioned"]
+        ) and not self.path_dict["is_deleted"]
 
     def revert(self, data=None):
         if self.path_dict["is_in_a_or_a_working_copy"]:
-            if (self.path_dict["is_added"] or
-                    self.path_dict["is_modified"] or
-                    self.path_dict["is_deleted"]):
+            if (
+                self.path_dict["is_added"]
+                or self.path_dict["is_modified"]
+                or self.path_dict["is_deleted"]
+            ):
                 return True
             else:
-                if (self.path_dict["is_dir"] and
-                        (self.path_dict["has_added"] or
-                        self.path_dict["has_modified"] or
-                        self.path_dict["has_deleted"] or
-                        self.path_dict["has_missing"])):
+                if self.path_dict["is_dir"] and (
+                    self.path_dict["has_added"]
+                    or self.path_dict["has_modified"]
+                    or self.path_dict["has_deleted"]
+                    or self.path_dict["has_missing"]
+                ):
                     return True
         return False
 
     def annotate(self, data=None):
-        return (self.path_dict["length"] == 1 and
-                not self.path_dict["is_dir"] and
-                self.path_dict["is_in_a_or_a_working_copy"] and
-                self.path_dict["is_versioned"] and
-                not self.path_dict["is_added"])
+        return (
+            self.path_dict["length"] == 1
+            and not self.path_dict["is_dir"]
+            and self.path_dict["is_in_a_or_a_working_copy"]
+            and self.path_dict["is_versioned"]
+            and not self.path_dict["is_added"]
+        )
 
     def properties(self, data=None):
-        return (self.path_dict["length"] == 1 and
-                self.path_dict["is_in_a_or_a_working_copy"] and
-                self.path_dict["is_versioned"])
+        return (
+            self.path_dict["length"] == 1
+            and self.path_dict["is_in_a_or_a_working_copy"]
+            and self.path_dict["is_versioned"]
+        )
 
     def create_patch(self, data=None):
         if self.path_dict["is_in_a_or_a_working_copy"]:
-            if (self.path_dict["is_added"] or
-                    self.path_dict["is_modified"] or
-                    self.path_dict["is_deleted"] or
-                    not self.path_dict["is_versioned"]):
+            if (
+                self.path_dict["is_added"]
+                or self.path_dict["is_modified"]
+                or self.path_dict["is_deleted"]
+                or not self.path_dict["is_versioned"]
+            ):
                 return True
-            elif (self.path_dict["is_dir"] and
-                    (self.path_dict["has_added"] or
-                    self.path_dict["has_modified"] or
-                    self.path_dict["has_deleted"] or
-                    self.path_dict["has_unversioned"] or
-                    self.path_dict["has_missing"])):
+            elif self.path_dict["is_dir"] and (
+                self.path_dict["has_added"]
+                or self.path_dict["has_modified"]
+                or self.path_dict["has_deleted"]
+                or self.path_dict["has_unversioned"]
+                or self.path_dict["has_missing"]
+            ):
                 return True
         return False
 
@@ -815,16 +896,22 @@ class ContextMenuConditions(object):
         return False
 
     def add_to_ignore_list(self, data=None):
-        return (self.path_dict["is_in_a_or_a_working_copy"] and
-                not self.path_dict["is_versioned"])
+        return (
+            self.path_dict["is_in_a_or_a_working_copy"]
+            and not self.path_dict["is_versioned"]
+        )
 
     def ignore_by_filename(self, *args):
-        return (self.path_dict["is_in_a_or_a_working_copy"] and
-                not self.path_dict["is_versioned"])
+        return (
+            self.path_dict["is_in_a_or_a_working_copy"]
+            and not self.path_dict["is_versioned"]
+        )
 
     def ignore_by_file_extension(self, *args):
-        return (self.path_dict["is_in_a_or_a_working_copy"] and
-                not self.path_dict["is_versioned"])
+        return (
+            self.path_dict["is_in_a_or_a_working_copy"]
+            and not self.path_dict["is_versioned"]
+        )
 
     def refresh_status(self, data=None):
         return True
@@ -845,11 +932,13 @@ class ContextMenuConditions(object):
         return self.path_dict["is_versioned"]
 
     def _import(self, data=None):
-        return (self.path_dict["length"] == 1 and
-                not self.path_dict["is_in_a_or_a_working_copy"])
+        return (
+            self.path_dict["length"] == 1
+            and not self.path_dict["is_in_a_or_a_working_copy"]
+        )
 
     def export(self, data=None):
-        return (self.path_dict["length"] == 1)
+        return self.path_dict["length"] == 1
 
     def svn_export(self, data=None):
         return self.export(data)
@@ -858,23 +947,31 @@ class ContextMenuConditions(object):
         return self.export(data)
 
     def update_to_revision(self, data=None):
-        return (self.path_dict["length"] == 1 and
-                self.path_dict["is_versioned"] and
-                self.path_dict["is_in_a_or_a_working_copy"])
+        return (
+            self.path_dict["length"] == 1
+            and self.path_dict["is_versioned"]
+            and self.path_dict["is_in_a_or_a_working_copy"]
+        )
 
     def mark_resolved(self, data=None):
-        return (self.path_dict["is_in_a_or_a_working_copy"] and
-                self.path_dict["is_versioned"] and
-                self.path_dict["is_conflicted"])
+        return (
+            self.path_dict["is_in_a_or_a_working_copy"]
+            and self.path_dict["is_versioned"]
+            and self.path_dict["is_conflicted"]
+        )
 
     def create_repository(self, data=None):
-        return (self.path_dict["length"] == 1 and
-                not self.path_dict["is_in_a_or_a_working_copy"])
+        return (
+            self.path_dict["length"] == 1
+            and not self.path_dict["is_in_a_or_a_working_copy"]
+        )
 
     def unlock(self, data=None):
-        return (self.path_dict["is_in_a_or_a_working_copy"] and
-                self.path_dict["is_versioned"] and
-                (self.path_dict["is_dir"] or self.path_dict["is_locked"]))
+        return (
+            self.path_dict["is_in_a_or_a_working_copy"]
+            and self.path_dict["is_versioned"]
+            and (self.path_dict["is_dir"] or self.path_dict["is_locked"])
+        )
 
     def cleanup(self, data=None):
         return self.path_dict["is_versioned"]
@@ -889,9 +986,11 @@ class ContextMenuConditions(object):
         return self.path_dict["has_missing"]
 
     def update(self, data=None):
-        return (self.path_dict["is_in_a_or_a_working_copy"] and
-                self.path_dict["is_versioned"] and
-                not self.path_dict["is_added"])
+        return (
+            self.path_dict["is_in_a_or_a_working_copy"]
+            and self.path_dict["is_versioned"]
+            and not self.path_dict["is_added"]
+        )
 
     def repo_browser(self, data=None):
         return True
@@ -900,16 +999,20 @@ class ContextMenuConditions(object):
         return False
 
     def rabbitvcs_svn(self, data=None):
-        return (self.path_dict["is_svn"] or
-            not self.path_dict["is_in_a_or_a_working_copy"])
+        return (
+            self.path_dict["is_svn"] or not self.path_dict["is_in_a_or_a_working_copy"]
+        )
 
     def rabbitvcs_git(self, data=None):
-        return (self.path_dict["is_git"] or
-            not self.path_dict["is_in_a_or_a_working_copy"])
+        return (
+            self.path_dict["is_git"] or not self.path_dict["is_in_a_or_a_working_copy"]
+        )
 
     def rabbitvcs_mercurial(self, data=None):
-        return (self.path_dict["is_mercurial"] or
-            not self.path_dict["is_in_a_or_a_working_copy"])
+        return (
+            self.path_dict["is_mercurial"]
+            or not self.path_dict["is_in_a_or_a_working_copy"]
+        )
 
     def debug(self, data=None):
         return settings.get("general", "show_debug")
@@ -930,63 +1033,71 @@ class ContextMenuConditions(object):
         return True
 
     def initialize_repository(self, data=None):
-        return (self.path_dict["is_dir"] and
-            not self.path_dict["is_in_a_or_a_working_copy"])
+        return (
+            self.path_dict["is_dir"] and not self.path_dict["is_in_a_or_a_working_copy"]
+        )
 
     def clone(self, data=None):
-        return (self.path_dict["is_dir"] and
-            not self.path_dict["is_in_a_or_a_working_copy"])
+        return (
+            self.path_dict["is_dir"] and not self.path_dict["is_in_a_or_a_working_copy"]
+        )
 
     def push(self, data=None):
-        return (self.path_dict["is_git"] or self.path_dict["is_mercurial"])
+        return self.path_dict["is_git"] or self.path_dict["is_mercurial"]
 
     def branches(self, data=None):
-        return (self.path_dict["is_git"])
+        return self.path_dict["is_git"]
 
     def tags(self, data=None):
-        return (self.path_dict["is_git"])
+        return self.path_dict["is_git"]
 
     def remotes(self, data=None):
-        return (self.path_dict["is_git"])
+        return self.path_dict["is_git"]
 
     def clean(self, data=None):
-        return (self.path_dict["is_git"])
+        return self.path_dict["is_git"]
 
     def reset(self, data=None):
-        return (self.path_dict["is_git"])
+        return self.path_dict["is_git"]
 
     def stage(self, data=None):
         if self.path_dict["is_git"]:
-            if (self.path_dict["is_dir"] and
-                    self.path_dict["is_in_a_or_a_working_copy"]):
+            if self.path_dict["is_dir"] and self.path_dict["is_in_a_or_a_working_copy"]:
                 return True
-            elif (not self.path_dict["is_dir"] and
-                    self.path_dict["is_in_a_or_a_working_copy"] and
-                    not self.path_dict["is_versioned"]):
+            elif (
+                not self.path_dict["is_dir"]
+                and self.path_dict["is_in_a_or_a_working_copy"]
+                and not self.path_dict["is_versioned"]
+            ):
                 return True
         return False
 
     def unstage(self, data=None):
         if self.path_dict["is_git"]:
-            if (self.path_dict["is_dir"] and
-                    self.path_dict["is_in_a_or_a_working_copy"]):
+            if self.path_dict["is_dir"] and self.path_dict["is_in_a_or_a_working_copy"]:
                 return True
-            elif (not self.path_dict["is_dir"] and
-                    self.path_dict["is_in_a_or_a_working_copy"] and
-                    self.path_dict["is_added"]):
+            elif (
+                not self.path_dict["is_dir"]
+                and self.path_dict["is_in_a_or_a_working_copy"]
+                and self.path_dict["is_added"]
+            ):
                 return True
         return False
 
     def edit_conflicts(self, data=None):
-        return (self.path_dict["is_in_a_or_a_working_copy"] and
-                self.path_dict["is_versioned"] and
-                self.path_dict["is_conflicted"])
+        return (
+            self.path_dict["is_in_a_or_a_working_copy"]
+            and self.path_dict["is_versioned"]
+            and self.path_dict["is_conflicted"]
+        )
+
 
 class GtkFilesContextMenuCallbacks(ContextMenuCallbacks):
     """
     A callback class created for GtkFilesContextMenus.  This class inherits from
     the standard ContextMenuCallbacks class and overrides some methods.
     """
+
     def __init__(self, caller, base_dir, vcs_client, paths=[]):
         """
         @param  caller: The calling object
@@ -1048,6 +1159,7 @@ class GtkFilesContextMenuCallbacks(ContextMenuCallbacks):
         proc = helper.launch_ui_window("unstage", ["-q"] + self.paths)
         self.caller.rescan_after_process_exit(proc, self.paths)
 
+
 class GtkFilesContextMenuConditions(ContextMenuConditions):
     """
     Sub-class for ContextMenuConditions for our dialogs.  Allows us to override
@@ -1055,6 +1167,7 @@ class GtkFilesContextMenuConditions(ContextMenuConditions):
     to the dialogs.
 
     """
+
     def __init__(self, vcs_client, paths=[]):
         """
         @param  vcs_client: The vcs client to be used
@@ -1081,16 +1194,25 @@ class GtkFilesContextMenuConditions(ContextMenuConditions):
             for status in statuses_tmp:
                 self.statuses[status.path] = status
 
-        self.text_statuses = [self.statuses[key].simple_content_status() for key in list(self.statuses.keys())]
-        self.prop_statuses = [self.statuses[key].simple_metadata_status() for key in list(self.statuses.keys())]
+        self.text_statuses = [
+            self.statuses[key].simple_content_status()
+            for key in list(self.statuses.keys())
+        ]
+        self.prop_statuses = [
+            self.statuses[key].simple_metadata_status()
+            for key in list(self.statuses.keys())
+        ]
+
 
 class GtkFilesContextMenu(object):
     """
     Defines context menu items for a table with files
 
     """
-    def __init__(self, caller, event, base_dir, paths=[],
-            conditions=None, callbacks=None):
+
+    def __init__(
+        self, caller, event, base_dir, paths=[], conditions=None, callbacks=None
+    ):
         """
         @param  caller: The calling object
         @type   caller: RabbitVCS extension
@@ -1121,10 +1243,7 @@ class GtkFilesContextMenu(object):
         self.callbacks = callbacks
         if self.callbacks is None:
             self.callbacks = GtkFilesContextMenuCallbacks(
-                self.caller,
-                self.base_dir,
-                self.vcs_client,
-                paths
+                self.caller, self.base_dir, self.vcs_client, paths
             )
 
         ignore_items = get_ignore_list_items(paths)
@@ -1148,7 +1267,7 @@ class GtkFilesContextMenu(object):
             (MenuAdd, None),
             (MenuStage, None),
             (MenuUnstage, None),
-            (MenuAddToIgnoreList, ignore_items)
+            (MenuAddToIgnoreList, ignore_items),
         ]
 
     def show(self):
@@ -1162,12 +1281,14 @@ class GtkFilesContextMenu(object):
         context_menu = GtkContextMenu(self.structure, self.conditions, self.callbacks)
         return context_menu.menu
 
+
 class MainContextMenuCallbacks(ContextMenuCallbacks):
     """
     The callback class used for the main context menu.  This inherits from
     and overrides the ContextMenuCallbacks class.
 
     """
+
     def __init__(self, caller, base_dir, vcs_client, paths=[]):
         """
         @param  caller: The calling object
@@ -1185,6 +1306,7 @@ class MainContextMenuCallbacks(ContextMenuCallbacks):
         """
         ContextMenuCallbacks.__init__(self, caller, base_dir, vcs_client, paths)
 
+
 class MainContextMenuConditions(ContextMenuConditions):
     """
     Sub-class for ContextMenuConditions used for file manager extensions.
@@ -1192,6 +1314,7 @@ class MainContextMenuConditions(ContextMenuConditions):
     more suitable to the dialogs.
 
     """
+
     def __init__(self, vcs_client, paths=[]):
         """
         @param  vcs_client: The vcs client to be used
@@ -1220,16 +1343,23 @@ class MainContextMenuConditions(ContextMenuConditions):
             for status in statuses_tmp:
                 self.statuses[status.path] = status
 
-        self.text_statuses = [self.statuses[key].simple_content_status() for key in list(self.statuses.keys())]
-        self.prop_statuses = [self.statuses[key].simple_metadata_status() for key in list(self.statuses.keys())]
+        self.text_statuses = [
+            self.statuses[key].simple_content_status()
+            for key in list(self.statuses.keys())
+        ]
+        self.prop_statuses = [
+            self.statuses[key].simple_metadata_status()
+            for key in list(self.statuses.keys())
+        ]
+
 
 class MainContextMenu(object):
     """
     Defines and composes the main context menu.
 
     """
-    def __init__(self, caller, base_dir, paths=[],
-            conditions=None, callbacks=None):
+
+    def __init__(self, caller, base_dir, paths=[], conditions=None, callbacks=None):
         """
         @param  caller: The calling object
         @type   caller: RabbitVCS extension
@@ -1259,10 +1389,7 @@ class MainContextMenu(object):
         self.callbacks = callbacks
         if self.callbacks is None:
             self.callbacks = MainContextMenuCallbacks(
-                self.caller,
-                self.base_dir,
-                self.vcs_client,
-                paths
+                self.caller, self.base_dir, self.vcs_client, paths
             )
 
         ignore_items = get_ignore_list_items(paths)
@@ -1271,111 +1398,131 @@ class MainContextMenu(object):
         # ContextMenuItems item.  The second element is either None when there
         # is no submenu, or a recursive list of tuples for desired submenus.
         self.structure = [
-            (MenuDebug, [
-                (MenuBugs, None),
-                (MenuPythonConsole, None),
-                (MenuRefreshStatus, None),
-                (MenuDebugRevert, None),
-                (MenuDebugInvalidate, None),
-                (MenuDebugAddEmblem, None)
-            ]),
+            (
+                MenuDebug,
+                [
+                    (MenuBugs, None),
+                    (MenuPythonConsole, None),
+                    (MenuRefreshStatus, None),
+                    (MenuDebugRevert, None),
+                    (MenuDebugInvalidate, None),
+                    (MenuDebugAddEmblem, None),
+                ],
+            ),
             (MenuUpdate, None),
             (MenuCommit, None),
             (MenuPush, None),
-            None if settings.get("HideItem", "svn") else (MenuRabbitVCSSvn, [
-                (MenuCheckout, None),
-                (MenuDiffMenu, [
-                    (MenuDiff, None),
-                    (MenuDiffPrevRev, None),
-                    (MenuDiffMultiple, None),
-                    (MenuCompareTool, None),
-                    (MenuCompareToolPrevRev, None),
-                    (MenuCompareToolMultiple, None),
-                    (MenuShowChanges, None),
-                ]),
-                (MenuShowLog, None),
-                (MenuRepoBrowser, None),
-                (MenuCheckForModifications, None),
-                (MenuSeparator, None),
-                (MenuAdd, None),
-                (MenuAddToIgnoreList, ignore_items),
-                (MenuSeparator, None),
-                (MenuUpdateToRevision, None),
-                (MenuRename, None),
-                (MenuDelete, None),
-                (MenuRevert, None),
-                (MenuEditConflicts, None),
-                (MenuMarkResolved, None),
-                (MenuRelocate, None),
-                (MenuGetLock, None),
-                (MenuUnlock, None),
-                (MenuCleanup, None),
-                (MenuSeparator, None),
-                (MenuSVNExport, None),
-                (MenuCreateRepository, None),
-                (MenuImport, None),
-                (MenuSeparator, None),
-                (MenuBranchTag, None),
-                (MenuSwitch, None),
-                (MenuMerge, None),
-                (MenuSeparator, None),
-                (MenuAnnotate, None),
-                (MenuSeparator, None),
-                (MenuCreatePatch, None),
-                (MenuApplyPatch, None),
-                (MenuProperties, None),
-                (MenuSeparator, None),
-                (MenuSettings, None),
-                (MenuAbout, None)
-            ]),
-            None if settings.get("HideItem", "git") else (MenuRabbitVCSGit, [
-                (MenuClone, None),
-                (MenuInitializeRepository, None),
-                (MenuSeparator, None),
-                (MenuDiffMenu, [
-                    (MenuDiff, None),
-                    (MenuDiffPrevRev, None),
-                    (MenuDiffMultiple, None),
-                    (MenuCompareTool, None),
-                    (MenuCompareToolPrevRev, None),
-                    (MenuCompareToolMultiple, None),
-                    (MenuShowChanges, None),
-                ]),
-                (MenuShowLog, None),
-                (MenuStage, None),
-                (MenuUnstage, None),
-                (MenuAddToIgnoreList, ignore_items),
-                (MenuSeparator, None),
-                (MenuRename, None),
-                (MenuDelete, None),
-                (MenuRevert, None),
-                (MenuClean, None),
-                (MenuReset, None),
-                (MenuCheckout, None),
-                (MenuSeparator, None),
-                (MenuBranches, None),
-                (MenuTags, None),
-                (MenuRemotes, None),
-                (MenuSeparator, None),
-                (MenuGitExport, None),
-                (MenuMerge, None),
-                (MenuSeparator, None),
-                (MenuAnnotate, None),
-                (MenuSeparator, None),
-                (MenuCreatePatch, None),
-                (MenuApplyPatch, None),
-                (MenuSeparator, None),
-                (MenuSettings, None),
-                (MenuAbout, None)
-            ]),
-            None if settings.get("HideItem", "hg") else (MenuRabbitVCSMercurial, [
-                (MenuSettings, None),
-                (MenuAbout, None)
-            ])
+            None
+            if settings.get("HideItem", "svn")
+            else (
+                MenuRabbitVCSSvn,
+                [
+                    (MenuCheckout, None),
+                    (
+                        MenuDiffMenu,
+                        [
+                            (MenuDiff, None),
+                            (MenuDiffPrevRev, None),
+                            (MenuDiffMultiple, None),
+                            (MenuCompareTool, None),
+                            (MenuCompareToolPrevRev, None),
+                            (MenuCompareToolMultiple, None),
+                            (MenuShowChanges, None),
+                        ],
+                    ),
+                    (MenuShowLog, None),
+                    (MenuRepoBrowser, None),
+                    (MenuCheckForModifications, None),
+                    (MenuSeparator, None),
+                    (MenuAdd, None),
+                    (MenuAddToIgnoreList, ignore_items),
+                    (MenuSeparator, None),
+                    (MenuUpdateToRevision, None),
+                    (MenuRename, None),
+                    (MenuDelete, None),
+                    (MenuRevert, None),
+                    (MenuEditConflicts, None),
+                    (MenuMarkResolved, None),
+                    (MenuRelocate, None),
+                    (MenuGetLock, None),
+                    (MenuUnlock, None),
+                    (MenuCleanup, None),
+                    (MenuSeparator, None),
+                    (MenuSVNExport, None),
+                    (MenuCreateRepository, None),
+                    (MenuImport, None),
+                    (MenuSeparator, None),
+                    (MenuBranchTag, None),
+                    (MenuSwitch, None),
+                    (MenuMerge, None),
+                    (MenuSeparator, None),
+                    (MenuAnnotate, None),
+                    (MenuSeparator, None),
+                    (MenuCreatePatch, None),
+                    (MenuApplyPatch, None),
+                    (MenuProperties, None),
+                    (MenuSeparator, None),
+                    (MenuSettings, None),
+                    (MenuAbout, None),
+                ],
+            ),
+            None
+            if settings.get("HideItem", "git")
+            else (
+                MenuRabbitVCSGit,
+                [
+                    (MenuClone, None),
+                    (MenuInitializeRepository, None),
+                    (MenuSeparator, None),
+                    (
+                        MenuDiffMenu,
+                        [
+                            (MenuDiff, None),
+                            (MenuDiffPrevRev, None),
+                            (MenuDiffMultiple, None),
+                            (MenuCompareTool, None),
+                            (MenuCompareToolPrevRev, None),
+                            (MenuCompareToolMultiple, None),
+                            (MenuShowChanges, None),
+                        ],
+                    ),
+                    (MenuShowLog, None),
+                    (MenuStage, None),
+                    (MenuUnstage, None),
+                    (MenuAddToIgnoreList, ignore_items),
+                    (MenuSeparator, None),
+                    (MenuRename, None),
+                    (MenuDelete, None),
+                    (MenuRevert, None),
+                    (MenuClean, None),
+                    (MenuReset, None),
+                    (MenuCheckout, None),
+                    (MenuSeparator, None),
+                    (MenuBranches, None),
+                    (MenuTags, None),
+                    (MenuRemotes, None),
+                    (MenuSeparator, None),
+                    (MenuGitExport, None),
+                    (MenuMerge, None),
+                    (MenuSeparator, None),
+                    (MenuAnnotate, None),
+                    (MenuSeparator, None),
+                    (MenuCreatePatch, None),
+                    (MenuApplyPatch, None),
+                    (MenuSeparator, None),
+                    (MenuSettings, None),
+                    (MenuAbout, None),
+                ],
+            ),
+            None
+            if settings.get("HideItem", "hg")
+            else (MenuRabbitVCSMercurial, [(MenuSettings, None), (MenuAbout, None)]),
         ]
         self.structure = [_f for _f in self.structure if _f]
+
     def get_menu(self):
         pass
+
 
 def TestMenuItemFunctions():
     """
@@ -1402,8 +1549,10 @@ def TestMenuItemFunctions():
         entity = getattr(contextmenuitems, name)
         if type(entity) == type:
             mro = inspect.getmro(entity)
-            if (entity is not contextmenuitems.MenuItem and
-                contextmenuitems.MenuItem in mro):
+            if (
+                entity is not contextmenuitems.MenuItem
+                and contextmenuitems.MenuItem in mro
+            ):
                 menu_item_subclasses.append(entity)
 
     condition_functions = []
@@ -1423,13 +1572,19 @@ def TestMenuItemFunctions():
             condition_functions.append(entity)
 
     for cls in menu_item_subclasses:
-        item = cls(ContextMenuConditions(), ContextMenuCallbacks(None, None, None, None))
+        item = cls(
+            ContextMenuConditions(), ContextMenuCallbacks(None, None, None, None)
+        )
         if not item.found_condition:
-            print("Did not find condition function in ContextMenuConditions " \
-                  "for %s (type: %s)" % (item.identifier, cls))
+            print(
+                "Did not find condition function in ContextMenuConditions "
+                "for %s (type: %s)" % (item.identifier, cls)
+            )
         if not item.callback:
-            print("Did not find callback function in ContextMenuCallbacks " \
-                  "for %s (type: %s)" % (item.identifier, cls))
+            print(
+                "Did not find callback function in ContextMenuCallbacks "
+                "for %s (type: %s)" % (item.identifier, cls)
+            )
 
 
 if __name__ == "__main__":

--- a/rabbitvcs/util/contextmenuitems.py
+++ b/rabbitvcs/util/contextmenuitems.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -24,6 +25,7 @@ import os.path
 
 import os
 import gi
+
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
@@ -31,14 +33,17 @@ from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 
 from rabbitvcs import gettext
+
 _ = gettext.gettext
 
 from rabbitvcs.util.log import Log
+
 log = Log("rabbitvcs.ui.contextmenuitems")
 _ = gettext.gettext
 
 
-SEPARATOR = u'\u2015' * 10
+SEPARATOR = "\u2015" * 10
+
 
 class MenuItem(object):
     """
@@ -109,7 +114,6 @@ class MenuItem(object):
     callback_name = None
     callback_args = ()
 
-
     # This is a string that holds the name of the function that is called to
     # determine whether to show the item.
     #
@@ -142,13 +146,13 @@ class MenuItem(object):
         # Try to get the callback function for this item
         self.callback = self._get_function(callbacks, self.callback_name)
 
-#        else:
-#            log.debug("Could not find callback for %s" % self.identifier)
+        #        else:
+        #            log.debug("Could not find callback for %s" % self.identifier)
 
         self.condition = {
             "callback": MenuItem.default_condition,
-            "args": self.condition_args
-            }
+            "args": self.condition_args,
+        }
 
         if self.condition_name is None:
             self.condition_name = default_name
@@ -158,8 +162,9 @@ class MenuItem(object):
         if condition:
             self.condition["callback"] = condition
             self.found_condition = True
-#        else:
-#            log.debug("Could not find condition for %s" % self.identifier)
+
+    #        else:
+    #            log.debug("Could not find condition for %s" % self.identifier)
 
     def show(self):
         return self.condition["callback"](*self.condition["args"])
@@ -176,7 +181,7 @@ class MenuItem(object):
 
         return function
 
-    def make_magic_id(self, id_magic = None):
+    def make_magic_id(self, id_magic=None):
         identifier = self.identifier
 
         if id_magic:
@@ -184,7 +189,7 @@ class MenuItem(object):
 
         return identifier
 
-    def make_action(self, id_magic = None):
+    def make_action(self, id_magic=None):
         """
         Creates the Action for the menu item. To avoid GTK "helpfully"
         preventing us from adding duplicates (eg. separators), you can pass in
@@ -194,19 +199,14 @@ class MenuItem(object):
 
         return Action(identifier, self.make_label(), self.tooltip, self.icon)
 
-    def make_thunar_action(self, id_magic = None):
+    def make_thunar_action(self, id_magic=None):
         identifier = self.make_magic_id(id_magic)
 
-        action = RabbitVCSAction(
-            identifier,
-            self.make_label(),
-            self.tooltip,
-            self.icon
-        )
+        action = RabbitVCSAction(identifier, self.make_label(), self.tooltip, self.icon)
 
         return action
 
-    def make_gtk_menu_item(self, id_magic = None):
+    def make_gtk_menu_item(self, id_magic=None):
         action = self.make_action(id_magic)
 
         if self.icon:
@@ -214,38 +214,43 @@ class MenuItem(object):
             # that method is not available until pyGtk 2.16
             action.set_menu_item_type(Gtk.ImageMenuItem)
             menuitem = action.create_menu_item()
-            menuitem.set_image(Gtk.image_new_from_icon_name(self.icon, Gtk.IconSize.MENU))
+            menuitem.set_image(
+                Gtk.image_new_from_icon_name(self.icon, Gtk.IconSize.MENU)
+            )
         else:
             menuitem = action.create_menu_item()
 
         return menuitem
 
-    def make_gtk3_menu_item(self, id_magic = None):
+    def make_gtk3_menu_item(self, id_magic=None):
         action = self.make_action(id_magic)
         menuitem = action.create_menu_item()
 
         if self.icon:
-            menuitem.set_image(Gtk.Image.new_from_icon_name(self.icon, Gtk.IconSize.MENU))
+            menuitem.set_image(
+                Gtk.Image.new_from_icon_name(self.icon, Gtk.IconSize.MENU)
+            )
 
         return menuitem
 
-    def make_thunarx_menu_item(self, id_magic = None):
+    def make_thunarx_menu_item(self, id_magic=None):
         # WARNING: this import is here because it will fail if it is not done
         # inside a thunar process and therefore can't be in the module proper.
         # This should only be used for Thunarx-3
         identifier = self.make_magic_id(id_magic)
 
         from gi.repository import Thunarx
+
         menuitem = Thunarx.MenuItem(
             name=identifier,
             label=self.make_label(),
             tooltip=self.tooltip,
-            icon=self.icon
+            icon=self.icon,
         )
 
         return menuitem
 
-    def make_nautilus_menu_item(self, id_magic = None):
+    def make_nautilus_menu_item(self, id_magic=None):
         # WARNING: this import is here because it will fail if it is not done
         # inside a nautilus process and therefore can't be in the module proper.
         # I'm happy to let the exception propagate the rest of the time, since
@@ -254,26 +259,26 @@ class MenuItem(object):
 
         try:
             from gi.repository import Nautilus
+
             menuitem = Nautilus.MenuItem(
                 name=identifier,
                 label=self.make_label(),
                 tip=self.tooltip,
-                icon=self.icon
+                icon=self.icon,
             )
         except ImportError:
             import nautilus
+
             menuitem = nautilus.MenuItem(
-                identifier,
-                self.make_label(),
-                self.tooltip,
-                self.icon
+                identifier, self.make_label(), self.tooltip, self.icon
             )
 
         return menuitem
 
     def make_label(self):
-        label = S(self.label).display().replace('_', '__')
+        label = S(self.label).display().replace("_", "__")
         return label
+
 
 class MenuSeparator(MenuItem):
     identifier = "RabbitVCS::Separator"
@@ -282,49 +287,52 @@ class MenuSeparator(MenuItem):
     def make_insensitive(self, menuitem):
         menuitem.set_property("sensitive", False)
 
-    def make_thunar_action(self, id_magic = None):
+    def make_thunar_action(self, id_magic=None):
         menuitem = super(MenuSeparator, self).make_thunar_action(id_magic)
         self.make_insensitive(menuitem)
         return menuitem
         # FIXME: I thought that this would work to create separators,
         # but all I get are black "-"s...
         # I thought
-        #~ identifier = self.make_magic_id(id_magic)
-        #~ # This information is not actually used, but is necessary for
-        #~ # the required subclassing of Action.
-        #~ action = ThunarSeparator(
-            #~ identifier,
-            #~ self.label,
-            #~ self.tooltip,
-            #~ self.icon,
-        #~ )
-        #~ return action
+        # ~ identifier = self.make_magic_id(id_magic)
+        # ~ # This information is not actually used, but is necessary for
+        # ~ # the required subclassing of Action.
+        # ~ action = ThunarSeparator(
+        # ~ identifier,
+        # ~ self.label,
+        # ~ self.tooltip,
+        # ~ self.icon,
+        # ~ )
+        # ~ return action
 
     # Make separators insensitive
-    def make_gtk_menu_item(self, id_magic = None):
+    def make_gtk_menu_item(self, id_magic=None):
         menuitem = Gtk.SeparatorMenuItem()
         menuitem.show()
         return menuitem
 
-    def make_gtk3_menu_item(self, id_magic = None):
+    def make_gtk3_menu_item(self, id_magic=None):
         menuitem = Gtk.SeparatorMenuItem()
         menuitem.show()
         return menuitem
 
-    def make_nautilus_menu_item(self, id_magic = None):
+    def make_nautilus_menu_item(self, id_magic=None):
         menuitem = super(MenuSeparator, self).make_nautilus_menu_item(id_magic)
         self.make_insensitive(menuitem)
         return menuitem
+
 
 class MenuDebug(MenuItem):
     identifier = "RabbitVCS::Debug"
     label = _("Debug")
     icon = "rabbitvcs-monkey"
 
+
 class MenuBugs(MenuItem):
     identifier = "RabbitVCS::Bugs"
     label = _("Bugs")
     icon = "rabbitvcs-bug"
+
 
 class MenuPythonConsole(MenuItem):
     identifier = "RabbitVCS::Python_Console"
@@ -332,10 +340,12 @@ class MenuPythonConsole(MenuItem):
     icon = "gnome-terminal"
     condition_name = "debug"
 
+
 class MenuRefreshStatus(MenuItem):
     identifier = "RabbitVCS::Refresh_Status"
     label = _("Refresh Status")
     icon = "rabbitvcs-refresh"
+
 
 class MenuDebugRevert(MenuItem):
     identifier = "RabbitVCS::Debug_Revert"
@@ -344,12 +354,14 @@ class MenuDebugRevert(MenuItem):
     icon = "rabbitvcs-revert"
     condition_name = "debug"
 
+
 class MenuDebugInvalidate(MenuItem):
     identifier = "RabbitVCS::Debug_Invalidate"
     label = _("Invalidate")
     tooltip = _("Force an invalidate_extension_info() call")
     icon = "rabbitvcs-clear"
     condition_name = "debug"
+
 
 class MenuDebugAddEmblem(MenuItem):
     identifier = "RabbitVCS::Debug_Add_Emblem"
@@ -358,11 +370,13 @@ class MenuDebugAddEmblem(MenuItem):
     icon = "rabbitvcs-emblems"
     condition_name = "debug"
 
+
 class MenuCheckout(MenuItem):
     identifier = "RabbitVCS::Checkout"
     label = _("Checkout...")
     tooltip = _("Check out a working copy")
     icon = "rabbitvcs-checkout"
+
 
 class MenuUpdate(MenuItem):
     identifier = "RabbitVCS::Update"
@@ -370,31 +384,37 @@ class MenuUpdate(MenuItem):
     tooltip = _("Update a working copy")
     icon = "rabbitvcs-update"
 
+
 class MenuCommit(MenuItem):
     identifier = "RabbitVCS::Commit"
     label = _("Commit")
     tooltip = _("Commit modifications to the repository")
     icon = "rabbitvcs-commit"
 
+
 class MenuRabbitVCS(MenuItem):
     identifier = "RabbitVCS::RabbitVCS"
     label = _("RabbitVCS")
     icon = "rabbitvcs"
+
 
 class MenuRabbitVCSSvn(MenuItem):
     identifier = "RabbitVCS::RabbitVCS_Svn"
     label = _("RabbitVCS SVN")
     icon = "rabbitvcs"
 
+
 class MenuRabbitVCSGit(MenuItem):
     identifier = "RabbitVCS::RabbitVCS_Git"
     label = _("RabbitVCS Git")
     icon = "rabbitvcs"
 
+
 class MenuRabbitVCSMercurial(MenuItem):
     identifier = "RabbitVCS::RabbitVCS_Mercurial"
     label = _("RabbitVCS Hg")
     icon = "rabbitvcs"
+
 
 class MenuRepoBrowser(MenuItem):
     identifier = "RabbitVCS::Repo_Browser"
@@ -402,11 +422,13 @@ class MenuRepoBrowser(MenuItem):
     tooltip = _("Browse a repository tree")
     icon = "edit-find"
 
+
 class MenuCheckForModifications(MenuItem):
     identifier = "RabbitVCS::Check_For_Modifications"
     label = _("Check for Modifications...")
     tooltip = _("Check for modifications made to the repository")
     icon = "rabbitvcs-checkmods"
+
 
 class MenuDiffMenu(MenuItem):
     identifier = "RabbitVCS::Diff_Menu"
@@ -414,11 +436,13 @@ class MenuDiffMenu(MenuItem):
     tooltip = _("List of comparison options")
     icon = "rabbitvcs-diff"
 
+
 class MenuDiff(MenuItem):
     identifier = "RabbitVCS::Diff"
     label = _("View diff against base")
     tooltip = _("View the modifications made to a file")
     icon = "rabbitvcs-diff"
+
 
 class MenuDiffMultiple(MenuItem):
     identifier = "RabbitVCS::Diff_Multiple"
@@ -426,11 +450,13 @@ class MenuDiffMultiple(MenuItem):
     tooltip = _("View the differences between two files")
     icon = "rabbitvcs-diff"
 
+
 class MenuDiffPrevRev(MenuItem):
     identifier = "RabbitVCS::Diff_Previous_Revision"
     label = _("View diff against previous revision")
     tooltip = _("View the modifications made to a file since its last change")
     icon = "rabbitvcs-diff"
+
 
 class MenuCompareTool(MenuItem):
     identifier = "RabbitVCS::Compare_Tool"
@@ -438,11 +464,13 @@ class MenuCompareTool(MenuItem):
     tooltip = _("Compare with base using side-by-side comparison tool")
     icon = "rabbitvcs-compare"
 
+
 class MenuCompareToolMultiple(MenuItem):
     identifier = "RabbitVCS::Compare_Tool_Multiple"
     label = _("Compare files/folders")
     tooltip = _("Compare the differences between two items")
     icon = "rabbitvcs-compare"
+
 
 class MenuCompareToolPrevRev(MenuItem):
     identifier = "RabbitVCS::Compare_Tool_Previous_Revision"
@@ -450,11 +478,13 @@ class MenuCompareToolPrevRev(MenuItem):
     tooltip = _("Compare with previous revision using side-by-side comparison tool")
     icon = "rabbitvcs-compare"
 
+
 class MenuShowChanges(MenuItem):
     identifier = "RabbitVCS::Show_Changes"
     label = _("Show Changes...")
     tooltip = _("Show changes between paths and revisions")
     icon = "rabbitvcs-changes"
+
 
 class MenuShowLog(MenuItem):
     identifier = "RabbitVCS::Show_Log"
@@ -462,16 +492,19 @@ class MenuShowLog(MenuItem):
     tooltip = _("Show a file's log information")
     icon = "rabbitvcs-show_log"
 
+
 class MenuAdd(MenuItem):
     identifier = "RabbitVCS::Add"
     label = _("Add")
     tooltip = _("Schedule items to be added to the repository")
     icon = "rabbitvcs-add"
 
+
 class MenuAddToIgnoreList(MenuItem):
     identifier = "RabbitVCS::Add_To_Ignore_List"
     label = _("Add to ignore list")
     icon = None
+
 
 class MenuUpdateToRevision(MenuItem):
     identifier = "RabbitVCS::Update_To_Revision"
@@ -479,11 +512,13 @@ class MenuUpdateToRevision(MenuItem):
     tooltip = _("Update a file to a specific revision")
     icon = "rabbitvcs-update"
 
+
 class MenuRename(MenuItem):
     identifier = "RabbitVCS::Rename"
     label = _("Rename...")
     tooltip = _("Schedule an item to be renamed on the repository")
     icon = "rabbitvcs-rename"
+
 
 class MenuDelete(MenuItem):
     identifier = "RabbitVCS::Delete"
@@ -491,11 +526,13 @@ class MenuDelete(MenuItem):
     tooltip = _("Schedule an item to be deleted from the repository")
     icon = "rabbitvcs-delete"
 
+
 class MenuRevert(MenuItem):
     identifier = "RabbitVCS::Revert"
     label = _("Revert")
     tooltip = _("Revert an item to its unmodified state")
     icon = "rabbitvcs-revert"
+
 
 class MenuMarkResolved(MenuItem):
     identifier = "RabbitVCS::Mark_Resolved"
@@ -503,10 +540,12 @@ class MenuMarkResolved(MenuItem):
     tooltip = _("Mark a conflicted item as resolved")
     icon = "rabbitvcs-resolve"
 
+
 class MenuRestore(MenuItem):
     identifier = "RabbitVCS::Restore"
     label = _("Restore")
     tooltip = _("Restore a missing item")
+
 
 class MenuRelocate(MenuItem):
     identifier = "RabbitVCS::Relocate"
@@ -514,11 +553,13 @@ class MenuRelocate(MenuItem):
     tooltip = _("Relocate your working copy")
     icon = "rabbitvcs-relocate"
 
+
 class MenuGetLock(MenuItem):
     identifier = "RabbitVCS::Get_Lock"
     label = _("Get Lock...")
     tooltip = _("Locally lock items")
     icon = "rabbitvcs-lock"
+
 
 class MenuUnlock(MenuItem):
     identifier = "RabbitVCS::Unlock"
@@ -526,11 +567,13 @@ class MenuUnlock(MenuItem):
     tooltip = _("Release lock on an item")
     icon = "rabbitvcs-unlock"
 
+
 class MenuCleanup(MenuItem):
     identifier = "RabbitVCS::Cleanup"
     label = _("Cleanup")
     tooltip = _("Clean up working copy")
     icon = "rabbitvcs-cleanup"
+
 
 class MenuExport(MenuItem):
     identifier = "RabbitVCS::Export"
@@ -538,19 +581,23 @@ class MenuExport(MenuItem):
     tooltip = _("Export a working copy or repository with no versioning information")
     icon = "rabbitvcs-export"
 
+
 class MenuSVNExport(MenuExport):
     identifier = "RabbitVCS::SVN_Export"
     pass
 
+
 class MenuGitExport(MenuExport):
     identifier = "RabbitVCS::Git_Export"
     pass
+
 
 class MenuCreateRepository(MenuItem):
     identifier = "RabbitVCS::Create_Repository"
     label = _("Create Repository here")
     tooltip = _("Create a repository in a folder")
     icon = "rabbitvcs-run"
+
 
 class MenuImport(MenuItem):
     identifier = "RabbitVCS::Import"
@@ -568,11 +615,13 @@ class MenuBranchTag(MenuItem):
     tooltip = _("Copy an item to another location in the repository")
     icon = "rabbitvcs-branch"
 
+
 class MenuSwitch(MenuItem):
     identifier = "RabbitVCS::Switch"
     label = _("Switch...")
     tooltip = _("Change the repository location of a working copy")
     icon = "rabbitvcs-switch"
+
 
 class MenuMerge(MenuItem):
     identifier = "RabbitVCS::Merge"
@@ -580,11 +629,13 @@ class MenuMerge(MenuItem):
     tooltip = _("A wizard with steps for merging")
     icon = "rabbitvcs-merge"
 
+
 class MenuAnnotate(MenuItem):
     identifier = "RabbitVCS::Annotate"
     label = _("Annotate...")
     tooltip = _("Annotate a file")
     icon = "rabbitvcs-annotate"
+
 
 class MenuCreatePatch(MenuItem):
     identifier = "RabbitVCS::Create_Patch"
@@ -592,11 +643,13 @@ class MenuCreatePatch(MenuItem):
     tooltip = _("Creates a unified diff file with all changes you made")
     icon = "rabbitvcs-createpatch"
 
+
 class MenuApplyPatch(MenuItem):
     identifier = "RabbitVCS::Apply_Patch"
     label = _("Apply Patch...")
     tooltip = _("Applies a unified diff file to the working copy")
     icon = "rabbitvcs-applypatch"
+
 
 class MenuProperties(MenuItem):
     identifier = "RabbitVCS::Properties"
@@ -604,11 +657,13 @@ class MenuProperties(MenuItem):
     tooltip = _("View the properties of an item")
     icon = "rabbitvcs-properties"
 
+
 class MenuHelp(MenuItem):
     identifier = "RabbitVCS::Help"
     label = _("Help")
     tooltip = _("View help")
     icon = "rabbitvcs-help"
+
 
 class MenuSettings(MenuItem):
     identifier = "RabbitVCS::Settings"
@@ -616,11 +671,13 @@ class MenuSettings(MenuItem):
     tooltip = _("View or change RabbitVCS settings")
     icon = "rabbitvcs-settings"
 
+
 class MenuAbout(MenuItem):
     identifier = "RabbitVCS::About"
     label = _("About")
     tooltip = _("About RabbitVCS")
     icon = "rabbitvcs-about"
+
 
 class MenuOpen(MenuItem):
     identifier = "RabbitVCS::Open"
@@ -631,37 +688,43 @@ class MenuOpen(MenuItem):
     condition_name = "_open"
     callback_name = "_open"
 
+
 class MenuBrowseTo(MenuItem):
     identifier = "RabbitVCS::Browse_To"
     label = _("Browse to")
     tooltip = _("Browse to a file or folder")
     icon = "drive-harddisk"
 
+
 class PropMenuRevert(MenuItem):
     identifier = "RabbitVCS::Property_Revert"
     label = _("Revert property")
-    icon =  "rabbitvcs-revert"
+    icon = "rabbitvcs-revert"
     tooltip = _("Revert this property to its original state")
+
 
 class PropMenuRevertRecursive(MenuItem):
     identifier = "RabbitVCS::Property_Revert_Recursive"
     label = _("Revert property (recursive)")
-    icon =  "rabbitvcs-revert"
+    icon = "rabbitvcs-revert"
     tooltip = _("Revert this property to its original state (recursive)")
     condition_name = "property_revert"
+
 
 class PropMenuDelete(MenuItem):
     identifier = "RabbitVCS::Property_Delete"
     label = _("Delete property")
-    icon =  "rabbitvcs-delete"
+    icon = "rabbitvcs-delete"
     tooltip = _("Delete this property")
+
 
 class PropMenuDeleteRecursive(MenuItem):
     identifier = "RabbitVCS::Property_Delete_Recursive"
     label = _("Delete property (recursive)")
-    icon =  "rabbitvcs-delete"
+    icon = "rabbitvcs-delete"
     tooltip = _("Delete this property (recursive)")
     condition_name = "property_delete"
+
 
 class PropMenuEdit(MenuItem):
     identifier = "RabbitVCS::Property_Edit"
@@ -669,64 +732,77 @@ class PropMenuEdit(MenuItem):
     icon = "rabbitvcs-editprops"
     tooltip = _("Show and edit property details")
 
+
 class MenuInitializeRepository(MenuItem):
     identifier = "RabbitVCS::Initialize_Repository"
     label = _("Initialize Repository")
     icon = "rabbitvcs-run"
+
 
 class MenuClone(MenuItem):
     identifier = "RabbitVCS::Clone"
     label = _("Clone")
     icon = "rabbitvcs-checkout"
 
+
 class MenuFetchPull(MenuItem):
     identifier = "RabbitVCS::Fetch_Pull"
     label = _("Fetch/Pull")
     icon = "rabbitvcs-update"
+
 
 class MenuPush(MenuItem):
     identifier = "RabbitVCS::Push"
     label = _("Push")
     icon = "rabbitvcs-push"
 
+
 class MenuBranches(MenuItem):
     identifier = "RabbitVCS::Branches"
     label = _("Branches")
     icon = "rabbitvcs-branch"
+
 
 class MenuTags(MenuItem):
     identifier = "RabbitVCS::Tags"
     label = _("Tags")
     icon = "rabbitvcs-branch"
 
+
 class MenuRemotes(MenuItem):
     identifier = "RabbitVCS::Remotes"
     label = _("Remotes")
     icon = "rabbitvcs-checkmods"
 
+
 class MenuClean(MenuCleanup):
     identifier = "RabbitVCS::Clean"
     label = _("Clean")
+
 
 class MenuReset(MenuItem):
     identifier = "RabbitVCS::Reset"
     label = _("Reset")
     icon = "rabbitvcs-reset"
 
+
 class MenuStage(MenuItem):
     identifier = "RabbitVCS::Stage"
     label = _("Stage")
     icon = "rabbitvcs-add"
+
 
 class MenuUnstage(MenuItem):
     identifier = "RabbitVCS::Unstage"
     label = _("Unstage")
     icon = "rabbitvcs-unstage"
 
+
 class MenuEditConflicts(MenuItem):
     identifier = "RabbitVCS::Edit_Conflicts"
     label = _("Edit conflicts")
     icon = "rabbitvcs-editconflicts"
+
 
 def get_ignore_list_items(paths):
     """
@@ -753,9 +829,9 @@ def get_ignore_list_items(paths):
                 label = basename
                 tooltip = _("Ignore item by filename")
                 callback_name = "ignore_by_filename"
-                callback_args = (path)
+                callback_args = path
                 condition_name = "ignore_by_filename"
-                condition_args = (path)
+                condition_args = path
 
             ignore_items.append((MenuIgnoreFilenameClass, None))
 
@@ -764,7 +840,7 @@ def get_ignore_list_items(paths):
     for path in paths:
         extension = helper.get_file_extension(path)
 
-        ext_str = "*%s"%extension
+        ext_str = "*%s" % extension
         if ext_str not in added_ignore_labels:
 
             class MenuIgnoreFileExtClass(MenuItem):
@@ -779,6 +855,7 @@ def get_ignore_list_items(paths):
             ignore_items.append((MenuIgnoreFileExtClass, None))
 
     return ignore_items
+
 
 class Action(object):
     def __init__(self, name, label, tooltip, icon_name):
@@ -797,8 +874,11 @@ class Action(object):
         if self.tooltip:
             item.set_tooltip_text(self.tooltip)
         if self.icon_name:
-            item.set_image(Gtk.Image.new_from_icon_name(self.icon_name, Gtk.IconSize.MENU))
+            item.set_image(
+                Gtk.Image.new_from_icon_name(self.icon_name, Gtk.IconSize.MENU)
+            )
         return item
+
 
 class RabbitVCSAction(Action):
     """
@@ -828,9 +908,9 @@ class RabbitVCSAction(Action):
 
         return menu_item
 
+
 # FIXME: apparently it's possible to get real GtkSeparators in a Thunar
 # menu, but this doesn't seem to work.
 class ThunarSeparator(RabbitVCSAction):
-
     def create_menu_item(self):
         return Gtk.SeparatorMenuItem()

--- a/rabbitvcs/util/decorators.py
+++ b/rabbitvcs/util/decorators.py
@@ -43,7 +43,9 @@ import warnings
 import threading
 
 from rabbitvcs.util.log import Log
+
 log = Log("rabbitvcs.util.decorators")
+
 
 def update_func_meta(fake_func, real_func):
     """
@@ -61,6 +63,7 @@ def update_func_meta(fake_func, real_func):
 
     return fake_func
 
+
 def deprecated(func):
     """
     A decorator which can be used to mark functions as deprecated.
@@ -74,11 +77,14 @@ def deprecated(func):
         """
         Print deprecated warning and execute original function.
         """
-        warnings.warn("Call to deprecated function %s." % func.__name__,
-                      category=DeprecationWarning)
+        warnings.warn(
+            "Call to deprecated function %s." % func.__name__,
+            category=DeprecationWarning,
+        )
         return func(*args, **kwargs)
 
     return update_func_meta(newfunc, func)
+
 
 def timeit(func):
     """
@@ -102,6 +108,7 @@ def timeit(func):
 
     return update_func_meta(newfunc, func)
 
+
 def disable(func):
     """
     Disable a function.
@@ -116,6 +123,7 @@ def disable(func):
 
     return update_func_meta(newfunc, func)
 
+
 def gtk_unsafe(func):
     """
     Used to wrap a function that makes calls to GTK from a thread in
@@ -128,6 +136,7 @@ def gtk_unsafe(func):
         return helper.run_in_main_thread(func, *args, **kwargs)
 
     return update_func_meta(newfunc, func)
+
 
 def debug_calls(caller_log, show_caller=False):
     """
@@ -144,21 +153,23 @@ def debug_calls(caller_log, show_caller=False):
 
     # We need a function within a function to be able to use the log argument.
     def real_debug(func):
-
         def newfunc(*args, **kwargs):
-            caller_log.debug("Calling: %s (%s)" %
-                                (func.__name__,
-                                 threading.currentThread().getName()))
+            caller_log.debug(
+                "Calling: %s (%s)"
+                % (func.__name__, threading.currentThread().getName())
+            )
 
             result = func(*args, **kwargs)
-            caller_log.debug("Returned: %s (%s)" %
-                                (func.__name__,
-                                 threading.currentThread().getName()))
+            caller_log.debug(
+                "Returned: %s (%s)"
+                % (func.__name__, threading.currentThread().getName())
+            )
             return result
 
         return update_func_meta(newfunc, func)
 
     return real_debug
+
 
 def structure_map(func):
     """
@@ -166,6 +177,7 @@ def structure_map(func):
     and build the equivalent structure with func results.
     Do not apply function to None.
     """
+
     def newfunc(obj, *args, **kwargs):
         if obj is None:
             return obj

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -53,9 +53,11 @@ from rabbitvcs.util.decorators import structure_map
 from rabbitvcs.util.strings import *
 
 from rabbitvcs.util.log import Log
+
 log = Log("rabbitvcs.util.helper")
 
 from rabbitvcs import gettext
+
 ngettext = gettext.ngettext
 
 try:
@@ -67,9 +69,10 @@ import gi
 from gi.repository import GObject
 
 from rabbitvcs import gettext
+
 _ = gettext.gettext
 
-LOG_DATETIME_FORMAT = "%Y-%m-%d %H:%M" # for log files
+LOG_DATETIME_FORMAT = "%Y-%m-%d %H:%M"  # for log files
 
 DT_FORMAT_TIME = _("%I:%M%P")
 DT_FORMAT_THISWEEK = _("%a %I:%M%p")
@@ -79,7 +82,7 @@ DT_FORMAT_ALL = _("%b %d %Y")
 LINE_BREAK_CHAR = six.unichr(0x23CE)
 
 
-def compare_version(version1, version2, length = None):
+def compare_version(version1, version2, length=None):
     if not length:
         length = max(len(version1), len(version2))
     for i in range(length):
@@ -90,6 +93,7 @@ def compare_version(version1, version2, length = None):
             return r
     return 0
 
+
 def gobject_threads_init():
     """
     Call GObject.threads_init() only if not deprecated.
@@ -97,6 +101,7 @@ def gobject_threads_init():
 
     if compare_version(GObject.pygobject_version, [3, 10, 2]) < 0:
         GObject.threads_init()
+
 
 @structure_map
 def to_bytes(s, encoding=UTF8_ENCODING):
@@ -112,6 +117,7 @@ def to_bytes(s, encoding=UTF8_ENCODING):
     if isinstance(s, bytes) and encoding.lower() != UTF8_ENCODING:
         return S(s).bytes(encoding)
     return s
+
 
 def run_in_main_thread(func, *args, **kwargs):
     """
@@ -136,27 +142,35 @@ def run_in_main_thread(func, *args, **kwargs):
         raise event.exception
     return event.result
 
+
 def get_tmp_path(filename):
     day = datetime.datetime.now().day
     day_string = S(str(day) + str(os.geteuid())).bytes()
     m = hashlib.md5(day_string).hexdigest()[0:10]
 
-    tmpdir = "/tmp/rabbitvcs-%s" %m
+    tmpdir = "/tmp/rabbitvcs-%s" % m
     if not os.path.isdir(tmpdir):
         os.mkdir(tmpdir)
 
     return "%s/%s" % (tmpdir, filename)
 
+
 def process_memory(pid):
     # ps -p 5205 -w -w -o rss --no-headers
     psproc = subprocess.Popen(
-                            ["ps",
-                             "-p", str(pid),
-                             "-w", "-w",        # Extra-wide format
-                             "-o", "size",      # "Size" is probably the best all round
-                                                # memory measure.
-                             "--no-headers"],
-                             stdout=subprocess.PIPE)
+        [
+            "ps",
+            "-p",
+            str(pid),
+            "-w",
+            "-w",  # Extra-wide format
+            "-o",
+            "size",  # "Size" is probably the best all round
+            # memory measure.
+            "--no-headers",
+        ],
+        stdout=subprocess.PIPE,
+    )
 
     (output, stdin) = psproc.communicate()
 
@@ -171,8 +185,9 @@ def process_memory(pid):
 
     return mem_in_kb
 
-def format_long_text(text, cols = None, line1only = False):
-    """ Nicely formats text containing linebreaks to display in a single line
+
+def format_long_text(text, cols=None, line1only=False):
+    """Nicely formats text containing linebreaks to display in a single line
     by replacing newlines with U+23CE, or keeping only the first non-empty
     line. If the param "cols" is given, the text
     beyond cols is replaced by "...".
@@ -186,6 +201,7 @@ def format_long_text(text, cols = None, line1only = False):
         text = six.u("%s...") % text[0:cols]
 
     return text
+
 
 def format_datetime(dt, format=None):
     if format:
@@ -202,7 +218,7 @@ def format_datetime(dt, format=None):
             if delta.seconds < 60:
                 returner = _("just now")
             elif delta.seconds >= 60 and delta.seconds < 600:
-                returner = _("%d minute(s) ago") % (delta.seconds/60)
+                returner = _("%d minute(s) ago") % (delta.seconds / 60)
             elif delta.seconds >= 600 and delta.seconds < 43200:
                 returner = dt.strftime(DT_FORMAT_TIME)
             else:
@@ -216,8 +232,9 @@ def format_datetime(dt, format=None):
 
     return S(returner).unicode()
 
+
 def in_rich_compare(item, list):
-    """ Tests whether the item is in the given list. This is mainly to work
+    """Tests whether the item is in the given list. This is mainly to work
     around the rich-compare bug in pysvn. This is not identical to the "in"
     operator when used for substring testing.
     """
@@ -232,6 +249,7 @@ def in_rich_compare(item, list):
                 pass
 
     return in_list
+
 
 # FIXME: this function is duplicated in settings.py
 def get_home_folder():
@@ -248,8 +266,7 @@ def get_home_folder():
     # Make sure we adher to the freedesktop.org XDG Base Directory
     # Specifications. $XDG_CONFIG_HOME if set, by default ~/.config
     xdg_config_home = os.environ.get(
-        "XDG_CONFIG_HOME",
-        os.path.join(os.path.expanduser("~"), ".config")
+        "XDG_CONFIG_HOME", os.path.join(os.path.expanduser("~"), ".config")
     )
     config_home = os.path.join(xdg_config_home, "rabbitvcs")
 
@@ -259,6 +276,7 @@ def get_home_folder():
         os.makedirs(config_home, 0o700)
 
     return config_home
+
 
 def get_user_path():
     """
@@ -272,6 +290,7 @@ def get_user_path():
 
     return os.path.abspath(os.path.expanduser("~"))
 
+
 def get_repository_paths_path():
     """
     Returns a valid URI for the repository paths file
@@ -281,6 +300,7 @@ def get_repository_paths_path():
 
     """
     return os.path.join(get_home_folder(), "repos_paths")
+
 
 def get_repository_paths():
     """
@@ -298,6 +318,7 @@ def get_repository_paths():
 
     return returner
 
+
 def get_previous_messages_path():
     """
     Returns a valid URI for the previous messages file
@@ -308,6 +329,7 @@ def get_previous_messages_path():
     """
 
     return os.path.join(get_home_folder(), "previous_log_messages")
+
 
 def get_previous_messages():
     """
@@ -347,8 +369,10 @@ def get_previous_messages():
 
     return returner
 
+
 def get_exclude_paths_path():
     return os.path.join(get_home_folder(), "exclude_paths")
+
 
 def get_exclude_paths():
     path = get_exclude_paths_path()
@@ -362,6 +386,7 @@ def get_exclude_paths():
     f.close()
 
     return paths
+
 
 def encode_revisions(revision_array):
     """
@@ -411,7 +436,7 @@ def encode_revisions(revision_array):
     while True:
         if current_position + 1 >= len(revision_array):
             append(start, last, returner)
-            break;
+            break
 
         current = revision_array[current_position]
         next = revision_array[current_position + 1]
@@ -426,6 +451,7 @@ def encode_revisions(revision_array):
 
     return ",".join(returner)
 
+
 def decode_revisions(string, head):
     """
     Takes a TortoiseSVN-like revision string and returns a list of integers.
@@ -438,14 +464,15 @@ def decode_revisions(string, head):
     for el in arr:
         if el.find("-") != -1:
             subarr = el.split("-")
-            if subarr[1] == 'HEAD':
+            if subarr[1] == "HEAD":
                 subarr[1] = head
-            for subel in range(int(subarr[0]), int(subarr[1])+1):
+            for subel in range(int(subarr[0]), int(subarr[1]) + 1):
                 returner.append(subel)
         else:
             returner.append(int(el))
 
     return returner
+
 
 def get_diff_tool():
     """
@@ -459,10 +486,8 @@ def get_diff_tool():
     diff_tool = sm.get("external", "diff_tool")
     diff_tool_swap = sm.get("external", "diff_tool_swap")
 
-    return {
-        "path": diff_tool,
-        "swap": diff_tool_swap
-    }
+    return {"path": diff_tool, "swap": diff_tool_swap}
+
 
 def get_merge_tool():
     """
@@ -473,7 +498,8 @@ def get_merge_tool():
     """
 
     sm = rabbitvcs.util.settings.SettingsManager()
-    return  sm.get("external", "merge_tool")
+    return sm.get("external", "merge_tool")
+
 
 def launch_diff_tool(path1, path2=None):
     """
@@ -515,27 +541,26 @@ def launch_diff_tool(path1, path2=None):
         else:
             return
 
-        os.popen(
-            "patch --reverse '%s' < %s" % (tmp_path, tmp_file)
-        )
+        os.popen("patch --reverse '%s' < %s" % (tmp_path, tmp_file))
         (lhs, rhs) = (tmp_path, path1)
 
     if diff["swap"]:
         (lhs, rhs) = (rhs, lhs)
 
-    os.spawnl(
-        os.P_NOWAIT,
-        diff["path"],
-        diff["path"],
-        lhs,
-        rhs
-    )
+    os.spawnl(os.P_NOWAIT, diff["path"], diff["path"], lhs, rhs)
+
 
 def launch_merge_tool(base="", mine="", theirs="", merged=""):
     merge_tool = get_merge_tool()
 
-    if(mine == None or mine == "" or not os.path.exists(mine) or
-       theirs == None or theirs == "" or not os.path.exists(theirs)):
+    if (
+        mine == None
+        or mine == ""
+        or not os.path.exists(mine)
+        or theirs == None
+        or theirs == ""
+        or not os.path.exists(theirs)
+    ):
         return
 
     if "%base" in merge_tool:
@@ -550,8 +575,9 @@ def launch_merge_tool(base="", mine="", theirs="", merged=""):
     if "%merged" in merge_tool:
         merge_tool = merge_tool.replace("%merged", merged)
 
-    log.debug("merge_tool: %s"%merge_tool)
+    log.debug("merge_tool: %s" % merge_tool)
     os.popen(merge_tool)
+
 
 def get_file_extension(path):
     """
@@ -565,6 +591,7 @@ def get_file_extension(path):
 
     """
     return os.path.splitext(path)[1]
+
 
 def open_item(path):
     """
@@ -581,7 +608,8 @@ def open_item(path):
     openers = []
 
     import platform
-    if platform.system() == 'Darwin':
+
+    if platform.system() == "Darwin":
         openers.append("open")
         subprocess.Popen(["open", os.path.abspath(path)])
     else:
@@ -590,7 +618,7 @@ def open_item(path):
         openers.append("xdg-open")
 
     for o in openers:
-        for p in set(os.environ['PATH'].split(':')):
+        for p in set(os.environ["PATH"].split(":")):
             if os.path.exists("%s/%s" % (p, o)):
                 command = [o]
                 if o == "gio":
@@ -599,6 +627,7 @@ def open_item(path):
 
                 subprocess.Popen(command)
                 return
+
 
 def browse_to_item(path):
     """
@@ -610,15 +639,19 @@ def browse_to_item(path):
     """
 
     import platform
-    if platform.system() == 'Darwin':
-        subprocess.Popen([
-            "open", "--reveal", os.path.dirname(os.path.abspath(path))
-        ])
+
+    if platform.system() == "Darwin":
+        subprocess.Popen(["open", "--reveal", os.path.dirname(os.path.abspath(path))])
     else:
-        subprocess.Popen([
-            "nautilus", "--no-desktop", "--browser",
-            os.path.dirname(os.path.abspath(path))
-        ])
+        subprocess.Popen(
+            [
+                "nautilus",
+                "--no-desktop",
+                "--browser",
+                os.path.dirname(os.path.abspath(path)),
+            ]
+        )
+
 
 def delete_item(path):
     """
@@ -633,7 +666,8 @@ def delete_item(path):
     try:
 
         import platform
-        if platform.system() == 'Darwin':
+
+        if platform.system() == "Darwin":
             retcode = subprocess.call(["mv", abspath, os.getenv("HOME") + "/.Trash"])
             if retcode:
                 permanent_delete = True
@@ -651,6 +685,7 @@ def delete_item(path):
             shutil.rmtree(abspath, True)
         else:
             os.remove(abspath)
+
 
 def save_log_message(message):
     """
@@ -690,10 +725,15 @@ def save_log_message(message):
 -- %s --
 %s
 %s
-"""%(m[0], m[1], s)
+""" % (
+            m[0],
+            m[1],
+            s,
+        )
 
     f.write(s)
     f.close()
+
 
 def save_repository_path(path):
     """
@@ -719,6 +759,7 @@ def save_repository_path(path):
     f.write(S("\n".join(paths)))
     f.close()
 
+
 def launch_ui_window(filename, args=[], block=False):
     """
     Launches a UI window in a new process, so that we don't have to worry about
@@ -736,12 +777,10 @@ def launch_ui_window(filename, args=[], block=False):
 
     # Hackish.  Get's the helper module's path, then assumes it is in
     # the lib folder.  Removes the /lib part of the path.
-    basedir, head = os.path.split(
-                        os.path.dirname(
-                            os.path.realpath(__file__)))
+    basedir, head = os.path.split(os.path.dirname(os.path.realpath(__file__)))
 
     if not head == "util":
-        log.warning("Helper module (%s) not in \"util\" dir" % __file__)
+        log.warning('Helper module (%s) not in "util" dir' % __file__)
 
     # Puts the whole path together.
     # path = "%s/ui/%s.py" % (basedir, filename)
@@ -753,7 +792,7 @@ def launch_ui_window(filename, args=[], block=False):
             executable = os.environ["PYTHON"]
         # Give all subprocesses the name 'RabbitVCS' to give Ubuntu desktop files the possibility
         # to group those windows in the launcher on WM_CLASS.
-        proc = subprocess.Popen([executable, path] + ['--name', 'RabbitVCS'] + args)
+        proc = subprocess.Popen([executable, path] + ["--name", "RabbitVCS"] + args)
 
         if block:
             proc.wait()
@@ -762,13 +801,16 @@ def launch_ui_window(filename, args=[], block=False):
     else:
         return None
 
+
 def get_log_messages_limit():
     sm = rabbitvcs.util.settings.SettingsManager()
     return int(sm.get("cache", "number_messages"))
 
+
 def get_repository_paths_limit():
     sm = rabbitvcs.util.settings.SettingsManager()
     return int(sm.get("cache", "number_repositories"))
+
 
 def get_common_directory(paths):
     common = os.path.commonprefix(abspaths(paths))
@@ -781,6 +823,7 @@ def get_common_directory(paths):
 
     return common
 
+
 def abspaths(paths):
     index = 0
     for path in paths:
@@ -788,6 +831,7 @@ def abspaths(paths):
         index += 1
 
     return paths
+
 
 def pretty_timedelta(time1, time2, resolution=None):
     """
@@ -810,32 +854,33 @@ def pretty_timedelta(time1, time2, resolution=None):
     # or less than two plural forms) we have to state all the strings
     # explicitely within an ngettext call
     if age_s <= 60 * 1.9:
-        return ngettext("%i second", "%i seconds",age_s) % age_s
+        return ngettext("%i second", "%i seconds", age_s) % age_s
     elif age_s <= 3600 * 1.9:
         r = age_s / 60
-        return ngettext("%i minute", "%i minutes",r) % r
+        return ngettext("%i minute", "%i minutes", r) % r
     elif age_s <= 3600 * 24 * 1.9:
         r = age_s / 3600
-        return ngettext("%i hour", "%i hours",r) % r
+        return ngettext("%i hour", "%i hours", r) % r
     elif age_s <= 3600 * 24 * 7 * 1.9:
         r = age_s / (3600 * 24)
-        return ngettext("%i day", "%i days",r) % r
+        return ngettext("%i day", "%i days", r) % r
     elif age_s <= 3600 * 24 * 30 * 1.9:
         r = age_s / (3600 * 24 * 7)
-        return ngettext("%i week", "%i weeks",r) % r
+        return ngettext("%i week", "%i weeks", r) % r
     elif age_s <= 3600 * 24 * 365 * 1.9:
         r = age_s / (3600 * 24 * 30)
-        return ngettext("%i month", "%i months",r) % r
+        return ngettext("%i month", "%i months", r) % r
     else:
         r = age_s / (3600 * 24 * 365)
-        return ngettext("%i year", "%i years",r) % r
+        return ngettext("%i year", "%i years", r) % r
+
 
 def utc_offset(timestamp=None):
     """
-        Compute the UTC offset of current locale for a timestamp in a
-        portable way, taking care of daylight saving. Positive is east of
-        Greenwich. Result in seconds. If no timestamp is given, the current
-        time is used.
+    Compute the UTC offset of current locale for a timestamp in a
+    portable way, taking care of daylight saving. Positive is east of
+    Greenwich. Result in seconds. If no timestamp is given, the current
+    time is used.
     """
 
     if timestamp is None:
@@ -846,14 +891,19 @@ def utc_offset(timestamp=None):
     local = datetime.datetime.fromtimestamp(timestamp)
     return int((local - utc).total_seconds())
 
+
 def _commonpath(l1, l2, common=[]):
     """
     Helper method for the get_relative_path method
     """
-    if len(l1) < 1: return (common, l1, l2)
-    if len(l2) < 1: return (common, l1, l2)
-    if l1[0] != l2[0]: return (common, l1, l2)
-    return _commonpath(l1[1:], l2[1:], common+[l1[0]])
+    if len(l1) < 1:
+        return (common, l1, l2)
+    if len(l2) < 1:
+        return (common, l1, l2)
+    if l1[0] != l2[0]:
+        return (common, l1, l2)
+    return _commonpath(l1[1:], l2[1:], common + [l1[0]])
+
 
 def get_relative_path(from_path, to_path):
     """
@@ -863,35 +913,37 @@ def get_relative_path(from_path, to_path):
     nice_path1 = from_path.rstrip(os.path.sep).split(os.path.sep)
     nice_path2 = to_path.rstrip(os.path.sep).split(os.path.sep)
 
-    (common,l1,l2) = _commonpath(nice_path1, nice_path2)
+    (common, l1, l2) = _commonpath(nice_path1, nice_path2)
 
     p = []
     if len(l1) > 0:
-        p = ['..'] * len(l1)
+        p = [".."] * len(l1)
     p = p + l2
 
     return os.sep.join(p)
+
 
 def launch_repo_browser(uri):
     sm = rabbitvcs.util.settings.SettingsManager()
     repo_browser = sm.get("external", "repo_browser")
 
     if repo_browser is not None:
-        subprocess.Popen([
-            repo_browser,
-            uri
-        ])
+        subprocess.Popen([repo_browser, uri])
+
 
 def launch_url_in_webbrowser(url):
     import webbrowser
+
     webbrowser.open(url)
+
 
 def parse_path_revision_string(pathrev):
     index = pathrev.rfind("@")
     if index == -1:
-        return (pathrev,None)
+        return (pathrev, None)
     else:
-        return (pathrev[0:index], pathrev[index+1:])
+        return (pathrev[0:index], pathrev[index + 1 :])
+
 
 def create_path_revision_string(path, revision=None):
     if revision:
@@ -899,28 +951,34 @@ def create_path_revision_string(path, revision=None):
     else:
         return path
 
+
 def url_join(path, *args):
     return "/".join([path.rstrip("/")] + list(args))
 
+
 def _quote(text):
-    return six.moves.urllib.parse.quote(text,
-                                        encoding=UTF8_ENCODING,
-                                        errors=SURROGATE_ESCAPE)
+    return six.moves.urllib.parse.quote(
+        text, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE
+    )
+
 
 def _quote_plus(text):
-    return six.moves.urllib.parse.quote_plus(text,
-                                             encoding=UTF8_ENCODING,
-                                             errors=SURROGATE_ESCAPE)
+    return six.moves.urllib.parse.quote_plus(
+        text, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE
+    )
+
 
 def _unquote(text):
-    return six.moves.urllib.parse.unquote(text,
-                                          encoding=UTF8_ENCODING,
-                                          errors=SURROGATE_ESCAPE)
+    return six.moves.urllib.parse.unquote(
+        text, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE
+    )
+
 
 def _unquote_plus(text):
-    return six.moves.urllib.parse.unquote_plus(text,
-                                               encoding=UTF8_ENCODING,
-                                               errors=SURROGATE_ESCAPE)
+    return six.moves.urllib.parse.unquote_plus(
+        text, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE
+    )
+
 
 quote = _quote
 quote_plus = _quote_plus
@@ -935,50 +993,58 @@ except TypeError:
     unquote = six.moves.urllib.parse.unquote
     unquote_plus = six.moves.urllib.parse.unquote_plus
 
+
 def quote_url(url_text):
-    (scheme, netloc, path, params, query, fragment) = six.moves.urllib.parse.urlparse(url_text)
+    (scheme, netloc, path, params, query, fragment) = six.moves.urllib.parse.urlparse(
+        url_text
+    )
     # netloc_quoted = quote(netloc)
     path_quoted = quote(path)
     params_quoted = quote(query)
     query_quoted = quote_plus(query)
     fragment_quoted = quote(fragment)
 
-    url_quoted = six.moves.urllib.parse.urlunparse((scheme,
-                                                    netloc,
-                                                    path_quoted,
-                                                    params_quoted,
-                                                    query_quoted,
-                                                    fragment_quoted))
+    url_quoted = six.moves.urllib.parse.urlunparse(
+        (scheme, netloc, path_quoted, params_quoted, query_quoted, fragment_quoted)
+    )
 
     return url_quoted
 
+
 def unquote_url(url_text):
-    (scheme, netloc, path, params, query, fragment) = six.moves.urllib.parse.urlparse(url_text)
+    (scheme, netloc, path, params, query, fragment) = six.moves.urllib.parse.urlparse(
+        url_text
+    )
     # netloc_unquoted = unquote(netloc)
     path_unquoted = unquote(path)
     params_unquoted = unquote(query)
     query_unquoted = unquote_plus(query)
     fragment_unquoted = unquote(fragment)
 
-    url_unquoted = six.moves.urllib.parse.urlunparse((scheme,
-                                                      netloc,
-                                                      path_unquoted,
-                                                      params_unquoted,
-                                                      query_unquoted,
-                                                      fragment_unquoted))
+    url_unquoted = six.moves.urllib.parse.urlunparse(
+        (
+            scheme,
+            netloc,
+            path_unquoted,
+            params_unquoted,
+            query_unquoted,
+            fragment_unquoted,
+        )
+    )
 
     return url_unquoted
 
 
 def pretty_filesize(bytes):
     if bytes >= 1073741824:
-        return str(int(bytes / 1073741824)) + ' GB'
+        return str(int(bytes / 1073741824)) + " GB"
     elif bytes >= 1048576:
-        return str(int(bytes / 1048576)) + ' MB'
+        return str(int(bytes / 1048576)) + " MB"
     elif bytes >= 1024:
-        return str(int(bytes / 1024)) + ' KB'
+        return str(int(bytes / 1024)) + " KB"
     elif bytes < 1024:
-        return str(bytes) + ' bytes'
+        return str(bytes) + " bytes"
+
 
 def get_node_kind(path):
     if os.path.exists(path):
@@ -989,8 +1055,10 @@ def get_node_kind(path):
 
     return "none"
 
-def walk_tree_depth_first(tree, show_levels=False,
-                          preprocess=None, filter=None, start=None):
+
+def walk_tree_depth_first(
+    tree, show_levels=False, preprocess=None, filter=None, start=None
+):
     """
     A non-recursive generator function that walks through a tree (and all
     children) yielding results.
@@ -1054,17 +1122,19 @@ def walk_tree_depth_first(tree, show_levels=False,
                 yield value
 
         if children:
-            annotated_children = [(level+1, child) for child in children]
+            annotated_children = [(level + 1, child) for child in children]
             annotated_children.reverse()
             to_process.extendleft(annotated_children)
+
 
 def urlize(path):
     if path.startswith("/"):
         return "file://%s" % path
     return path
 
+
 def parse_patch_output(patch_file, base_dir, strip=0):
-    """ Runs the GNU 'patch' utility, parsing the output. This is actually a
+    """Runs the GNU 'patch' utility, parsing the output. This is actually a
     generator which yields values as each section of the patch is applied.
 
     @param patch_file: the location of the patch file
@@ -1091,12 +1161,14 @@ def parse_patch_output(patch_file, base_dir, strip=0):
     #    the file has the wrong version for the Prereq:
     #    line in the patch; and assume that patches are
     #    reversed if they look like they are.
-    env = os.environ.copy().update({"LC_ALL" : "C"})
+    env = os.environ.copy().update({"LC_ALL": "C"})
     p = "-p%s" % strip
-    patch_proc = subprocess.Popen(["patch", "-N", "-t", p, "-i", str(patch_file), "--directory", base_dir],
-                                      stdout = subprocess.PIPE,
-                                      stderr = subprocess.STDOUT,
-                                      env = env)
+    patch_proc = subprocess.Popen(
+        ["patch", "-N", "-t", p, "-i", str(patch_file), "--directory", base_dir],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
 
     # Intialise things...
     out = codecs.getreader(UTF8_ENCODING)(patch_proc.stdout, SURROGATE_ESCAPE)
@@ -1106,7 +1178,7 @@ def parse_patch_output(patch_file, base_dir, strip=0):
     current_file = None
     if patch_match:
         current_file = patch_match.group(1)
-    elif line: # and not patch_match
+    elif line:  # and not patch_match
         # There was output, but unexpected. Almost certainly an error of some
         # sort.
         patch_proc.wait()
@@ -1154,7 +1226,7 @@ def parse_patch_output(patch_file, base_dir, strip=0):
                 reject_file = reject_match.group(1)
             # else: we have an unknown error
 
-    patch_proc.wait() # Don't leave process running...
+    patch_proc.wait()  # Don't leave process running...
     return
 
 
@@ -1212,6 +1284,7 @@ The following class implements a mechanism to avoid that:
 For this reason, the current module MAY NOT import Gdk, directly or
 indirectly.
 """
+
 
 class SanitizeArgv(object):
     def __init__(self):

--- a/rabbitvcs/util/highlighter.py
+++ b/rabbitvcs/util/highlighter.py
@@ -42,18 +42,22 @@ try:
 except:
     HAS_PYGMENTS = False
 
+
 def mklist(arg):
     if not isinstance(arg, list):
         arg = [arg]
     return arg
+
 
 def no_highlight(lines):
     return [html_escape(S(l), True) for l in mklist(lines)]
 
 
 if not HAS_PYGMENTS:
+
     def highlight(filename, sourcelines):
         return no_highlight(sourcelines)
+
 else:
     # Pygments custom formatter generating Pango makup language.
 
@@ -113,7 +117,6 @@ else:
 
                 self.lastval += value
 
-
             for ttype, value in tokensource:
                 lines = [value]
                 if self.bylines:
@@ -132,7 +135,6 @@ else:
                         format_single(self, ttype, line)
 
             flush(self)
-
 
     def highlight(filename, sourcelines):
         if not SettingsManager().get("general", "enable_highlighting"):

--- a/rabbitvcs/util/log.py
+++ b/rabbitvcs/util/log.py
@@ -50,11 +50,11 @@ from rabbitvcs.util.settings import SettingsManager, get_home_folder
 from rabbitvcs.util.strings import *
 
 LEVELS = {
-    "debug":    logging.DEBUG,
-    "info":     logging.INFO,
-    "warning":  logging.WARNING,
-    "error":    logging.ERROR,
-    "critical": logging.CRITICAL
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
 }
 
 settings = SettingsManager()
@@ -77,10 +77,12 @@ if changed:
     settings.write()
 
 LOG_PATH = os.path.join(get_home_folder(), "RabbitVCS.log")
-if not os.path.exists(LOG_PATH): open(LOG_PATH, "a").close()
+if not os.path.exists(LOG_PATH):
+    open(LOG_PATH, "a").close()
 DEFAULT_FORMAT = "%(message)s"
 FILE_FORMAT = "%(asctime)s %(levelname)s\t%(name)s\t%(message)s"
 CONSOLE_FORMAT = "%(levelname)s\t%(name)s\t%(message)s"
+
 
 class BaseLog(object):
     """
@@ -200,6 +202,7 @@ class BaseLog(object):
         self.handler.setFormatter(logging.Formatter(format))
         self.logger.addHandler(self.handler)
 
+
 class ConsoleLog(BaseLog):
     """
     Inherits from BaseLog and provides a simple interface to log calls to the
@@ -250,9 +253,12 @@ class FileLog(BaseLog):
 
         BaseLog.__init__(self, logger, level)
         self.set_handler(
-            logging.handlers.TimedRotatingFileHandler(LOG_PATH, "D", 1, 7, UTF8_ENCODING),
-            FILE_FORMAT
+            logging.handlers.TimedRotatingFileHandler(
+                LOG_PATH, "D", 1, 7, UTF8_ENCODING
+            ),
+            FILE_FORMAT,
         )
+
 
 class DualLog(BaseLog):
     """
@@ -279,10 +285,13 @@ class DualLog(BaseLog):
 
         BaseLog.__init__(self, logger, level)
         self.set_handler(
-            logging.handlers.TimedRotatingFileHandler(LOG_PATH, "D", 1, 7, UTF8_ENCODING),
-            FILE_FORMAT
+            logging.handlers.TimedRotatingFileHandler(
+                LOG_PATH, "D", 1, 7, UTF8_ENCODING
+            ),
+            FILE_FORMAT,
         )
         self.set_handler(logging.StreamHandler(), CONSOLE_FORMAT)
+
 
 class NullHandler(logging.Handler):
     """
@@ -292,6 +301,7 @@ class NullHandler(logging.Handler):
 
     def emit(self, record):
         pass
+
 
 class NullLog(BaseLog):
     """
@@ -304,6 +314,7 @@ class NullLog(BaseLog):
         BaseLog.__init__(self, *args, **kwargs)
         self.set_handler(NullHandler())
 
+
 Log = NullLog
 if DEFAULT_LOG_TYPE == "File":
     Log = FileLog
@@ -311,6 +322,7 @@ elif DEFAULT_LOG_TYPE == "Console":
     Log = ConsoleLog
 elif DEFAULT_LOG_TYPE == "Both":
     Log = DualLog
+
 
 def reload_log_settings():
     """

--- a/rabbitvcs/util/settings.py
+++ b/rabbitvcs/util/settings.py
@@ -38,8 +38,9 @@ import re
 
 from rabbitvcs import package_prefix
 
-MULTILINE_ESCAPE_RE = re.compile(r'''([\\'"])''')
+MULTILINE_ESCAPE_RE = re.compile(r"""([\\'"])""")
 MULTILINE_UNESCAPE_RE = re.compile(r"\\(.)")
+
 
 def get_home_folder():
     """
@@ -58,8 +59,7 @@ def get_home_folder():
     # Make sure we adher to the freedesktop.org XDG Base Directory
     # Specifications. $XDG_CONFIG_HOME if set, by default ~/.config
     xdg_config_home = os.environ.get(
-        "XDG_CONFIG_HOME",
-        os.path.join(os.path.expanduser("~"), ".config")
+        "XDG_CONFIG_HOME", os.path.join(os.path.expanduser("~"), ".config")
     )
     config_home = os.path.join(xdg_config_home, "rabbitvcs")
 
@@ -70,7 +70,9 @@ def get_home_folder():
 
     return config_home
 
+
 SETTINGS_FILE = "%s/settings.conf" % get_home_folder()
+
 
 def find_configspec():
     # Search the following paths for a configspec file
@@ -78,7 +80,7 @@ def find_configspec():
         os.path.join(dirname(__file__), "configspec/configspec.ini"),
         os.path.join(package_prefix(), "share/rabbitvcs/configspec.ini"),
         "/usr/share/rabbitvcs/configspec.ini",
-        "/usr/local/share/rabbitvcs/configspec.ini"
+        "/usr/local/share/rabbitvcs/configspec.ini",
     ]
 
     for path in configspec_paths:
@@ -86,6 +88,7 @@ def find_configspec():
             return path
 
     raise IOError("Cannot find a configspec.ini file")
+
 
 SETTINGS_SPEC = find_configspec()
 
@@ -113,7 +116,7 @@ class SettingsManager(object):
             infile=SETTINGS_FILE,
             create_empty=True,
             indent_type="    ",
-            configspec=SETTINGS_SPEC
+            configspec=SETTINGS_SPEC,
         )
 
         self.validator = validate.Validator()
@@ -132,7 +135,6 @@ class SettingsManager(object):
             # One option is to copy it to a different file and recreate it...
             log.warning("User configuration not valid. Backing up and recreating.")
             self.backup_and_rewrite_config()
-
 
     def get(self, section=None, keyword=None):
         """
@@ -244,10 +246,7 @@ class SettingsManager(object):
 
         """
 
-        self.settings = configobj.ConfigObj(
-            DEFAULT_SETTINGS,
-            indent_type="    "
-        )
+        self.settings = configobj.ConfigObj(DEFAULT_SETTINGS, indent_type="    ")
         self.settings.filename = SETTINGS_FILE
 
     def get_default(self, section, keyword):
@@ -280,7 +279,7 @@ class SettingsManager(object):
 
         return returner
 
-    def backup_and_rewrite_config(self) :
+    def backup_and_rewrite_config(self):
         """
         Backs up the user configuration file (for debugging) and rewrites a
         valid config file.
@@ -300,20 +299,20 @@ class SettingsManager(object):
             # FIXME: is this too paranoid?
             if not os.path.exists(new_name):
 
-                    new_file_free = True
+                new_file_free = True
 
-                    created = False
+                created = False
 
-                    try:
-                        os.rename(SETTINGS_FILE, new_name)
-                        created = True
-                    except IOError:
-                        # Paranoid again?
-                        print("Could not back up user configuration.")
+                try:
+                    os.rename(SETTINGS_FILE, new_name)
+                    created = True
+                except IOError:
+                    # Paranoid again?
+                    print("Could not back up user configuration.")
 
-                    if created:
-                        self.settings.reset()
-                        self.write()
+                if created:
+                    self.settings.reset()
+                    self.write()
             else:
                 renumber += 1
 

--- a/rabbitvcs/util/strings.py
+++ b/rabbitvcs/util/strings.py
@@ -37,9 +37,13 @@ __all__ = ["S", "IDENTITY_ENCODING", "UTF8_ENCODING", "SURROGATE_ESCAPE"]
 unicode_null_string = six.u("")
 non_alpha_num_re = re.compile("[^A-Za-z0-9]+")
 SURROGATE_BASE = 0xDC00
-RE_SURROGATE = re.compile(six.u("[") + six.unichr(SURROGATE_BASE + 0x80) +
-                          six.u("-") + six.unichr(SURROGATE_BASE + 0xFF) +
-                          six.u("]"))
+RE_SURROGATE = re.compile(
+    six.u("[")
+    + six.unichr(SURROGATE_BASE + 0x80)
+    + six.u("-")
+    + six.unichr(SURROGATE_BASE + 0xFF)
+    + six.u("]")
+)
 RE_UTF8 = re.compile("^[Uu][Tt][Ff][ _-]?8$")
 
 #   Codec that maps ord(byte) == ord(unicode_char).
@@ -47,17 +51,17 @@ RE_UTF8 = re.compile("^[Uu][Tt][Ff][ _-]?8$")
 IDENTITY_ENCODING = "latin-1"
 
 
-
 #   An UTF-8 codec that implements surrogates, even in Python 2.
 
 UTF8_ENCODING = "rabbitvcs-utf8"
+
 
 def utf8_decode(input, errors="strict"):
     return codecs.utf_8_decode(input, errors, True)
 
 
 def utf8_encode(input, errors="strict"):
-    output = b''
+    output = b""
     pos = 0
     end = len(input)
     eh = None
@@ -71,9 +75,9 @@ def utf8_encode(input, errors="strict"):
             output += p
             pos = n
         if pos < end:
-            e = UnicodeEncodeError(UTF8_ENCODING,
-                                   input, pos, pos + 1,
-                                   "surrogates not allowed")
+            e = UnicodeEncodeError(
+                UTF8_ENCODING, input, pos, pos + 1, "surrogates not allowed"
+            )
             if not eh:
                 eh = codecs.lookup_error(errors)
             p, n = eh(e)
@@ -83,16 +87,20 @@ def utf8_encode(input, errors="strict"):
             pos = n
     return (output, len(input))
 
+
 class Utf8IncrementalEncoder(codecs.IncrementalEncoder):
     def encode(self, input, final=False):
         return utf8_encode(input, self.errors)[0]
 
+
 class Utf8IncrementalDecoder(codecs.BufferedIncrementalDecoder):
     _buffer_decode = codecs.utf_8_decode
 
+
 class Utf8StreamWriter(codecs.StreamWriter):
-    def encode(self, input, errors='strict'):
+    def encode(self, input, errors="strict"):
         return utf8_encode(input, errors)
+
 
 class Utf8StreamReader(codecs.StreamReader):
     decode = codecs.utf_8_decode
@@ -103,14 +111,15 @@ def utf8_search(encoding):
     if encoding != UTF8_ENCODING:
         return None
     return codecs.CodecInfo(
-                   name=UTF8_ENCODING,
-                   encode=utf8_encode,
-                   decode=utf8_decode,
-                   incrementalencoder=Utf8IncrementalEncoder,
-                   incrementaldecoder=Utf8IncrementalDecoder,
-                   streamwriter=Utf8StreamWriter,
-                   streamreader=Utf8StreamReader
+        name=UTF8_ENCODING,
+        encode=utf8_encode,
+        decode=utf8_decode,
+        incrementalencoder=Utf8IncrementalEncoder,
+        incrementaldecoder=Utf8IncrementalDecoder,
+        streamwriter=Utf8StreamWriter,
+        streamreader=Utf8StreamReader,
     )
+
 
 codecs.register(utf8_search)
 
@@ -120,13 +129,16 @@ codecs.register(utf8_search)
 
 SURROGATE_ESCAPE = "rabbitvcs-surrogateescape"
 
+
 def rabbitvcs_surrogate_escape(e):
     if not isinstance(e, UnicodeError):
         raise e
-    input = e.object[e.start:e.end]
+    input = e.object[e.start : e.end]
     if isinstance(e, UnicodeDecodeError):
-        output = [six.unichr(b) if b < 0x80 else                             \
-                  six.unichr(SURROGATE_BASE + b) for b in bytearray(input)]
+        output = [
+            six.unichr(b) if b < 0x80 else six.unichr(SURROGATE_BASE + b)
+            for b in bytearray(input)
+        ]
         return (unicode_null_string.join(output), e.end)
     if isinstance(e, UnicodeEncodeError):
         output = b""
@@ -137,6 +149,7 @@ def rabbitvcs_surrogate_escape(e):
             output += six.int2byte(b)
         return (output, e.end)
     raise e
+
 
 codecs.register_error(SURROGATE_ESCAPE, rabbitvcs_surrogate_escape)
 
@@ -179,7 +192,7 @@ class S(str):
             encoding, errors = self._codeargs(encoding, errors)
             return str.decode(self, encoding, errors)
 
-        def display(self, encoding=None, errors='replace'):
+        def display(self, encoding=None, errors="replace"):
             encoding, errors = self._codeargs(encoding, errors)
             value = str.decode(self, UTF8_ENCODING, errors)
             return value.encode(encoding, errors)
@@ -201,9 +214,9 @@ class S(str):
             return str.encode(self, encoding, errors)
 
         def decode(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
-            return str(self);
+            return str(self)
 
-        def display(self, encoding=None, errors='replace'):
+        def display(self, encoding=None, errors="replace"):
             return RE_SURROGATE.sub(six.unichr(0xFFFD), self)
 
     def bytes(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
@@ -223,6 +236,6 @@ class S(str):
                 encoding = sys.getdefaultencoding()
         if RE_UTF8.match(encoding):
             encoding = UTF8_ENCODING
-        if errors.lower() == 'strict':
+        if errors.lower() == "strict":
             errors = SURROGATE_ESCAPE
         return encoding, errors

--- a/rabbitvcs/vcs/__init__.py
+++ b/rabbitvcs/vcs/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -23,9 +24,11 @@ from __future__ import absolute_import
 
 import os.path
 from rabbitvcs import gettext
+
 _ = gettext.gettext
 
 from rabbitvcs.util.log import Log
+
 logger = Log("rabbitvcs.vcs")
 
 from rabbitvcs.util.helper import get_exclude_paths
@@ -35,16 +38,17 @@ settings = SettingsManager()
 
 EXT_UTIL_ERROR = _("The output from '%s' was not able to be processed.\n%s")
 
-VCS_SVN = 'svn'
-VCS_GIT = 'git'
-VCS_MERCURIAL = 'mercurial'
-VCS_DUMMY = 'unknown'
+VCS_SVN = "svn"
+VCS_GIT = "git"
+VCS_MERCURIAL = "mercurial"
+VCS_DUMMY = "unknown"
 
 VCS_FOLDERS = {}
 if not settings.get("HideItem", "svn"):
     VCS_FOLDERS[".svn"] = VCS_SVN
 if not settings.get("HideItem", "git"):
     VCS_FOLDERS[".git"] = VCS_GIT
+
 
 def _guess(path):
     # Determine the VCS instance based on the path
@@ -54,17 +58,12 @@ def _guess(path):
         while path_to_check != "/" and path_to_check != "":
             for folder, client in list(VCS_FOLDERS.items()):
                 if os.path.isdir(os.path.join(path_to_check, folder)):
-                    cache = {
-                        "vcs": client,
-                        "repo_path": path_to_check
-                    }
+                    cache = {"vcs": client, "repo_path": path_to_check}
                     return cache
             path_to_check = os.path.split(path_to_check)[0]
 
-    return {
-        "vcs": VCS_DUMMY,
-        "repo_path": path
-    }
+    return {"vcs": VCS_DUMMY, "repo_path": path}
+
 
 # Override the standard guessing method to ensure we
 # can return a dummy object if needed
@@ -88,6 +87,7 @@ class VCS(object):
             return self.clients[VCS_DUMMY]
         else:
             from rabbitvcs.vcs.dummy import Dummy
+
             self.clients[VCS_DUMMY] = Dummy()
             return self.clients[VCS_DUMMY]
 
@@ -100,6 +100,7 @@ class VCS(object):
         else:
             try:
                 from rabbitvcs.vcs.svn import SVN
+
                 self.clients[VCS_SVN] = SVN()
                 return self.clients[VCS_SVN]
             except Exception as e:
@@ -128,6 +129,7 @@ class VCS(object):
         else:
             try:
                 from rabbitvcs.vcs.git import Git
+
                 git = Git()
 
                 if path:
@@ -163,6 +165,7 @@ class VCS(object):
         else:
             try:
                 from rabbitvcs.vcs.mercurial import Mercurial
+
                 mercurial = Mercurial()
 
                 if path:
@@ -245,7 +248,7 @@ class VCS(object):
         client = self.client(paths[0])
         return client.get_items(paths, statuses)
 
-    def statuses_for_add(self,paths):
+    def statuses_for_add(self, paths):
         client = self.client(paths[0])
         return client.STATUSES_FOR_ADD
 
@@ -257,26 +260,28 @@ class VCS(object):
         client = self.client(paths[0])
         return client.STATUSES_FOR_REVERT
 
+
 def create_vcs_instance(path=None, vcs=None):
     """
     Create a VCS instance based on the working copy path
     """
     return VCS()
 
+
 def guess_vcs(path):
     vcs = VCS()
     return vcs.guess(path)
 
+
 class ExternalUtilError(Exception):
-    """ Represents an error caused by unexpected output from an external
+    """Represents an error caused by unexpected output from an external
     program.
     """
 
     def __init__(self, program, output):
-        """ Initialises the error with the external tool and the unexpected
+        """Initialises the error with the external tool and the unexpected
         output.
         """
-        Exception.__init__(self,
-                           EXT_UTIL_ERROR % (program, output))
+        Exception.__init__(self, EXT_UTIL_ERROR % (program, output))
         self.program = program
         self.output = output

--- a/rabbitvcs/vcs/branch.py
+++ b/rabbitvcs/vcs/branch.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.

--- a/rabbitvcs/vcs/git/__init__.py
+++ b/rabbitvcs/vcs/git/__init__.py
@@ -43,6 +43,7 @@ from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.vcs.git")
 
 from rabbitvcs import gettext
+
 _ = gettext.gettext
 
 
@@ -64,7 +65,7 @@ class Revision(object):
     def __str__(self):
         if self.value:
             return S(self.value)
-        return  S(self.kind)
+        return S(self.kind)
 
     def __unicode__(self):
         return self.__str__().unicode()
@@ -84,37 +85,30 @@ class Revision(object):
 
 class Git(object):
     STATUS = {
-        "normal":       gittyup.objects.NormalStatus,
-        "added":        gittyup.objects.AddedStatus,
-        "renamed":      gittyup.objects.RenamedStatus,
-        "removed":      gittyup.objects.RemovedStatus,
-        "modified":     gittyup.objects.ModifiedStatus,
-        "killed":       gittyup.objects.KilledStatus,
-        "untracked":    gittyup.objects.UntrackedStatus,
-        "missing":      gittyup.objects.MissingStatus
+        "normal": gittyup.objects.NormalStatus,
+        "added": gittyup.objects.AddedStatus,
+        "renamed": gittyup.objects.RenamedStatus,
+        "removed": gittyup.objects.RemovedStatus,
+        "modified": gittyup.objects.ModifiedStatus,
+        "killed": gittyup.objects.KilledStatus,
+        "untracked": gittyup.objects.UntrackedStatus,
+        "missing": gittyup.objects.MissingStatus,
     }
 
     STATUS_REVERSE = {
-        gittyup.objects.NormalStatus:       "normal",
-        gittyup.objects.AddedStatus:        "added",
-        gittyup.objects.RenamedStatus:      "renamed",
-        gittyup.objects.RemovedStatus:      "removed",
-        gittyup.objects.ModifiedStatus:     "modified",
-        gittyup.objects.KilledStatus:       "killed",
-        gittyup.objects.UntrackedStatus:    "untracked",
-        gittyup.objects.MissingStatus:      "missing"
+        gittyup.objects.NormalStatus: "normal",
+        gittyup.objects.AddedStatus: "added",
+        gittyup.objects.RenamedStatus: "renamed",
+        gittyup.objects.RemovedStatus: "removed",
+        gittyup.objects.ModifiedStatus: "modified",
+        gittyup.objects.KilledStatus: "killed",
+        gittyup.objects.UntrackedStatus: "untracked",
+        gittyup.objects.MissingStatus: "missing",
     }
 
-    STATUSES_FOR_REVERT = [
-        "missing",
-        "renamed",
-        "modified",
-        "removed"
-    ]
+    STATUSES_FOR_REVERT = ["missing", "renamed", "modified", "removed"]
 
-    STATUSES_FOR_ADD = [
-        "untracked"
-    ]
+    STATUSES_FOR_ADD = ["untracked"]
 
     STATUSES_FOR_COMMIT = [
         "untracked",
@@ -122,16 +116,12 @@ class Git(object):
         "renamed",
         "modified",
         "added",
-        "removed"
+        "removed",
     ]
 
-    STATUSES_FOR_STAGE = [
-        "untracked"
-    ]
+    STATUSES_FOR_STAGE = ["untracked"]
 
-    STATUSES_FOR_UNSTAGE = [
-        "added"
-    ]
+    STATUSES_FOR_UNSTAGE = ["added"]
 
     def __init__(self, repo=None):
         self.vcs = rabbitvcs.vcs.VCS_GIT
@@ -229,8 +219,7 @@ class Git(object):
         return path_status
 
     def is_working_copy(self, path):
-        if (os.path.isdir(path) and
-                os.path.isdir(os.path.join(path, ".git"))):
+        if os.path.isdir(path) and os.path.isdir(os.path.join(path, ".git")):
             return True
         return False
 
@@ -238,7 +227,7 @@ class Git(object):
         if self.is_working_copy(path):
             return True
 
-        return (self.find_repository_path(os.path.split(path)[0]) != "")
+        return self.find_repository_path(os.path.split(path)[0]) != ""
 
     def is_versioned(self, path):
         if self.is_working_copy(path):
@@ -327,7 +316,6 @@ class Git(object):
 
     def is_tracking(self, name):
         return self.client.is_tracking("refs/heads/%s" % name)
-
 
     #
     # Action Methods
@@ -443,12 +431,14 @@ class Git(object):
         results = self.client.branch_list(revision_str)
         branches = []
         for result in results:
-            branches.append(BranchEntry(
-                result["name"],
-                result["tracking"],
-                result["revision"],
-                result["message"]
-            ))
+            branches.append(
+                BranchEntry(
+                    result["name"],
+                    result["tracking"],
+                    result["revision"],
+                    result["message"],
+                )
+            )
 
         return branches
 
@@ -460,7 +450,7 @@ class Git(object):
                     result["name"],
                     result["tracking"],
                     result["revision"],
-                    result["message"]
+                    result["message"],
                 )
 
         return None
@@ -501,9 +491,19 @@ class Git(object):
 
         return self.client.clone(host, path, bare, origin)
 
-    def commit(self, message, parents=None, committer=None, commit_time=None,
-            commit_timezone=None, author=None, author_time=None,
-            author_timezone=None, encoding=None, commit_all=False):
+    def commit(
+        self,
+        message,
+        parents=None,
+        committer=None,
+        commit_time=None,
+        commit_timezone=None,
+        author=None,
+        author_time=None,
+        author_timezone=None,
+        encoding=None,
+        commit_all=False,
+    ):
         """
         Commit staged files to the local repository
 
@@ -543,9 +543,18 @@ class Git(object):
 
         """
 
-        return self.client.commit(message, parents, committer, commit_time,
-            commit_timezone, author, author_time, author_timezone, encoding,
-            commit_all)
+        return self.client.commit(
+            message,
+            parents,
+            committer,
+            commit_time,
+            commit_timezone,
+            author,
+            author_time,
+            author_timezone,
+            encoding,
+            commit_all,
+        )
 
     def remove(self, paths):
         """
@@ -589,7 +598,9 @@ class Git(object):
 
         return self.client.pull(repository, refspec, options)
 
-    def push(self, repository="origin", refspec="master", tags=True, force_with_lease=False):
+    def push(
+        self, repository="origin", refspec="master", tags=True, force_with_lease=False
+    ):
         """
         Push objects from the local repository into the remote repository
             and merge them.
@@ -735,8 +746,9 @@ class Git(object):
 
         return self.client.tag_list()
 
-
-    def log(self, path=None, skip=0, limit=None, revision=Revision("HEAD"), showtype="all"):
+    def log(
+        self, path=None, skip=0, limit=None, revision=Revision("HEAD"), showtype="all"
+    ):
         """
         Returns a revision history list
 
@@ -768,6 +780,7 @@ class Git(object):
         # Temporarily change the locale to en_US so strptime can work consistently
         # Then change it back at the end of the method
         import locale
+
         current_locale = locale.getlocale()
         if current_locale[0] is not None:
             locale.setlocale(locale.LC_ALL, "C")
@@ -794,13 +807,16 @@ class Git(object):
             changed_paths = []
             if "changed_paths" in item:
                 for changed_path in item["changed_paths"]:
-                    action = "+%s/-%s" % (changed_path["additions"], changed_path["removals"])
+                    action = "+%s/-%s" % (
+                        changed_path["additions"],
+                        changed_path["removals"],
+                    )
 
-                    changed_paths.append(rabbitvcs.vcs.log.LogChangedPath(
-                        changed_path["path"],
-                        action,
-                        "", ""
-                    ))
+                    changed_paths.append(
+                        rabbitvcs.vcs.log.LogChangedPath(
+                            changed_path["path"], action, "", ""
+                        )
+                    )
 
             parents = []
             if "parents" in item:
@@ -811,15 +827,11 @@ class Git(object):
             if item["commit"] == self.client.head():
                 head = True
 
-            returner.append(rabbitvcs.vcs.log.Log(
-                date,
-                revision,
-                author,
-                message,
-                changed_paths,
-                parents,
-                head
-            ))
+            returner.append(
+                rabbitvcs.vcs.log.Log(
+                    date, revision, author, message, changed_paths, parents, head
+                )
+            )
 
         locale.setlocale(locale.LC_ALL, current_locale)
 
@@ -843,12 +855,15 @@ class Git(object):
 
         """
 
-        summary_raw = self.client.diff_summarize(path1, revision_obj1.primitive(),
-            path2, revision_obj2.primitive())
+        summary_raw = self.client.diff_summarize(
+            path1, revision_obj1.primitive(), path2, revision_obj2.primitive()
+        )
 
         summary = []
         for item in summary_raw:
-            summary.append(rabbitvcs.vcs.log.LogChangedPath(item["path"], item["action"], "", ""))
+            summary.append(
+                rabbitvcs.vcs.log.LogChangedPath(item["path"], item["action"], "", "")
+            )
 
         return summary
 
@@ -898,8 +913,9 @@ class Git(object):
 
         """
 
-        return self.client.diff(path1, revision_obj1.primitive(), path2,
-            revision_obj2.primitive())
+        return self.client.diff(
+            path1, revision_obj1.primitive(), path2, revision_obj2.primitive()
+        )
 
     def apply_patch(self, patch_file, base_dir):
         """
@@ -915,28 +931,30 @@ class Git(object):
 
         any_failures = False
 
-        for file, success, rej_file in helper.parse_patch_output(patch_file, base_dir, 1):
+        for file, success, rej_file in helper.parse_patch_output(
+            patch_file, base_dir, 1
+        ):
 
             fullpath = os.path.join(base_dir, file)
 
             event_dict = dict()
 
             event_dict["path"] = file
-            event_dict["mime_type"] = "" # meh
+            event_dict["mime_type"] = ""  # meh
 
             if success:
-                event_dict["action"] = _("Patched") # not in pysvn, but
-                                                    # we have a fallback
+                event_dict["action"] = _("Patched")  # not in pysvn, but
+                # we have a fallback
             else:
                 any_failures = True
-                event_dict["action"] = _("Patch Failed") # better wording needed?
+                event_dict["action"] = _("Patch Failed")  # better wording needed?
 
             if rej_file:
                 rej_info = {
-                    "path" : rej_file,
-                    "action" : _("Rejected Patch"),
-                    "mime_type" : None
-                            }
+                    "path": rej_file,
+                    "action": _("Rejected Patch"),
+                    "mime_type": None,
+                }
 
             if self.client.callback_notify:
                 self.client.callback_notify(event_dict)
@@ -960,11 +978,19 @@ class Git(object):
 
         return self.client.export(path, dest_path, revision.primitive())
 
-    def clean(self, path, remove_dir=True, remove_ignored_too=False,
-            remove_only_ignored=False, dry_run=False, force=True):
+    def clean(
+        self,
+        path,
+        remove_dir=True,
+        remove_ignored_too=False,
+        remove_only_ignored=False,
+        dry_run=False,
+        force=True,
+    ):
 
-        return self.client.clean(path, remove_dir, remove_ignored_too,
-            remove_only_ignored, dry_run, force)
+        return self.client.clean(
+            path, remove_dir, remove_ignored_too, remove_only_ignored, dry_run, force
+        )
 
     def reset(self, path, revision, type=None):
         """
@@ -998,7 +1024,7 @@ class Git(object):
         self.client.set_callback_notify(func)
 
     def set_callback_progress_update(self, func):
-        self.client.set_callback_progress_update (func)
+        self.client.set_callback_progress_update(func)
 
     def set_callback_get_user(self, func):
         self.client.set_callback_get_user(func)

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # client.py
 #
@@ -22,7 +23,8 @@ import dulwich.repo
 import dulwich.porcelain
 import dulwich.objects
 from dulwich.index import write_index_dict, SHA1Writer
-#from dulwich.patch import write_tree_diff
+
+# from dulwich.patch import write_tree_diff
 
 from .exceptions import *
 from . import util
@@ -44,8 +46,10 @@ RE_STATUS = re.compile("^([\sA-Z\?]+)\s(?:\S+\s->\s)?(.*?)$")
 def callback_notify_null(val):
     pass
 
+
 def callback_get_user():
     from pwd import getpwuid
+
     pwuid = getpwuid(os.getuid())
 
     user = pwuid[0]
@@ -54,17 +58,21 @@ def callback_get_user():
 
     return (fullname, "%s@%s" % (user, host))
 
+
 def callback_get_cancel():
     return False
+
 
 def mkdir_p(path):
     # http://stackoverflow.com/questions/600268/mkdir-p-functionality-in-python
     try:
         os.makedirs(path)
-    except OSError as exc: # Python >2.5
+    except OSError as exc:  # Python >2.5
         if exc.errno == errno.EEXIST and os.path.isdir(path):
             pass
-        else: raise
+        else:
+            raise
+
 
 def get_tmp_path(filename):
     tmpdir = "/tmp/rabbitvcs"
@@ -141,7 +149,10 @@ class GittyupClient(object):
         tree_index = {}
         if tree:
             for item in self.repo.object_store.iter_tree_contents(tree.id):
-                tree_index[item[0].decode(self.UTF8)] = (item[1], item[2].decode(self.UTF8))
+                tree_index[item[0].decode(self.UTF8)] = (
+                    item[1],
+                    item[2].decode(self.UTF8),
+                )
 
         return tree_index
 
@@ -154,9 +165,11 @@ class GittyupClient(object):
             return self.git_version
         else:
             try:
-                proc = subprocess.Popen(["git", "--version"],
-                                        stdout=subprocess.PIPE,
-                                        universal_newlines=True)
+                proc = subprocess.Popen(
+                    ["git", "--version"],
+                    stdout=subprocess.PIPE,
+                    universal_newlines=True,
+                )
                 response = proc.communicate()[0].split()
                 version = [int(x) for x in response[2].split(".")]
                 self.git_version = version
@@ -194,7 +207,7 @@ class GittyupClient(object):
         files.append(excludefile)
 
         try:
-            core_excludesfile = self._config_get(("core", ), "excludesfile")
+            core_excludesfile = self._config_get(("core",), "excludesfile")
             if core_excludesfile:
                 files.append(core_excludesfile)
         except KeyError:
@@ -276,8 +289,8 @@ class GittyupClient(object):
 
             directories.append(rel_root)
 
-        #Remove duplicates in list
-        directories=list(set(directories))
+        # Remove duplicates in list
+        directories = list(set(directories))
         return (sorted(files), directories)
 
     def _get_blob_from_file(self, path):
@@ -323,8 +336,8 @@ class GittyupClient(object):
 
     def _get_config_user(self):
         try:
-            config_user_name = S(self._config_get(("user", ), "name"))
-            config_user_email = S(self._config_get(("user", ), "email"))
+            config_user_name = S(self._config_get(("user",), "name"))
+            config_user_email = S(self._config_get(("user",), "email"))
             if config_user_name == "" or config_user_email == "":
                 raise KeyError()
         except KeyError:
@@ -333,8 +346,8 @@ class GittyupClient(object):
             if config_user_name == None and config_user_email == None:
                 return None
 
-        self._config_set(("user", ), "name", config_user_name)
-        self._config_set(("user", ), "email", config_user_email)
+        self._config_set(("user",), "name", config_user_name)
+        self._config_set(("user",), "email", config_user_email)
         self.config.write_to_path()
         return "%s <%s>" % (config_user_name, config_user_email)
 
@@ -394,7 +407,7 @@ class GittyupClient(object):
         self.repo.refs.set_symbolic_ref(b"HEAD", name)
 
     def is_tracking(self, name):
-        return (self.repo.refs.read_ref(b"HEAD")[5:] == name)
+        return self.repo.refs.read_ref(b"HEAD")[5:] == name
 
     def tracking(self):
         return self.repo.refs.read_ref(b"HEAD")[5:]
@@ -420,11 +433,13 @@ class GittyupClient(object):
             relative_path = self.get_relative_path(path)
             absolute_path = self.get_absolute_path(path)
 
-            self.notify({
-                "action": "Staged",
-                "path": absolute_path,
-                "mime_type": guess_type(absolute_path)[0]
-            })
+            self.notify(
+                {
+                    "action": "Staged",
+                    "path": absolute_path,
+                    "mime_type": guess_type(absolute_path)[0],
+                }
+            )
             to_stage.append(S(relative_path))
         self.repo.stage(to_stage)
 
@@ -465,7 +480,18 @@ class GittyupClient(object):
             relative_path = S(self.get_relative_path(path)).bytes()
             if relative_path in index:
                 if relative_path in tree:
-                    (ctime, mtime, dev, ino, mode, uid, gid, size, blob_id, flags) = index[relative_path]
+                    (
+                        ctime,
+                        mtime,
+                        dev,
+                        ino,
+                        mode,
+                        uid,
+                        gid,
+                        size,
+                        blob_id,
+                        flags,
+                    ) = index[relative_path]
                     (mode, blob_id) = tree[relative_path]
 
                     # If the file is locally modified, set these vars to 0
@@ -481,18 +507,38 @@ class GittyupClient(object):
                         gid = 0
                         size = 0
 
-                    index[relative_path] = (ctime, mtime, dev, ino, mode, uid, gid, size, blob_id, flags)
+                    index[relative_path] = (
+                        ctime,
+                        mtime,
+                        dev,
+                        ino,
+                        mode,
+                        uid,
+                        gid,
+                        size,
+                        blob_id,
+                        flags,
+                    )
                 else:
                     del index[relative_path]
             else:
                 if relative_path in tree:
-                    index[relative_path] = (0, 0, 0, 0, tree[relative_path][0], 0, 0, 0, tree[relative_path][1], 0)
+                    index[relative_path] = (
+                        0,
+                        0,
+                        0,
+                        0,
+                        tree[relative_path][0],
+                        0,
+                        0,
+                        0,
+                        tree[relative_path][1],
+                        0,
+                    )
 
-        self.notify({
-            "action": "Unstaged",
-            "path": path,
-            "mime_type": guess_type(path)[0]
-        })
+        self.notify(
+            {"action": "Unstaged", "path": path, "mime_type": guess_type(path)[0]}
+        )
         index.write()
 
     def unstage_all(self):
@@ -549,7 +595,7 @@ class GittyupClient(object):
             staged_files = self.get_staged()
 
         relative_path = self.get_relative_path(path)
-        return (relative_path in staged_files)
+        return relative_path in staged_files
 
     def branch(self, name, commit_sha=None, track=False):
         """
@@ -577,7 +623,9 @@ class GittyupClient(object):
         cmd += [name, commit_sha]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -640,7 +688,9 @@ class GittyupClient(object):
             cmd += ["--contains", commit_sha]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -656,18 +706,20 @@ class GittyupClient(object):
             if components[0] == "(no":
                 name = components.pop(0) + " " + components.pop(0)
             elif components[0] == "(HEAD":
-                continue            # Detached head is not a branch.
+                continue  # Detached head is not a branch.
             else:
-               name = components.pop(0)
+                name = components.pop(0)
             revision = components.pop(0)
             message = " ".join(components)
 
-            branches.append({
-                "tracking": tracking,
-                "name": name,
-                "revision": revision,
-                "message": message
-            })
+            branches.append(
+                {
+                    "tracking": tracking,
+                    "name": name,
+                    "revision": revision,
+                    "message": message,
+                }
+            )
 
         return branches
 
@@ -691,10 +743,11 @@ class GittyupClient(object):
         cmd = ["git", "checkout", "-m", revision] + paths
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
-
 
     def clone(self, host, path, bare=False, origin="origin"):
         """
@@ -716,7 +769,7 @@ class GittyupClient(object):
 
         self.numberOfCommandStages = 3
 
-        more = ["-o", "origin","--progress"]
+        more = ["-o", "origin", "--progress"]
         if bare:
             more.append("--bare")
 
@@ -729,15 +782,20 @@ class GittyupClient(object):
         self.modifiedHost = host
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=base_dir, notify=self.notify_and_parse_progress, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd,
+                cwd=base_dir,
+                notify=self.notify_and_parse_progress,
+                cancel=self.get_cancel(),
+            ).execute()
 
-            if stdout[1].find('could not read Username') > -1:
+            if stdout[1].find("could not read Username") > -1:
                 # Prompt for username if it does not exist in the url.
                 isUsername, originalRemoteUrl = self.promptUsername(self.modifiedHost)
 
                 # Prompt for password if a username exists in the remote url without a password.
                 isPassword, originalRemoteUrl2 = self.promptPassword(self.modifiedHost)
-            elif stdout[1].find('could not read Password') > -1:
+            elif stdout[1].find("could not read Password") > -1:
                 # Prompt for password if a username exists in the remote url without a password.
                 isPassword, originalRemoteUrl = self.promptPassword(self.modifiedHost)
 
@@ -746,7 +804,12 @@ class GittyupClient(object):
                 cmd = ["git", "clone", self.modifiedHost, path] + more
 
                 # Try again.
-                (status, stdout, stderr) = GittyupCommand(cmd, cwd=base_dir, notify=self.notify_and_parse_progress, cancel=self.get_cancel()).execute()
+                (status, stdout, stderr) = GittyupCommand(
+                    cmd,
+                    cwd=base_dir,
+                    notify=self.notify_and_parse_progress,
+                    cancel=self.get_cancel(),
+                ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -757,12 +820,22 @@ class GittyupClient(object):
             self._load_config()
 
             # Write original url back to config.
-            self._config_set("remote \"origin\"", "url", host)
+            self._config_set('remote "origin"', "url", host)
             self.config.write_to_path()
 
-    def commit(self, message, parents=None, committer=None, commit_time=None,
-            commit_timezone=None, author=None, author_time=None,
-            author_timezone=None, encoding=None, commit_all=False):
+    def commit(
+        self,
+        message,
+        parents=None,
+        committer=None,
+        commit_time=None,
+        commit_timezone=None,
+        author=None,
+        author_time=None,
+        author_timezone=None,
+        encoding=None,
+        commit_all=False,
+    ):
         """
         Commit staged files to the local repository
 
@@ -812,7 +885,9 @@ class GittyupClient(object):
         if commit_timezone is None:
             commit_timezone = helper.utc_offset()
 
-        commit_id = self.repo.do_commit(**helper.to_bytes({
+        commit_id = self.repo.do_commit(
+            **helper.to_bytes(
+                {
                     "message": message,
                     "committer": committer,
                     "commit_timestamp": commit_time,
@@ -821,21 +896,25 @@ class GittyupClient(object):
                     "author_timestamp": author_time,
                     "author_timezone": author_timezone,
                     "encoding": encoding,
-                    "merge_heads": parents}, encoding))
+                    "merge_heads": parents,
+                },
+                encoding,
+            )
+        )
 
         branch_full = self.repo.refs.read_ref(b"HEAD")
 
         if branch_full is not None:
             branch_components = re.search(b"refs/heads/(.+)", branch_full)
 
-            if (branch_components != None):
+            if branch_components != None:
                 branch = branch_components.group(1)
 
                 self.notify("[%s] -> %s" % (S(commit_id), S(branch)))
                 self.notify("To branch: " + S(branch))
 
-        #Print tree changes.
-        #dulwich.patch.write_tree_diff(sys.stdout, self.repo.object_store, commit.tree, commit.id)
+        # Print tree changes.
+        # dulwich.patch.write_tree_diff(sys.stdout, self.repo.object_store, commit.tree, commit.id)
 
         return commit_id
 
@@ -926,29 +1005,39 @@ class GittyupClient(object):
             if options.count("all"):
                 cmd.append("--all")
             else:
-                cmd.append (repository)
-                cmd.append (refspec)
+                cmd.append(repository)
+                cmd.append(refspec)
 
         # Setup the section name in the config for the remote target.
-        remoteKey = "remote \"" + repository + "\""
+        remoteKey = 'remote "' + repository + '"'
         isUsername = False
         isPassword = False
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel()).execute()
-            if stdout[0].find('could not read Username') > -1:
+            (status, stdout, stderr) = GittyupCommand(
+                cmd,
+                cwd=self.repo.path,
+                notify=self.notify_and_parse_git_push,
+                cancel=self.get_cancel(),
+            ).execute()
+            if stdout[0].find("could not read Username") > -1:
                 # Prompt for username if it does not exist in the url.
                 isUsername, originalRemoteUrl = self.promptUsername(remoteKey)
 
                 # Prompt for password if a username exists in the remote url without a password.
                 isPassword, originalRemoteUrl2 = self.promptPassword(remoteKey)
-            elif stdout[0].find('could not read Password') > -1:
+            elif stdout[0].find("could not read Password") > -1:
                 # Prompt for password if a username exists in the remote url without a password.
                 isPassword, originalRemoteUrl = self.promptPassword(remoteKey)
 
             if isUsername == True or isPassword == True:
                 # Try again.
-                (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel()).execute()
+                (status, stdout, stderr) = GittyupCommand(
+                    cmd,
+                    cwd=self.repo.path,
+                    notify=self.notify_and_parse_git_push,
+                    cancel=self.get_cancel(),
+                ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -958,7 +1047,9 @@ class GittyupClient(object):
             self._config_set(remoteKey, "url", originalRemoteUrl)
             self.config.write_to_path()
 
-    def push(self, repository="origin", refspec="master", tags=True, force_with_lease=False):
+    def push(
+        self, repository="origin", refspec="master", tags=True, force_with_lease=False
+    ):
         """
         Push objects from the local repository into the remote repository
             and merge them.
@@ -984,25 +1075,35 @@ class GittyupClient(object):
         cmd.extend([repository, refspec])
 
         # Setup the section name in the config for the remote target.
-        remoteKey = "remote \"" + repository + "\""
+        remoteKey = 'remote "' + repository + '"'
         isUsername = False
         isPassword = False
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel()).execute()
-            if stdout[0].find('could not read Username') > -1:
+            (status, stdout, stderr) = GittyupCommand(
+                cmd,
+                cwd=self.repo.path,
+                notify=self.notify_and_parse_git_push,
+                cancel=self.get_cancel(),
+            ).execute()
+            if stdout[0].find("could not read Username") > -1:
                 # Prompt for username if it does not exist in the url.
                 isUsername, originalRemoteUrl = self.promptUsername(remoteKey)
 
                 # Prompt for password if a username exists in the remote url without a password.
                 isPassword, originalRemoteUrl2 = self.promptPassword(remoteKey)
-            elif stdout[0].find('could not read Password') > -1:
+            elif stdout[0].find("could not read Password") > -1:
                 # Prompt for password if a username exists in the remote url without a password.
                 isPassword, originalRemoteUrl = self.promptPassword(remoteKey)
 
             if isUsername == True or isPassword == True:
                 # Try again.
-                (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify_and_parse_git_push, cancel=self.get_cancel()).execute()
+                (status, stdout, stderr) = GittyupCommand(
+                    cmd,
+                    cwd=self.repo.path,
+                    notify=self.notify_and_parse_git_push,
+                    cancel=self.get_cancel(),
+                ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1015,7 +1116,9 @@ class GittyupClient(object):
     def onUsername(self, window, username, remoteKey, originalRemoteUrl, isOk):
         if isOk == True:
             if username == "":
-                six.moves.tkinter_messagebox.showinfo("Error", "Please enter a username.", parent=window)
+                six.moves.tkinter_messagebox.showinfo(
+                    "Error", "Please enter a username.", parent=window
+                )
                 return
             else:
                 # Insert password into url.
@@ -1035,7 +1138,9 @@ class GittyupClient(object):
     def onPassword(self, window, password, remoteKey, originalRemoteUrl, isOk):
         if isOk == True:
             if password == "":
-                six.moves.tkinter_messagebox.showinfo("Error", "Please enter a password.", parent=window)
+                six.moves.tkinter_messagebox.showinfo(
+                    "Error", "Please enter a password.", parent=window
+                )
                 return
             else:
                 # Insert password into url.
@@ -1066,12 +1171,12 @@ class GittyupClient(object):
             # Get existing url from config, otherwise just use what was provided (the url from cloning, etc).
             originalRemoteUrl = S(self._config_get(remoteKey, "url"))
 
-        if originalRemoteUrl.find('@') == -1:
+        if originalRemoteUrl.find("@") == -1:
             # No username or password. Prompt for both. Create dialog.
             window = six.moves.tkinter.Tk()
 
             window.title("Please enter your username")
-            window.resizable(0,0)
+            window.resizable(0, 0)
             window["padx"] = 40
             window["pady"] = 20
             textFrame = six.moves.tkinter.Frame(window)
@@ -1084,19 +1189,51 @@ class GittyupClient(object):
             # Create textbox.
             entryWidget = six.moves.tkinter.Entry(textFrame)
             entryWidget["width"] = 25
-            entryWidget.bind("<Return>", (lambda event: self.onUsername(window, entryWidget.get(), remoteKey, originalRemoteUrl, True)))
-            entryWidget.bind("<KP_Enter>", (lambda event: self.onUsername(window, entryWidget.get(), remoteKey, originalRemoteUrl, True)))
+            entryWidget.bind(
+                "<Return>",
+                (
+                    lambda event: self.onUsername(
+                        window, entryWidget.get(), remoteKey, originalRemoteUrl, True
+                    )
+                ),
+            )
+            entryWidget.bind(
+                "<KP_Enter>",
+                (
+                    lambda event: self.onUsername(
+                        window, entryWidget.get(), remoteKey, originalRemoteUrl, True
+                    )
+                ),
+            )
             entryWidget.pack(side=six.moves.tkinter.LEFT)
-            entryWidget.focus();
+            entryWidget.focus()
 
             textFrame.pack()
 
             # Create OK button.
-            button = six.moves.tkinter.Button(window, width=5, text="OK", command = (lambda: self.onUsername(window, entryWidget.get(), remoteKey, originalRemoteUrl, True)))
+            button = six.moves.tkinter.Button(
+                window,
+                width=5,
+                text="OK",
+                command=(
+                    lambda: self.onUsername(
+                        window, entryWidget.get(), remoteKey, originalRemoteUrl, True
+                    )
+                ),
+            )
             button.pack(side=six.moves.tkinter.RIGHT)
 
             # Create Cancel button.
-            button = six.moves.tkinter.Button(window, width=5, text="Cancel", command = (lambda: self.onUsername(window, entryWidget.get(), remoteKey, originalRemoteUrl, False)))
+            button = six.moves.tkinter.Button(
+                window,
+                width=5,
+                text="Cancel",
+                command=(
+                    lambda: self.onUsername(
+                        window, entryWidget.get(), remoteKey, originalRemoteUrl, False
+                    )
+                ),
+            )
             button.pack(side=six.moves.tkinter.RIGHT)
 
             # Position window in center of screen.
@@ -1124,12 +1261,12 @@ class GittyupClient(object):
             originalRemoteUrl = S(self._config_get(remoteKey, "url"))
 
         # If the url contains a username (@) without a password (:), then prompt for a password.
-        if originalRemoteUrl.find('@') > -1 and originalRemoteUrl.rfind(':') <= 5:
+        if originalRemoteUrl.find("@") > -1 and originalRemoteUrl.rfind(":") <= 5:
             # Prompt for password. Create dialog.
             window = six.moves.tkinter.Tk()
 
             window.title("Please enter your password")
-            window.resizable(0,0)
+            window.resizable(0, 0)
             window["padx"] = 40
             window["pady"] = 20
             textFrame = six.moves.tkinter.Frame(window)
@@ -1143,19 +1280,51 @@ class GittyupClient(object):
             entryWidget = six.moves.tkinter.Entry(textFrame)
             entryWidget["show"] = "*"
             entryWidget["width"] = 25
-            entryWidget.bind("<Return>", (lambda event: self.onPassword(window, entryWidget.get(), remoteKey, originalRemoteUrl, True)))
-            entryWidget.bind("<KP_Enter>", (lambda event: self.onPassword(window, entryWidget.get(), remoteKey, originalRemoteUrl, True)))
+            entryWidget.bind(
+                "<Return>",
+                (
+                    lambda event: self.onPassword(
+                        window, entryWidget.get(), remoteKey, originalRemoteUrl, True
+                    )
+                ),
+            )
+            entryWidget.bind(
+                "<KP_Enter>",
+                (
+                    lambda event: self.onPassword(
+                        window, entryWidget.get(), remoteKey, originalRemoteUrl, True
+                    )
+                ),
+            )
             entryWidget.pack(side=six.moves.tkinter.LEFT)
-            entryWidget.focus();
+            entryWidget.focus()
 
             textFrame.pack()
 
             # Create OK button.
-            button = six.moves.tkinter.Button(window, width=5, text="OK", command = (lambda: self.onPassword(window, entryWidget.get(), remoteKey, originalRemoteUrl, True)))
+            button = six.moves.tkinter.Button(
+                window,
+                width=5,
+                text="OK",
+                command=(
+                    lambda: self.onPassword(
+                        window, entryWidget.get(), remoteKey, originalRemoteUrl, True
+                    )
+                ),
+            )
             button.pack(side=six.moves.tkinter.RIGHT)
 
             # Create Cancel button.
-            button = six.moves.tkinter.Button(window, width=5, text="Cancel", command = (lambda: self.onPassword(window, entryWidget.get(), remoteKey, originalRemoteUrl, False)))
+            button = six.moves.tkinter.Button(
+                window,
+                width=5,
+                text="Cancel",
+                command=(
+                    lambda: self.onPassword(
+                        window, entryWidget.get(), remoteKey, originalRemoteUrl, False
+                    )
+                ),
+            )
             button.pack(side=six.moves.tkinter.RIGHT)
 
             # Position window in center of screen.
@@ -1185,21 +1354,27 @@ class GittyupClient(object):
             cmd.append(branch)
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
     def fetch_all(self):
         cmd = ["git", "fetch", "--all"]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
     def merge(self, branch):
         cmd = ["git", "merge", branch]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1217,7 +1392,9 @@ class GittyupClient(object):
 
         cmd = ["git", "remote", "add", name, host]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1235,7 +1412,9 @@ class GittyupClient(object):
 
         cmd = ["git", "remote", "rename", current_name, new_name]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1253,7 +1432,9 @@ class GittyupClient(object):
 
         cmd = ["git", "remote", "set-url", name, url]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1268,7 +1449,9 @@ class GittyupClient(object):
 
         cmd = ["git", "remote", "rm", name]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1284,7 +1467,9 @@ class GittyupClient(object):
         cmd = ["git", "remote", "-v"]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
@@ -1302,10 +1487,7 @@ class GittyupClient(object):
                         add = False
 
                 if add:
-                    returner.append({
-                        "name": name,
-                        "host": host
-                    })
+                    returner.append({"name": name, "host": host})
 
         return returner
 
@@ -1371,7 +1553,9 @@ class GittyupClient(object):
 
         cmd = ["git", "status", "--porcelain", path]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1406,7 +1590,9 @@ class GittyupClient(object):
         # Determine untracked directories
         cmd = ["git", "clean", "-nd", self.repo.path]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
 
@@ -1415,21 +1601,23 @@ class GittyupClient(object):
             components = re.match("^(Would remove)\s(.*?)$", line)
             if components:
                 untracked_path = components.group(2)
-                if untracked_path[-1]=='/':
+                if untracked_path[-1] == "/":
                     untracked_directories.append(untracked_path[:-1])
 
-        #Determine the ignored files and directories in Repo
+        # Determine the ignored files and directories in Repo
         cmd = ["git", "clean", "-ndX", self.repo.path]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
-        ignored_directories=[]
+        ignored_directories = []
         for line in stdout:
             components = re.match("^(Would remove)\s(.*?)$", line)
             if components:
-                ignored_path=components.group(2)
-                if ignored_path[-1]=='/':
+                ignored_path = components.group(2)
+                if ignored_path[-1] == "/":
                     ignored_directories.append(ignored_path[:-1])
                     next
                 statuses.append(IgnoredStatus(ignored_path))
@@ -1438,22 +1626,22 @@ class GittyupClient(object):
                     del files_hash[ignored_path]
                 except Exception as e:
                     pass
-        for file,data in list(files_hash.items()):
-            ignore_file=False
-            untracked_file=False
+        for file, data in list(files_hash.items()):
+            ignore_file = False
+            untracked_file = False
             for ignored_path in ignored_directories:
                 if S(ignored_path) in file:
-                    ignore_file=True
+                    ignore_file = True
                     break
             for untracked_path in untracked_directories:
                 if S(untracked_path) in file:
-                    untracked_file=True
+                    untracked_file = True
                     break
-            if untracked_file==True:
+            if untracked_file == True:
                 statuses.append(UntrackedStatus(file))
-                if ignore_file==True:
+                if ignore_file == True:
                     self.ignored_paths.append(file)
-            elif ignore_file==True:
+            elif ignore_file == True:
                 statuses.append(IgnoredStatus(file))
                 self.ignored_paths.append(file)
             else:
@@ -1475,7 +1663,9 @@ class GittyupClient(object):
 
             # Check if directory includes modified files
             for file in modified_files:
-                if ("/%s" % file).startswith(dirPattern): # fix, when file startwith same prefix as directory, fix status for root repo path ""
+                if ("/%s" % file).startswith(
+                    dirPattern
+                ):  # fix, when file startwith same prefix as directory, fix status for root repo path ""
                     d_status = ModifiedStatus(d)
                     break
 
@@ -1535,7 +1725,7 @@ class GittyupClient(object):
                 pass
 
         # Calculate statuses for untracked files
-        for name,data in list(files_hash.items()):
+        for name, data in list(files_hash.items()):
             try:
                 inTreeIndex = tree[name]
             except Exception as e:
@@ -1555,10 +1745,14 @@ class GittyupClient(object):
             patterns = []
             path_to_check = os.path.dirname(self.get_absolute_path(name))
             while path_to_check != self.repo.path:
-                patterns += self.get_ignore_patterns_from_file(self.get_local_ignore_file(path_to_check))
+                patterns += self.get_ignore_patterns_from_file(
+                    self.get_local_ignore_file(path_to_check)
+                )
                 path_to_check = os.path.split(path_to_check)[0]
 
-            patterns += self.get_ignore_patterns_from_file(self.get_local_ignore_file(self.repo.path))
+            patterns += self.get_ignore_patterns_from_file(
+                self.get_local_ignore_file(self.repo.path)
+            )
             patterns += self.global_ignore_patterns
 
             if not self._ignore_file(patterns, os.path.basename(name)):
@@ -1582,7 +1776,6 @@ class GittyupClient(object):
     def get_all_ignore_file_paths(self, path):
         return self.ignored_paths
 
-
     def status(self, path):
         # TODO - simply get this from the status implementation / avoid global state
         self.ignored_paths = []
@@ -1591,8 +1784,17 @@ class GittyupClient(object):
 
     def log(self, path="", skip=0, limit=None, revision="", showtype="all"):
 
-        cmd = ["git", "--no-pager", "log", "--numstat", "--parents", "--pretty=fuller",
-            "--date-order", "--date=default", "-m"]
+        cmd = [
+            "git",
+            "--no-pager",
+            "log",
+            "--numstat",
+            "--parents",
+            "--pretty=fuller",
+            "--date-order",
+            "--date=default",
+            "-m",
+        ]
 
         if showtype == "all":
             cmd.append("--all")
@@ -1602,7 +1804,7 @@ class GittyupClient(object):
         if skip:
             cmd.append("--skip=%s" % skip)
         if revision:
-            if showtype=="push":
+            if showtype == "push":
                 cmd.append("%s.." % revision)
             else:
                 cmd.append(revision)
@@ -1613,7 +1815,9 @@ class GittyupClient(object):
             cmd += ["--", path]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             return []
@@ -1621,7 +1825,7 @@ class GittyupClient(object):
         revisions = []
         revision = {}
         changed_file = {}
-        pattern_from = re.compile(r' \(from (.*)\)')
+        pattern_from = re.compile(r" \(from (.*)\)")
         last_commitId = ""
         for line in stdout:
             if line == "":
@@ -1629,7 +1833,7 @@ class GittyupClient(object):
 
             if line[0:6] == "commit":
                 match = pattern_from.search(line)
-                commit_line = re.sub(" \(from.*\)","", line).split(" ")
+                commit_line = re.sub(" \(from.*\)", "", line).split(" ")
                 fromPath = ""
                 if match:
                     fromPath = match.group(1)
@@ -1642,14 +1846,13 @@ class GittyupClient(object):
                     else:
                         del revision["message"]
 
-
                 if len(fromPath) > 0:
                     if "changed_paths" not in revision:
-                        revision["changed_paths"] =[]
+                        revision["changed_paths"] = []
                     changed_file = {
                         "additions": "-",
                         "removals": "-",
-                        "path": "Diff with parent : %s " % fromPath
+                        "path": "Diff with parent : %s " % fromPath,
                     }
                     revision["changed_paths"].append(changed_file)
 
@@ -1684,10 +1887,13 @@ class GittyupClient(object):
                     changed_file = {
                         "additions": file_line[0],
                         "removals": file_line[1],
-                        "path": self.string_unescape(file_line[2])
+                        "path": self.string_unescape(file_line[2]),
                     }
-                    if changed_file['path'][0] == '"' and changed_file['path'][-1] == '"':
-                        changed_file['path'] = changed_file['path'][1:-1]
+                    if (
+                        changed_file["path"][0] == '"'
+                        and changed_file["path"][-1] == '"'
+                    ):
+                        changed_file["path"] = changed_file["path"][1:-1]
                     revision["changed_paths"].append(changed_file)
 
         if revision:
@@ -1712,7 +1918,9 @@ class GittyupClient(object):
         cmd = ["git", "annotate", "-l", revision_obj, relative_path]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
@@ -1723,20 +1931,22 @@ class GittyupClient(object):
             if len(components) < 4:
                 continue
 
-            dt = datetime(*time.strptime(components[2][:-6],"%Y-%m-%d %H:%M:%S")[:-2])
+            dt = datetime(*time.strptime(components[2][:-6], "%Y-%m-%d %H:%M:%S")[:-2])
 
             message = components[3].split(")", 1)
             code = message[1]
             if len(components) == 5:
                 code = components[4]
 
-            returner.append({
-                "revision": components[0],
-                "author": components[1][1:],
-                "date": dt,
-                "line": code,
-                "number": message[0]
-            })
+            returner.append(
+                {
+                    "revision": components[0],
+                    "author": components[1][1:],
+                    "date": dt,
+                    "line": code,
+                    "number": message[0],
+                }
+            )
 
         return returner
 
@@ -1758,14 +1968,18 @@ class GittyupClient(object):
 
         cmd = ["git", "show", "%s:%s" % (revision_obj, relative_path)]
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
 
         return "\n".join(stdout)
 
-    def diff(self, path1, revision_obj1, path2=None, revision_obj2=None, summarize=False):
+    def diff(
+        self, path1, revision_obj1, path2=None, revision_obj2=None, summarize=False
+    ):
         """
         Returns the diff between the path(s)/revision(s)
 
@@ -1804,12 +2018,14 @@ class GittyupClient(object):
             cmd += [relative_path2]
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
 
-        return ''.join(x + "\n" for x in stdout)
+        return "".join(x + "\n" for x in stdout)
 
     def diff_summarize(self, path1, revision_obj1, path2=None, revision_obj2=None):
         results = self.diff(path1, revision_obj1, path2, revision_obj2, True)
@@ -1819,10 +2035,7 @@ class GittyupClient(object):
                 continue
 
             (action, path) = (line + "\t").split("\t")[:2]
-            summary.append({
-                "action": action,
-                "path": path
-            })
+            summary.append({"action": action, "path": path})
 
         return summary
 
@@ -1848,8 +2061,12 @@ class GittyupClient(object):
         mkdir_p(dest_path)
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd1, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
-            (status, stdout, stderr) = GittyupCommand(cmd2, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd1, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd2, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             stdout = []
@@ -1857,8 +2074,15 @@ class GittyupClient(object):
         self.notify("%s at %s exported to %s" % (path, revision, dest_path))
         return "\n".join(stdout)
 
-    def clean(self, path, remove_dir=True, remove_ignored_too=False,
-            remove_only_ignored=False, dry_run=False, force=True):
+    def clean(
+        self,
+        path,
+        remove_dir=True,
+        remove_ignored_too=False,
+        remove_only_ignored=False,
+        dry_run=False,
+        force=True,
+    ):
 
         cmd = ["git", "clean"]
         if remove_dir:
@@ -1880,7 +2104,9 @@ class GittyupClient(object):
         cmd.append(relative_path)
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             return
@@ -1897,7 +2123,9 @@ class GittyupClient(object):
             cmd.append(relative_path)
 
         try:
-            (status, stdout, stderr) = GittyupCommand(cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()).execute()
+            (status, stdout, stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify, cancel=self.get_cancel()
+            ).execute()
         except GittyupCommandError as e:
             self.callback_notify(e)
             return
@@ -1925,14 +2153,13 @@ class GittyupClient(object):
         # When a command has reached 100% the format of this final message assumes the formatt:
         #  "<Command>: 100% (<num pieces>/<num pieces>), <total size> <unit>, done."
 
+        returnData = {"action": "", "path": "", "mime_type": ""}
 
-        returnData = {"action":"","path":"","mime_type":""}
-
-        #print "parsing message: " + str(data)
+        # print "parsing message: " + str(data)
 
         # If data is already a dict, we'll assume it's already been parsed, and return.
-        if isinstance (data, dict):
-            self.notify (data);
+        if isinstance(data, dict):
+            self.notify(data)
             return
 
         # Is this an error?
@@ -1941,7 +2168,7 @@ class GittyupClient(object):
         if message_components != None:
             returnData["action"] = "Error"
             returnData["path"] = message_components.group(2)
-            self.notify (returnData)
+            self.notify(returnData)
             return
 
         # Check to see if this is a remote command.
@@ -1966,7 +2193,7 @@ class GittyupClient(object):
             else:
                 returnData["path"] = message
 
-            self.notify (returnData)
+            self.notify(returnData)
             return
 
         # Extract the percentage, which will be all numerals directly
@@ -1977,19 +2204,23 @@ class GittyupClient(object):
             print("Error: failed to parse git string: " + data)
             return
 
-        fraction = float(message_components.group(2)) / 100 # Convert percentage to fraction.
+        fraction = (
+            float(message_components.group(2)) / 100
+        )  # Convert percentage to fraction.
         current_action = message_components.group(1)
 
         # If we're at 0%, then we want to notify which action we're performing.
         if fraction == 0:
-                returnData["path"] = current_action
-                self.notify(returnData)
+            returnData["path"] = current_action
+            self.notify(returnData)
 
-        #print "stage fraction: " + str (fraction)
+        # print "stage fraction: " + str (fraction)
 
         # If we're using a number of stages, adjust the fraction acordingly.
         if self.numberOfCommandStages > 0:
-            fraction = (self.numberOfCommandStagesExecuted + fraction) / self.numberOfCommandStages
+            fraction = (
+                self.numberOfCommandStagesExecuted + fraction
+            ) / self.numberOfCommandStages
 
         # If we've finished the current stage (100%).
         if "done" in message:
@@ -1997,7 +2228,7 @@ class GittyupClient(object):
 
         # If we've registered a callback for progress, update with the new fraction.
         if self.callback_progress_update != None:
-            #print "setting pbar: " + str(fraction)
+            # print "setting pbar: " + str(fraction)
             self.callback_progress_update(fraction)
 
         # If we've finished the whole command (all stages).
@@ -2006,8 +2237,8 @@ class GittyupClient(object):
             self.numberOfCommandStages = 0
             self.numberOfCommandStagesExecuted = 0
 
-    def notify_and_parse_git_pull (self, data):
-        return_data = {"action":"","path":"","mime_type":""}
+    def notify_and_parse_git_pull(self, data):
+        return_data = {"action": "", "path": "", "mime_type": ""}
 
         message_parsed = False
 
@@ -2024,7 +2255,9 @@ class GittyupClient(object):
 
         if message_components != None:
             return_data["action"] = "Branch"
-            return_data["path"] = message_components.group(1) + " -> " + message_components.group(2)
+            return_data["path"] = (
+                message_components.group(1) + " -> " + message_components.group(2)
+            )
             message_parsed = True
 
         # Look for a file line (e.g. "src/somefile.py       | 5 -++++")
@@ -2033,7 +2266,9 @@ class GittyupClient(object):
         if message_components != None:
             return_data["action"] = "Modified"
             return_data["path"] = message_components.group(1)
-            return_data["mime_type"] = message_components.group(2) + " " + message_components.group(3)
+            return_data["mime_type"] = (
+                message_components.group(2) + " " + message_components.group(3)
+            )
             message_parsed = True
 
         # Look for a updating line (e.g. "Updating ffffff..ffffff")
@@ -2071,7 +2306,9 @@ class GittyupClient(object):
             message_parsed = True
 
         # Look for a "binary" line (e.g. "icons/file.png"    | Bin 0 -> 55555 bytes)
-        message_components = re.search("^[ ](.+) +\| Bin ([0-9]+ -> [0-9]+ bytes)", data)
+        message_components = re.search(
+            "^[ ](.+) +\| Bin ([0-9]+ -> [0-9]+ bytes)", data
+        )
 
         if message_components != None:
             return_data["action"] = "Binary"
@@ -2108,10 +2345,10 @@ class GittyupClient(object):
         if message_parsed == False:
             return_data = data
 
-        self.notify_and_parse_progress (return_data)
+        self.notify_and_parse_progress(return_data)
 
-    def notify_and_parse_git_push (self, data):
-        return_data = {"action":"","path":"","mime_type":""}
+    def notify_and_parse_git_push(self, data):
+        return_data = {"action": "", "path": "", "mime_type": ""}
 
         message_parsed = False
 
@@ -2129,7 +2366,9 @@ class GittyupClient(object):
 
         if message_components != None:
             return_data["action"] = "New Branch"
-            return_data["path"] = message_components.group(1) + " -> " + message_components.group(2)
+            return_data["path"] = (
+                message_components.group(1) + " -> " + message_components.group(2)
+            )
             message_parsed = True
 
         # Look for "rejected" line. e.g. " ![rejected]   master -> master (non-fast-forward)".
@@ -2143,7 +2382,7 @@ class GittyupClient(object):
         if message_parsed == False:
             return_data = data
 
-        self.notify_and_parse_progress (return_data)
+        self.notify_and_parse_progress(return_data)
 
     def get_cancel(self):
         return self.callback_get_cancel

--- a/rabbitvcs/vcs/git/gittyup/command.py
+++ b/rabbitvcs/vcs/git/gittyup/command.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # command.py
 #
@@ -16,6 +17,7 @@ from rabbitvcs.util.strings import *
 
 def notify_func(data):
     pass
+
 
 def cancel_func():
     return False
@@ -47,18 +49,20 @@ class GittyupCommand(object):
 
     def execute(self):
         env = os.environ.copy()
-        env["LANG"] = "C";
+        env["LANG"] = "C"
         env["PYTHONIOENCODING"] = "UTF-8"
         env["GIT_TERMINAL_PROMPT"] = "0"
         env["GIT_SSL_CERT_PASSWORD_PROTECTED"] = ""
-        proc = subprocess.Popen(self.command,
-                                cwd=self.cwd,
-                                stdin=None,
-                                stderr=subprocess.STDOUT,
-                                stdout=subprocess.PIPE,
-                                env=env,
-                                close_fds=True,
-                                preexec_fn=os.setsid)
+        proc = subprocess.Popen(
+            self.command,
+            cwd=self.cwd,
+            stdin=None,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            env=env,
+            close_fds=True,
+            preexec_fn=os.setsid,
+        )
 
         out = codecs.getreader(UTF8_ENCODING)(proc.stdout, SURROGATE_ESCAPE)
         stdout = []
@@ -66,9 +70,9 @@ class GittyupCommand(object):
         while True:
             line = out.readline()
 
-            if line == '':
+            if line == "":
                 break
-            line = line.rstrip("\r\n") # Strip trailing newline.
+            line = line.rstrip("\r\n")  # Strip trailing newline.
             self.notify(line)
             stdout.append(line)
 

--- a/rabbitvcs/vcs/git/gittyup/exceptions.py
+++ b/rabbitvcs/vcs/git/gittyup/exceptions.py
@@ -2,11 +2,13 @@
 # exceptions.py
 #
 
+
 class NotRepositoryError(Exception):
     """Indicates that no Git repository was found."""
 
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
+
 
 class GittyupCommandError(Exception):
     """Indicates a command returned an error"""

--- a/rabbitvcs/vcs/git/gittyup/objects.py
+++ b/rabbitvcs/vcs/git/gittyup/objects.py
@@ -6,6 +6,7 @@
 class GittyupStatus(object):
     path = None
     is_staged = False
+
     def __init__(self, path):
         self.path = path
 
@@ -13,45 +14,57 @@ class GittyupStatus(object):
         return "<Status %s %s>" % (self.path, self.identifier)
 
     def __eq__(self, other):
-        return (self.identifier == other.identifier)
+        return self.identifier == other.identifier
+
 
 class NormalStatus(GittyupStatus):
     identifier = "normal"
 
+
 class AddedStatus(GittyupStatus):
     identifier = "added"
+
 
 class RenamedStatus(GittyupStatus):
     identifier = "renamed"
 
+
 class RemovedStatus(GittyupStatus):
     identifier = "removed"
+
 
 class ModifiedStatus(GittyupStatus):
     identifier = "modified"
 
+
 class KilledStatus(GittyupStatus):
     identifier = "killed"
+
 
 class UntrackedStatus(GittyupStatus):
     identifier = "untracked"
 
+
 class MissingStatus(GittyupStatus):
     identifier = "missing"
+
 
 class IgnoredStatus(GittyupStatus):
     identifier = "ignored"
 
+
 class NoStatus(GittyupStatus):
     identifier = ""
+
     def __eq__(self, other):
-        return (self.path == other.path)
+        return self.path == other.path
 
 
 class GittyupObject(object):
     def __init__(self, sha, obj):
         self.sha = sha
         self.obj = obj
+
 
 class Commit(GittyupObject):
     def __init__(self, sha, obj, changed_paths=[]):
@@ -101,6 +114,7 @@ class Commit(GittyupObject):
     def __eq__(self, other):
         return self.sha == other.sha
 
+
 class Tag(GittyupObject):
     def __repr__(self):
         return "<Tag %s>" % self.sha
@@ -129,6 +143,7 @@ class Tag(GittyupObject):
     def tag_timezone(self):
         return self.obj.tag_timezone
 
+
 class CommitTag(Commit):
     def __init__(self, name, sha, obj):
         self._name = name
@@ -143,7 +158,7 @@ class CommitTag(Commit):
         return self._name
 
     def __eq__(self, other):
-        return (self.name == other)
+        return self.name == other
 
     @property
     def tag_type(self):
@@ -165,9 +180,11 @@ class CommitTag(Commit):
     def tag_timezone(self):
         return self.obj.commit_timezone
 
+
 class Tree(GittyupObject):
     def __repr__(self):
         return "<Tree %s>" % self.sha
+
 
 class Branch(Commit):
     def __init__(self, name, sha, obj):
@@ -183,4 +200,4 @@ class Branch(Commit):
         return self._name
 
     def __eq__(self, other):
-        return (self.name == other)
+        return self.name == other

--- a/rabbitvcs/vcs/git/gittyup/tests/branch.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/branch.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # test/stage.py
 #
@@ -24,7 +25,9 @@ if options.cleanup:
     print("branch.py clean")
 else:
     if os.path.isdir(DIR):
-        raise SystemExit("This test script has already been run.  Please call this script with --cleanup to start again")
+        raise SystemExit(
+            "This test script has already been run.  Please call this script with --cleanup to start again"
+        )
 
     os.mkdir(DIR)
     g = GittyupClient()
@@ -33,32 +36,32 @@ else:
     touch(DIR + "/test1.txt")
     touch(DIR + "/test2.txt")
 
-    g.stage([DIR+"/test1.txt", DIR+"/test2.txt"])
+    g.stage([DIR + "/test1.txt", DIR + "/test2.txt"])
     g.commit("This is a commit")
 
     # Create a new branch, don't track it
     g.branch("branch1")
-    assert "branch1" in [x['name'] for x in g.branch_list()]
+    assert "branch1" in [x["name"] for x in g.branch_list()]
 
     # Make sure we are still tracking master
-    assert (g.is_tracking("refs/heads/master"))
+    assert g.is_tracking("refs/heads/master")
 
     # Track branch1
     g.track("refs/heads/branch1")
-    assert (g.is_tracking("refs/heads/branch1"))
+    assert g.is_tracking("refs/heads/branch1")
 
     # Rename branch1 to branch1b
     g.branch_rename("branch1", "branch1b")
-    assert "branch1b" in [x['name'] for x in g.branch_list()]
+    assert "branch1b" in [x["name"] for x in g.branch_list()]
 
     # Make sure we are now tracking branch1b
-    assert (g.is_tracking("refs/heads/branch1b"))
+    assert g.is_tracking("refs/heads/branch1b")
 
     # Delete branch1b
     g.branch_delete("branch1b")
-    assert ("branch1b" not in g.branch_list())
+    assert "branch1b" not in g.branch_list()
 
     # Make sure we are now tracking master
-    assert (g.is_tracking("refs/heads/master"))
+    assert g.is_tracking("refs/heads/master")
 
     print("branch.py pass")

--- a/rabbitvcs/vcs/git/gittyup/tests/clone.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/clone.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # test/clone.py
 #
@@ -24,10 +25,11 @@ if options.cleanup:
     print("clone.py clean")
 else:
     if os.path.isdir(DIR):
-        raise SystemExit("This test script has already been run.  Please call this script with --cleanup to start again")
+        raise SystemExit(
+            "This test script has already been run.  Please call this script with --cleanup to start again"
+        )
 
     g = GittyupClient()
     g.clone("git://github.com/adamplumb/sprout.git", DIR)
-
 
     print("clone.py pass")

--- a/rabbitvcs/vcs/git/gittyup/tests/commit.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/commit.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # test/stage.py
 #
@@ -25,7 +26,9 @@ if options.cleanup:
     print("commit.py clean")
 else:
     if os.path.isdir(DIR):
-        raise SystemExit("This test script has already been run.  Please call this script with --cleanup to start again")
+        raise SystemExit(
+            "This test script has already been run.  Please call this script with --cleanup to start again"
+        )
 
     os.mkdir(DIR)
     g = GittyupClient()
@@ -34,11 +37,11 @@ else:
     touch(DIR + "/test1.txt")
     touch(DIR + "/test2.txt")
 
-    g.stage([DIR+"/test1.txt", DIR+"/test2.txt"])
+    g.stage([DIR + "/test1.txt", DIR + "/test2.txt"])
     g.commit("First commit", commit_all=True)
 
     change(DIR + "/test1.txt")
-    g.stage([DIR+"/test1.txt"])
+    g.stage([DIR + "/test1.txt"])
     g.commit("Second commit", author="Alex Plumb <alexplumb@gmail.com>")
 
     print("commit.py pass")

--- a/rabbitvcs/vcs/git/gittyup/tests/move.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/move.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # test/stage.py
 #
@@ -25,45 +26,47 @@ if options.cleanup:
     print("move.py clean")
 else:
     if os.path.isdir(DIR):
-        raise SystemExit("This test script has already been run.  Please call this script with --cleanup to start again")
+        raise SystemExit(
+            "This test script has already been run.  Please call this script with --cleanup to start again"
+        )
 
     g = GittyupClient(DIR, create=True)
 
     touch(DIR + "/test.txt")
 
     # Stage and commit the file
-    g.stage([DIR+"/test.txt"])
+    g.stage([DIR + "/test.txt"])
     g.commit("Adding test.txt")
 
     st = g.status()
 
     # Move file explicity test
-    os.mkdir(DIR+"/fol")
-    g.move(DIR+"/test.txt", DIR+"/fol/test.txt")
+    os.mkdir(DIR + "/fol")
+    g.move(DIR + "/test.txt", DIR + "/fol/test.txt")
     st = g.status()
-    assert (not os.path.exists(DIR+"/test.txt"))
-    assert (os.path.exists(DIR+"/fol/test.txt"))
-    assert (g.is_staged(DIR+"/fol/test.txt"))
-    assert (st[0] == RemovedStatus)
-    assert (st[1] == AddedStatus)
+    assert not os.path.exists(DIR + "/test.txt")
+    assert os.path.exists(DIR + "/fol/test.txt")
+    assert g.is_staged(DIR + "/fol/test.txt")
+    assert st[0] == RemovedStatus
+    assert st[1] == AddedStatus
 
     # Move as children test
     touch(DIR + "/test2.txt")
-    g.stage([DIR+"/test2.txt"])
+    g.stage([DIR + "/test2.txt"])
     g.commit("Adding test2.txt")
-    g.move(DIR+"/test2.txt", DIR+"/fol")
+    g.move(DIR + "/test2.txt", DIR + "/fol")
     st = g.status()
-    assert (not os.path.exists(DIR+"/test2.txt"))
-    assert (os.path.exists(DIR+"/fol/test2.txt"))
-    assert (g.is_staged(DIR+"/fol/test2.txt"))
-    assert (st[1] == RemovedStatus)
-    assert (st[2] == AddedStatus)
+    assert not os.path.exists(DIR + "/test2.txt")
+    assert os.path.exists(DIR + "/fol/test2.txt")
+    assert g.is_staged(DIR + "/fol/test2.txt")
+    assert st[1] == RemovedStatus
+    assert st[2] == AddedStatus
     g.commit("Committing the test2 move")
 
-    g.move(DIR+"/fol", DIR+"/bar")
+    g.move(DIR + "/fol", DIR + "/bar")
     st = g.status()
-    assert (os.path.exists(DIR+"/bar/test.txt"))
-    assert (st[0] == RemovedStatus)
-    assert (st[2] == AddedStatus)
+    assert os.path.exists(DIR + "/bar/test.txt")
+    assert st[0] == RemovedStatus
+    assert st[2] == AddedStatus
 
     print("move.py pass")

--- a/rabbitvcs/vcs/git/gittyup/tests/pull.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/pull.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # test/pull.py
 #
@@ -24,7 +25,9 @@ if options.cleanup:
     print("pull.py clean")
 else:
     if os.path.isdir(DIR):
-        raise SystemExit("This test script has already been run.  Please call this script with --cleanup to start again")
+        raise SystemExit(
+            "This test script has already been run.  Please call this script with --cleanup to start again"
+        )
 
     g = GittyupClient(DIR, create=True)
     g.remote_add("origin", "git://github.com/adamplumb/gittyup.git")

--- a/rabbitvcs/vcs/git/gittyup/tests/remote.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/remote.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # test/remote.py
 #
@@ -24,19 +25,21 @@ if options.cleanup:
     print("remote.py clean")
 else:
     if os.path.isdir(DIR):
-        raise SystemExit("This test script has already been run.  Please call this script with --cleanup to start again")
+        raise SystemExit(
+            "This test script has already been run.  Please call this script with --cleanup to start again"
+        )
 
     os.mkdir(DIR)
     g = GittyupClient(DIR, create=True)
     g.remote_add("origin", "git://github.com/adamplumb/sprout.git")
     l = g.remote_list()
 
-    assert (len(l) == 1)
-    assert (l[0]["host"] == "git://github.com/adamplumb/sprout.git")
+    assert len(l) == 1
+    assert l[0]["host"] == "git://github.com/adamplumb/sprout.git"
 
     g.remote_delete("origin")
     l = g.remote_list()
 
-    assert (len(l) == 0)
+    assert len(l) == 0
 
     print("remote.py pass")

--- a/rabbitvcs/vcs/git/gittyup/tests/remove.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/remove.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # test/stage.py
 #
@@ -25,7 +26,9 @@ if options.cleanup:
     print("remove.py clean")
 else:
     if os.path.isdir(DIR):
-        raise SystemExit("This test script has already been run.  Please call this script with --cleanup to start again")
+        raise SystemExit(
+            "This test script has already been run.  Please call this script with --cleanup to start again"
+        )
 
     os.mkdir(DIR)
     g = GittyupClient()
@@ -34,25 +37,25 @@ else:
     touch(DIR + "/test.txt")
 
     # Stage and commit the file
-    g.stage([DIR+"/test.txt"])
+    g.stage([DIR + "/test.txt"])
     g.commit("Adding test.txt")
 
-    g.remove([DIR+"/test.txt"])
+    g.remove([DIR + "/test.txt"])
     st = g.status()
-    assert (not os.path.exists(DIR+"/test.txt"))
-    assert (g.is_staged(DIR+"/test.txt"))
-    assert (st[0] == RemovedStatus)
+    assert not os.path.exists(DIR + "/test.txt")
+    assert g.is_staged(DIR + "/test.txt")
+    assert st[0] == RemovedStatus
 
-    g.unstage([DIR+"/test.txt"])
+    g.unstage([DIR + "/test.txt"])
     st = g.status()
-    assert (not os.path.exists(DIR+"/test.txt"))
-    assert (not g.is_staged(DIR+"/test.txt"))
-    assert (st[0] == MissingStatus)
+    assert not os.path.exists(DIR + "/test.txt")
+    assert not g.is_staged(DIR + "/test.txt")
+    assert st[0] == MissingStatus
 
-    g.checkout([DIR+"/test.txt"])
+    g.checkout([DIR + "/test.txt"])
     st = g.status()
-    assert (os.path.exists(DIR+"/test.txt"))
-    assert (not g.is_staged(DIR+"/test.txt"))
-    assert (st[0] == NormalStatus)
+    assert os.path.exists(DIR + "/test.txt")
+    assert not g.is_staged(DIR + "/test.txt")
+    assert st[0] == NormalStatus
 
     print("remove.py pass")

--- a/rabbitvcs/vcs/git/gittyup/tests/run_all.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/run_all.py
@@ -1,13 +1,16 @@
 from __future__ import absolute_import
+
 #!/usr/bin/python
 
 from sys import argv
 import os
 import subprocess
 
+
 def cleanup(modules):
     for module in modules:
         subprocess.call(["python", module, "--cleanup"])
+
 
 modules = [
     "branch.py",
@@ -18,10 +21,10 @@ modules = [
     "clone.py",
     "move.py",
     "pull.py",
-    "remote.py"
+    "remote.py",
 ]
 
-if len(argv) == 2 and  argv[1] == "--cleanup":
+if len(argv) == 2 and argv[1] == "--cleanup":
     cleanup(modules)
 
 for module in modules:

--- a/rabbitvcs/vcs/git/gittyup/tests/stage.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/stage.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # test/stage.py
 #
@@ -25,7 +26,9 @@ if options.cleanup:
     print("stage.py clean")
 else:
     if os.path.isdir(DIR):
-        raise SystemExit("This test script has already been run.  Please call this script with --cleanup to start again")
+        raise SystemExit(
+            "This test script has already been run.  Please call this script with --cleanup to start again"
+        )
 
     os.mkdir(DIR)
     g = GittyupClient()
@@ -35,43 +38,43 @@ else:
     touch(DIR + "/test2.txt")
 
     # Stage both files
-    g.stage([DIR+"/test1.txt", DIR+"/test2.txt"])
+    g.stage([DIR + "/test1.txt", DIR + "/test2.txt"])
     st = g.status(DIR)
-    assert (st[0] == AddedStatus), st
-    assert (st[1] == AddedStatus)
-    assert (st[0].is_staged)
+    assert st[0] == AddedStatus, st
+    assert st[1] == AddedStatus
+    assert st[0].is_staged
 
     # Unstage both files
-    g.unstage([DIR+"/test1.txt", DIR+"/test2.txt"])
+    g.unstage([DIR + "/test1.txt", DIR + "/test2.txt"])
     st = g.status(DIR)
-    assert (st[0] == UntrackedStatus)
-    assert (st[1] == UntrackedStatus)
-    assert (not st[0].is_staged)
+    assert st[0] == UntrackedStatus
+    assert st[1] == UntrackedStatus
+    assert not st[0].is_staged
 
     # Untracked files should not be staged
     g.stage_all()
     st = g.status(DIR)
-    assert (st[0] == UntrackedStatus)
-    assert (st[1] == UntrackedStatus)
+    assert st[0] == UntrackedStatus
+    assert st[1] == UntrackedStatus
 
     # test1.txt is changed, so it should get staged and set as Modified
-    g.stage([DIR+"/test1.txt"])
+    g.stage([DIR + "/test1.txt"])
     g.commit("Test commit")
-    change(DIR+"/test1.txt")
+    change(DIR + "/test1.txt")
     st = g.status(DIR)
-    assert (st[0] == ModifiedStatus)
+    assert st[0] == ModifiedStatus
     g.stage_all()
     st = g.status(DIR)
-    assert (st[0] == ModifiedStatus)
-    assert (g.is_staged(DIR+"/" + st[0].path))
-    assert (not g.is_staged(DIR+"/" + st[1].path))
+    assert st[0] == ModifiedStatus
+    assert g.is_staged(DIR + "/" + st[0].path)
+    assert not g.is_staged(DIR + "/" + st[1].path)
 
     # Unstage all staged files
     g.unstage_all()
     st = g.status(DIR)
-    assert (not g.is_staged(DIR+"/" + st[0].path))
-    assert (not g.is_staged(DIR+"/" + st[1].path))
-    assert (st[0] == ModifiedStatus)
-    assert (st[1] == UntrackedStatus)
+    assert not g.is_staged(DIR + "/" + st[0].path)
+    assert not g.is_staged(DIR + "/" + st[1].path)
+    assert st[0] == ModifiedStatus
+    assert st[1] == UntrackedStatus
 
     print("stage.py pass")

--- a/rabbitvcs/vcs/git/gittyup/tests/tag.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/tag.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #
 # test/stage.py
 #
@@ -25,7 +26,9 @@ if options.cleanup:
     print("tag.py clean")
 else:
     if os.path.isdir(DIR):
-        raise SystemExit("This test script has already been run.  Please call this script with --cleanup to start again")
+        raise SystemExit(
+            "This test script has already been run.  Please call this script with --cleanup to start again"
+        )
 
     os.mkdir(DIR)
     g = GittyupClient()
@@ -34,12 +37,12 @@ else:
     touch(DIR + "/test1.txt")
     touch(DIR + "/test2.txt")
 
-    g.stage([DIR+"/test1.txt", DIR+"/test2.txt"])
+    g.stage([DIR + "/test1.txt", DIR + "/test2.txt"])
     commit_id = g.commit("First commit", commit_all=True)
 
     tag_id = g.tag("tag1", "Tagging as tag1", track=True)
-    assert (g.is_tracking("refs/tags/tag1"))
+    assert g.is_tracking("refs/tags/tag1")
 
-    assert (len(g.tag_list()) == 1)
+    assert len(g.tag_list()) == 1
 
     print("tag.py pass")

--- a/rabbitvcs/vcs/git/gittyup/tests/util.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/util.py
@@ -1,13 +1,16 @@
 from __future__ import absolute_import
+
 #
 # util.py
 #
 
 import os
 
-def touch(fname, times = None):
-    with open(fname, 'a'):
+
+def touch(fname, times=None):
+    with open(fname, "a"):
         os.utime(fname, times)
+
 
 def change(path):
     f = open(path, "a")

--- a/rabbitvcs/vcs/git/gittyup/util.py
+++ b/rabbitvcs/vcs/git/gittyup/util.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
+
 #
 # util.py
 #
 
 import os
+
 
 def splitall(path):
     """Split a path into all of its parts.
@@ -23,6 +25,7 @@ def splitall(path):
             path = parts[0]
             allparts.insert(0, parts[1])
     return allparts
+
 
 def relativepath(fromdir, tofile):
     """Find relative path from 'fromdir' to 'tofile'.
@@ -52,16 +55,18 @@ def relativepath(fromdir, tofile):
                 break
         del f1parts[0]
         del f2parts[0]
-    result = ['..' for part in f2parts]
+    result = [".." for part in f2parts]
     result.extend(f1parts)
     result.append(f1basename)
     return os.sep.join(result)
 
+
 def get_transport_and_path(uri):
     from dulwich.client import TCPGitClient, SSHGitClient, SubprocessGitClient
+
     for handler, transport in (("git://", TCPGitClient), ("git+ssh://", SSHGitClient)):
         if uri.startswith(handler):
-            host, path = uri[len(handler):].split("/", 1)
-            return transport(host), "/"+path
+            host, path = uri[len(handler) :].split("/", 1)
+            return transport(host), "/" + path
     # if its not git or git+ssh, try a local url..
     return SubprocessGitClient(), uri

--- a/rabbitvcs/vcs/log.py
+++ b/rabbitvcs/vcs/log.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -48,7 +49,9 @@ class Log(object):
     # A list of LogChangedFiles elements
     changed_paths = []
 
-    def __init__(self, date, revision, author, message, changed_paths, parents=[], head=False):
+    def __init__(
+        self, date, revision, author, message, changed_paths, parents=[], head=False
+    ):
         self.date = date
         self.revision = revision
         self.author = author

--- a/rabbitvcs/vcs/mercurial/__init__.py
+++ b/rabbitvcs/vcs/mercurial/__init__.py
@@ -42,6 +42,7 @@ from rabbitvcs.util.log import Log
 log = Log("rabbitvcs.vcs.mercurial")
 
 from rabbitvcs import gettext
+
 _ = gettext.gettext
 
 
@@ -83,44 +84,30 @@ class Revision(object):
 
 class Mercurial(object):
     STATUS = {
-        "normal":       "C",
-        "added":        "A",
-        "removed":      "R",
-        "modified":     "M",
-        "untracked":    "?",
-        "missing":      "!"
+        "normal": "C",
+        "added": "A",
+        "removed": "R",
+        "modified": "M",
+        "untracked": "?",
+        "missing": "!",
     }
 
     STATUS_REVERSE = {
-        "C":       "normal",
-        "A":        "added",
-        "R":      "removed",
-        "M":     "modified",
-        "?":    "untracked",
-        "!":      "missing"
+        "C": "normal",
+        "A": "added",
+        "R": "removed",
+        "M": "modified",
+        "?": "untracked",
+        "!": "missing",
     }
 
-    STATUSES_FOR_REVERT = [
-        "missing",
-        "modified",
-        "removed"
-    ]
+    STATUSES_FOR_REVERT = ["missing", "modified", "removed"]
 
-    STATUSES_FOR_COMMIT = [
-        "untracked",
-        "missing",
-        "modified",
-        "added",
-        "removed"
-    ]
+    STATUSES_FOR_COMMIT = ["untracked", "missing", "modified", "added", "removed"]
 
-    STATUSES_FOR_STAGE = [
-        "untracked"
-    ]
+    STATUSES_FOR_STAGE = ["untracked"]
 
-    STATUSES_FOR_UNSTAGE = [
-        "added"
-    ]
+    STATUSES_FOR_UNSTAGE = ["added"]
 
     def __init__(self, repo=None):
         self.vcs = rabbitvcs.vcs.VCS_MERCURIAL
@@ -165,7 +152,15 @@ class Mercurial(object):
 
         # the status method returns a series of tuples filled with files matching
         # the statuses below
-        tuple_order = ["modified", "added", "removed", "missing", "unknown", "ignored", "clean"]
+        tuple_order = [
+            "modified",
+            "added",
+            "removed",
+            "missing",
+            "unknown",
+            "ignored",
+            "clean",
+        ]
 
         # go through each tuple (each of which has a defined status), and
         # generate a flat list of rabbitvcs statuses
@@ -177,10 +172,9 @@ class Mercurial(object):
             for item in status_tuple:
                 st_path = self.get_absolute_path(item)
 
-                rabbitvcs_status = rabbitvcs.vcs.status.MercurialStatus({
-                    "path": st_path,
-                    "content": content
-                })
+                rabbitvcs_status = rabbitvcs.vcs.status.MercurialStatus(
+                    {"path": st_path, "content": content}
+                )
                 statuses.append(rabbitvcs_status)
 
                 # determine the statuses of the parent folders
@@ -190,11 +184,13 @@ class Mercurial(object):
 
                 path_to_check = os.path.dirname(st_path)
                 while True:
-                    if path_to_check not in directories or directories[path_to_check] not in self.STATUSES_FOR_COMMIT:
-                        rabbitvcs_status = rabbitvcs.vcs.status.MercurialStatus({
-                            "path": path_to_check,
-                            "content": dir_content
-                        })
+                    if (
+                        path_to_check not in directories
+                        or directories[path_to_check] not in self.STATUSES_FOR_COMMIT
+                    ):
+                        rabbitvcs_status = rabbitvcs.vcs.status.MercurialStatus(
+                            {"path": path_to_check, "content": dir_content}
+                        )
                         statuses.append(rabbitvcs_status)
                         directories[path_to_check] = dir_content
 
@@ -227,8 +223,7 @@ class Mercurial(object):
         return path_status
 
     def is_working_copy(self, path):
-        if (os.path.isdir(path) and
-                os.path.isdir(os.path.join(path, ".hg"))):
+        if os.path.isdir(path) and os.path.isdir(os.path.join(path, ".hg")):
             return True
         return False
 
@@ -236,7 +231,7 @@ class Mercurial(object):
         if self.is_working_copy(path):
             return True
 
-        return (self.find_repository_path(os.path.split(path)[0]) != "")
+        return self.find_repository_path(os.path.split(path)[0]) != ""
 
     def is_versioned(self, path):
         if self.is_working_copy(path):

--- a/rabbitvcs/vcs/mercurial/util.py
+++ b/rabbitvcs/vcs/mercurial/util.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -23,6 +24,7 @@ from __future__ import absolute_import
 
 import os
 
+
 def splitall(path):
     """Split a path into all of its parts.
 
@@ -41,6 +43,7 @@ def splitall(path):
             path = parts[0]
             allparts.insert(0, parts[1])
     return allparts
+
 
 def relativepath(fromdir, tofile):
     """Find relative path from 'fromdir' to 'tofile'.
@@ -70,7 +73,7 @@ def relativepath(fromdir, tofile):
                 break
         del f1parts[0]
         del f2parts[0]
-    result = ['..' for part in f2parts]
+    result = [".." for part in f2parts]
     result.extend(f1parts)
     result.append(f1basename)
     return os.sep.join(result)

--- a/rabbitvcs/vcs/status.py
+++ b/rabbitvcs/vcs/status.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.
@@ -36,33 +37,35 @@ from six.moves import range
 log = Log("rabbitvcs.vcs.status")
 
 from rabbitvcs import gettext
+
 _ = gettext.gettext
 
 # These are the statuses that we might represent with icons
-status_normal = 'normal'
-status_modified = 'modified'
-status_added = 'added'
-status_deleted = 'deleted'
-status_ignored = 'ignored'
-status_read_only = 'read-only'
-status_locked = 'locked'
-status_unknown = 'unknown'
+status_normal = "normal"
+status_modified = "modified"
+status_added = "added"
+status_deleted = "deleted"
+status_ignored = "ignored"
+status_read_only = "read-only"
+status_locked = "locked"
+status_unknown = "unknown"
 # Specifically: this means something IN A WORKING COPY but not added
-status_unversioned = 'unversioned'
-status_missing = 'missing'
-status_replaced = 'replaced'
+status_unversioned = "unversioned"
+status_missing = "missing"
+status_replaced = "replaced"
 # "complicated" = anything we display with that exclamation mark icon
-status_complicated = 'complicated'
-status_calculating = 'calculating'
-status_error = 'error'
+status_complicated = "complicated"
+status_calculating = "calculating"
+status_error = "error"
 
 MODIFIED_CHILD_STATUSES = [
     status_modified,
     status_added,
     status_deleted,
     status_missing,
-    status_replaced
+    status_replaced,
 ]
+
 
 class StatusCache(object):
     keys = [
@@ -80,7 +83,7 @@ class StatusCache(object):
         status_replaced,
         status_complicated,
         status_calculating,
-        status_error
+        status_error,
     ]
 
     authors = []
@@ -98,13 +101,13 @@ class StatusCache(object):
                 author_index = self.authors.index(status.author)
             except ValueError as e:
                 self.authors.append(status.author)
-                author_index = len(self.authors) -1
+                author_index = len(self.authors) - 1
 
             try:
                 revision_index = self.revisions.index(status.revision)
             except ValueError as e:
                 self.revisions.append(status.revision)
-                revision_index = len(self.revisions) -1
+                revision_index = len(self.revisions) - 1
 
             self.cache[path] = (
                 status.__class__,
@@ -112,22 +115,30 @@ class StatusCache(object):
                 metadata_index,
                 revision_index,
                 author_index,
-                status.date
+                status.date,
             )
         except Exception as e:
             log.debug(e)
 
     def __getitem__(self, path):
         try:
-            (statusclass, content_index, metadata_index, revision_index, author_index, date) = self.cache[path]
+            (
+                statusclass,
+                content_index,
+                metadata_index,
+                revision_index,
+                author_index,
+                date,
+            ) = self.cache[path]
 
             content = self.keys[content_index]
             metadata = self.keys[metadata_index]
             revision = self.revisions[revision_index]
             author = self.authors[author_index]
 
-            status = Status(path, content, metadata, revision=revision,
-                author=author, date=date)
+            status = Status(
+                path, content, metadata, revision=revision, author=author, date=date
+            )
             status.__class__ = statusclass
             return status
         except Exception as e:
@@ -138,7 +149,6 @@ class StatusCache(object):
             del self.cache[path]
         except KeyError as e:
             log.debug(e)
-
 
     def __contains__(self, path):
         return path in self.cache
@@ -154,29 +164,37 @@ class StatusCache(object):
 
         return statuses
 
-class Status(object):
 
+class Status(object):
     @staticmethod
     def status_unknown(path):
-        return Status(path, status_unknown, summary = status_unknown)
+        return Status(path, status_unknown, summary=status_unknown)
 
     @staticmethod
     def status_error(path):
-        return Status(path, status_error, summary = status_error)
+        return Status(path, status_error, summary=status_error)
 
     @staticmethod
     def status_calc(path):
-        return Status(path, status_calculating, summary = status_calculating)
+        return Status(path, status_calculating, summary=status_calculating)
 
     vcs_type = rabbitvcs.vcs.VCS_DUMMY
 
-    clean_statuses = ['unchanged']
+    clean_statuses = ["unchanged"]
 
     content_status_map = None
     metadata_status_map = None
 
-    def __init__(self, path, content, metadata=None, summary=None,
-            revision=None, author=None, date=None):
+    def __init__(
+        self,
+        path,
+        content,
+        metadata=None,
+        summary=None,
+        revision=None,
+        author=None,
+        date=None,
+    ):
 
         """
         The status objects accepts the following items
@@ -240,9 +258,8 @@ class Status(object):
         else:
             return self.metadata
 
-    def make_summary(self, child_statuses = []):
-        """ Summarises statuses for directories.
-        """
+    def make_summary(self, child_statuses=[]):
+        """Summarises statuses for directories."""
         summary = status_unknown
 
         status_set = set([st.single for st in child_statuses])
@@ -275,11 +292,13 @@ class Status(object):
         return self.summary is not status_normal
 
     def __repr__(self):
-        return "<%s %s (%s) %s/%s>" % (_("RabbitVCS status for"),
-                                        self.path,
-                                        self.vcs_type,
-                                        self.simple_content_status(),
-                                        self.simple_metadata_status())
+        return "<%s %s (%s) %s/%s>" % (
+            _("RabbitVCS status for"),
+            self.path,
+            self.vcs_type,
+            self.simple_content_status(),
+            self.simple_metadata_status(),
+        )
 
     def __getstate__(self):
         attrs = self.__dict__.copy()
@@ -287,48 +306,49 @@ class Status(object):
         for key in attrs:
             if isinstance(attrs[key], (six.string_types, six.text_type)):
                 attrs[key] = S(attrs[key]).unicode()
-        attrs['__type__'] = type(self).__name__
-        attrs['__module__'] = type(self).__module__
+        attrs["__type__"] = type(self).__name__
+        attrs["__module__"] = type(self).__module__
         return attrs
 
     def __setstate__(self, state_dict):
-        del state_dict['__type__']
-        del state_dict['__module__']
+        del state_dict["__type__"]
+        del state_dict["__module__"]
         # Store strings in native str type.
         for key in state_dict:
             if isinstance(state_dict[key], (six.string_types, six.text_type)):
                 state_dict[key] = str(S(state_dict[key]))
         self.__dict__ = state_dict
 
+
 class SVNStatus(Status):
 
     vcs_type = rabbitvcs.vcs.VCS_SVN
 
     content_status_map = {
-        'normal': status_normal,
-        'added': status_added,
-        'missing': status_missing,
-        'unversioned': status_unversioned,
-        'deleted': status_deleted,
-        'replaced': status_modified,
-        'modified': status_modified,
-        'merged': status_modified,
-        'conflicted': status_complicated,
-        'ignored': status_ignored,
-        'obstructed': status_complicated,
+        "normal": status_normal,
+        "added": status_added,
+        "missing": status_missing,
+        "unversioned": status_unversioned,
+        "deleted": status_deleted,
+        "replaced": status_modified,
+        "modified": status_modified,
+        "merged": status_modified,
+        "conflicted": status_complicated,
+        "ignored": status_ignored,
+        "obstructed": status_complicated,
         # FIXME: is this the best representation of 'externally populated'?
-        'external': status_normal,
-        'incomplete': status_complicated
+        "external": status_normal,
+        "incomplete": status_complicated,
     }
 
     metadata_status_map = {
-        'normal': status_normal,
-        'none': status_normal,
-        'modified': status_modified
-        }
+        "normal": status_normal,
+        "none": status_normal,
+        "modified": status_modified,
+    }
 
-#external - an unversioned path populated by an svn:external property
-#incomplete - a directory doesn't contain a complete entries list
+    # external - an unversioned path populated by an svn:external property
+    # incomplete - a directory doesn't contain a complete entries list
 
     def __init__(self, pysvn_status):
         revision = author = date = None
@@ -347,7 +367,7 @@ class SVNStatus(Status):
             metadata=str(pysvn_status.prop_status),
             revision=revision,
             author=author,
-            date=date
+            date=date,
         )
 
         # self.remote_content = getattr(pysvn_status, "repos_text_status", None)
@@ -356,71 +376,61 @@ class SVNStatus(Status):
         self.remote_content = str(pysvn_status.repos_text_status)
         self.remote_metadata = str(pysvn_status.repos_prop_status)
 
+
 class GitStatus(Status):
 
-    vcs_type = 'git'
+    vcs_type = "git"
 
     content_status_map = {
-        'normal': status_normal,
-        'added': status_added,
-        'missing': status_missing,
-        'untracked': status_unversioned,
-        'removed': status_deleted,
-        'modified': status_modified,
-        'renamed': status_modified,
-        'ignored': status_ignored
+        "normal": status_normal,
+        "added": status_added,
+        "missing": status_missing,
+        "untracked": status_unversioned,
+        "removed": status_deleted,
+        "modified": status_modified,
+        "renamed": status_modified,
+        "ignored": status_ignored,
     }
 
-    metadata_status_map = {
-        'normal': status_normal,
-        None: status_normal
-    }
+    metadata_status_map = {"normal": status_normal, None: status_normal}
 
     def __init__(self, gittyup_status):
         super(GitStatus, self).__init__(
-            gittyup_status.path,
-            content=str(gittyup_status.identifier),
-            metadata=None)
+            gittyup_status.path, content=str(gittyup_status.identifier), metadata=None
+        )
+
 
 class MercurialStatus(Status):
-    vcs_type = 'mercurial'
+    vcs_type = "mercurial"
 
     content_status_map = {
-        'clean': status_normal,
-        'added': status_added,
-        'missing': status_missing,
-        'unknown': status_unversioned,
-        'removed': status_deleted,
-        'modified': status_modified,
-        'ignored': status_ignored
+        "clean": status_normal,
+        "added": status_added,
+        "missing": status_missing,
+        "unknown": status_unversioned,
+        "removed": status_deleted,
+        "modified": status_modified,
+        "ignored": status_ignored,
     }
 
-    metadata_status_map = {
-        'normal': status_normal,
-        None: status_normal
-    }
+    metadata_status_map = {"normal": status_normal, None: status_normal}
 
     def __init__(self, mercurial_status):
         super(MercurialStatus, self).__init__(
             mercurial_status["path"],
             content=str(mercurial_status["content"]),
-            metadata=None)
+            metadata=None,
+        )
 
-STATUS_TYPES = [
-    Status,
-    SVNStatus,
-    GitStatus,
-    MercurialStatus
-]
+
+STATUS_TYPES = [Status, SVNStatus, GitStatus, MercurialStatus]
+
 
 class TestStatusObjects(unittest.TestCase):
-
     @classmethod
     def __initclass__(self):
         self.base = "/path/to/test"
-        self.children = [
-            os.path.join(self.base, chr(x)) for x in range(97,123)
-        ]
+        self.children = [os.path.join(self.base, chr(x)) for x in range(97, 123)]
 
     def testsingle_clean(self):
         status = Status(self.base, status_normal)
@@ -475,9 +485,7 @@ class TestStatusObjects(unittest.TestCase):
         top_status = Status(self.base, status_normal)
         child_sts = [Status(path, status_normal) for path in self.children]
 
-        child_sts[1] = Status(child_sts[1].path,
-                              status_normal,
-                              status_modified)
+        child_sts[1] = Status(child_sts[1].path, status_normal, status_modified)
 
         top_status.make_summary(child_sts)
         self.assertEqual(top_status.summary, status_modified)
@@ -486,9 +494,7 @@ class TestStatusObjects(unittest.TestCase):
         top_status = Status(self.base, status_normal)
         child_sts = [Status(path, status_normal) for path in self.children]
 
-        child_sts[1] = Status(child_sts[1].path,
-                              status_complicated,
-                              status_modified)
+        child_sts[1] = Status(child_sts[1].path, status_complicated, status_modified)
 
         top_status.make_summary(child_sts)
         self.assertEqual(top_status.summary, status_complicated)
@@ -501,6 +507,7 @@ class TestStatusObjects(unittest.TestCase):
 
         top_status.make_summary(child_sts)
         self.assertEqual(top_status.summary, status_added)
+
 
 TestStatusObjects.__initclass__()
 

--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -47,10 +47,12 @@ from six.moves import range
 log = Log("rabbitvcs.vcs.svn")
 
 from rabbitvcs import gettext
+
 _ = gettext.gettext
 
 # Extra "action" for "commit completed"
 commit_completed = "commit_completed"
+
 
 @structure_map
 def pure_unicode(obj):
@@ -75,14 +77,14 @@ class Revision(object):
     """
 
     KINDS = {
-        "unspecified":      pysvn.opt_revision_kind.unspecified,
-        "number":           pysvn.opt_revision_kind.number,
-        "date":             pysvn.opt_revision_kind.date,
-        "committed":        pysvn.opt_revision_kind.committed,
-        "previous":         pysvn.opt_revision_kind.previous,
-        "working":          pysvn.opt_revision_kind.working,
-        "head":             pysvn.opt_revision_kind.head,
-        "base":             pysvn.opt_revision_kind.base
+        "unspecified": pysvn.opt_revision_kind.unspecified,
+        "number": pysvn.opt_revision_kind.number,
+        "date": pysvn.opt_revision_kind.date,
+        "committed": pysvn.opt_revision_kind.committed,
+        "previous": pysvn.opt_revision_kind.previous,
+        "working": pysvn.opt_revision_kind.working,
+        "head": pysvn.opt_revision_kind.head,
+        "base": pysvn.opt_revision_kind.base,
     }
 
     def __init__(self, kind, value=None):
@@ -91,7 +93,7 @@ class Revision(object):
         self.is_revision_object = True
 
         # TODO Shift to options factory?
-        if self.value and str(self.value).lower().strip() == 'head':
+        if self.value and str(self.value).lower().strip() == "head":
             self.kind = "head"
 
         if self.value is None and self.kind in ("number", "date"):
@@ -130,128 +132,133 @@ class Revision(object):
 
 
 class SVN(object):
-    """
-
-    """
+    """ """
 
     STATUS = {
-        "none"          : pysvn.wc_status_kind.none,
-        "unversioned"   : pysvn.wc_status_kind.unversioned,
-        "normal"        : pysvn.wc_status_kind.normal,
-        "added"         : pysvn.wc_status_kind.added,
-        "missing"       : pysvn.wc_status_kind.missing,
-        "deleted"       : pysvn.wc_status_kind.deleted,
-        "replaced"      : pysvn.wc_status_kind.replaced,
-        "modified"      : pysvn.wc_status_kind.modified,
-        "merged"        : pysvn.wc_status_kind.merged,
-        "conflicted"    : pysvn.wc_status_kind.conflicted,
-        "ignored"       : pysvn.wc_status_kind.ignored,
-        "obstructed"    : pysvn.wc_status_kind.obstructed,
-        "external"      : pysvn.wc_status_kind.external,
-        "incomplete"    : pysvn.wc_status_kind.incomplete
+        "none": pysvn.wc_status_kind.none,
+        "unversioned": pysvn.wc_status_kind.unversioned,
+        "normal": pysvn.wc_status_kind.normal,
+        "added": pysvn.wc_status_kind.added,
+        "missing": pysvn.wc_status_kind.missing,
+        "deleted": pysvn.wc_status_kind.deleted,
+        "replaced": pysvn.wc_status_kind.replaced,
+        "modified": pysvn.wc_status_kind.modified,
+        "merged": pysvn.wc_status_kind.merged,
+        "conflicted": pysvn.wc_status_kind.conflicted,
+        "ignored": pysvn.wc_status_kind.ignored,
+        "obstructed": pysvn.wc_status_kind.obstructed,
+        "external": pysvn.wc_status_kind.external,
+        "incomplete": pysvn.wc_status_kind.incomplete,
     }
 
-    STATUSES_FOR_COMMIT = list(map(str,
-        [
-            pysvn.wc_status_kind.unversioned,
-            pysvn.wc_status_kind.added,
-            pysvn.wc_status_kind.deleted,
-            pysvn.wc_status_kind.replaced,
-            pysvn.wc_status_kind.modified,
-            pysvn.wc_status_kind.missing,
-            pysvn.wc_status_kind.obstructed
-        ]))
+    STATUSES_FOR_COMMIT = list(
+        map(
+            str,
+            [
+                pysvn.wc_status_kind.unversioned,
+                pysvn.wc_status_kind.added,
+                pysvn.wc_status_kind.deleted,
+                pysvn.wc_status_kind.replaced,
+                pysvn.wc_status_kind.modified,
+                pysvn.wc_status_kind.missing,
+                pysvn.wc_status_kind.obstructed,
+            ],
+        )
+    )
 
-    STATUSES_FOR_REVERT = list(map(str,
-        [
-            pysvn.wc_status_kind.missing,
-            pysvn.wc_status_kind.added,
-            pysvn.wc_status_kind.modified,
-            pysvn.wc_status_kind.deleted
-        ]))
+    STATUSES_FOR_REVERT = list(
+        map(
+            str,
+            [
+                pysvn.wc_status_kind.missing,
+                pysvn.wc_status_kind.added,
+                pysvn.wc_status_kind.modified,
+                pysvn.wc_status_kind.deleted,
+            ],
+        )
+    )
 
-    STATUSES_FOR_ADD = list(map(str,
-        [
-            pysvn.wc_status_kind.unversioned,
-            pysvn.wc_status_kind.obstructed
-        ]))
+    STATUSES_FOR_ADD = list(
+        map(str, [pysvn.wc_status_kind.unversioned, pysvn.wc_status_kind.obstructed])
+    )
 
-    STATUSES_FOR_RESOLVE = list(map(str,
-        [
-            pysvn.wc_status_kind.conflicted
-        ]))
+    STATUSES_FOR_RESOLVE = list(map(str, [pysvn.wc_status_kind.conflicted]))
 
-    STATUSES_FOR_CHECK = list(map(str,
-        [
-            pysvn.wc_status_kind.added,
-            pysvn.wc_status_kind.deleted,
-            pysvn.wc_status_kind.replaced,
-            pysvn.wc_status_kind.modified,
-            pysvn.wc_status_kind.missing,
-            pysvn.wc_status_kind.conflicted,
-        ]))
+    STATUSES_FOR_CHECK = list(
+        map(
+            str,
+            [
+                pysvn.wc_status_kind.added,
+                pysvn.wc_status_kind.deleted,
+                pysvn.wc_status_kind.replaced,
+                pysvn.wc_status_kind.modified,
+                pysvn.wc_status_kind.missing,
+                pysvn.wc_status_kind.conflicted,
+            ],
+        )
+    )
 
     PROPERTIES = {
-        "executable":   "svn:executable",
-        "mime-type":    "svn:mime-type",
-        "ignore":       "svn:ignore",
-        "keywords":     "svn:keywords",
-        "eol-style":    "svn:eol-style",
-        "externals":    "svn:externals",
-        "special":      "svn:special"
+        "executable": "svn:executable",
+        "mime-type": "svn:mime-type",
+        "ignore": "svn:ignore",
+        "keywords": "svn:keywords",
+        "eol-style": "svn:eol-style",
+        "externals": "svn:externals",
+        "special": "svn:special",
     }
 
     NOTIFY_ACTIONS = {
-        pysvn.wc_notify_action.add:                     _("Added"),
-        pysvn.wc_notify_action.copy:                    _("Copied"),
-        pysvn.wc_notify_action.delete:                  _("Deleted"),
-        pysvn.wc_notify_action.restore:                 _("Restored"),
-        pysvn.wc_notify_action.revert:                  _("Reverted"),
-        pysvn.wc_notify_action.failed_revert:           _("Failed Revert"),
-        pysvn.wc_notify_action.resolved:                _("Resolved"),
-        pysvn.wc_notify_action.skip:                    _("Skipped"),
-        pysvn.wc_notify_action.update_delete:           _("Deleted"),
-        pysvn.wc_notify_action.update_add:              _("Added"),
-        pysvn.wc_notify_action.update_started:          _("Updating"),
-        pysvn.wc_notify_action.update_update:           _("Updated"),
-        pysvn.wc_notify_action.update_completed:        _("Completed"),
-        pysvn.wc_notify_action.update_external:         _("External"),
-        pysvn.wc_notify_action.status_completed:        _("Completed"),
-        pysvn.wc_notify_action.status_external:         _("External"),
-        pysvn.wc_notify_action.commit_modified:         _("Modified"),
-        pysvn.wc_notify_action.commit_added:            _("Added"),
-        pysvn.wc_notify_action.commit_deleted:          _("Deleted"),
-        pysvn.wc_notify_action.commit_replaced:         _("Replaced"),
-        pysvn.wc_notify_action.commit_postfix_txdelta:  _("Changed"),
-        pysvn.wc_notify_action.annotate_revision:       _("Annotated"),
-        pysvn.wc_notify_action.locked:                  _("Locked"),
-        pysvn.wc_notify_action.unlocked:                _("Unlocked"),
-        pysvn.wc_notify_action.failed_lock:             _("Failed Lock"),
-        pysvn.wc_notify_action.failed_unlock:           _("Failed Unlock")
+        pysvn.wc_notify_action.add: _("Added"),
+        pysvn.wc_notify_action.copy: _("Copied"),
+        pysvn.wc_notify_action.delete: _("Deleted"),
+        pysvn.wc_notify_action.restore: _("Restored"),
+        pysvn.wc_notify_action.revert: _("Reverted"),
+        pysvn.wc_notify_action.failed_revert: _("Failed Revert"),
+        pysvn.wc_notify_action.resolved: _("Resolved"),
+        pysvn.wc_notify_action.skip: _("Skipped"),
+        pysvn.wc_notify_action.update_delete: _("Deleted"),
+        pysvn.wc_notify_action.update_add: _("Added"),
+        pysvn.wc_notify_action.update_started: _("Updating"),
+        pysvn.wc_notify_action.update_update: _("Updated"),
+        pysvn.wc_notify_action.update_completed: _("Completed"),
+        pysvn.wc_notify_action.update_external: _("External"),
+        pysvn.wc_notify_action.status_completed: _("Completed"),
+        pysvn.wc_notify_action.status_external: _("External"),
+        pysvn.wc_notify_action.commit_modified: _("Modified"),
+        pysvn.wc_notify_action.commit_added: _("Added"),
+        pysvn.wc_notify_action.commit_deleted: _("Deleted"),
+        pysvn.wc_notify_action.commit_replaced: _("Replaced"),
+        pysvn.wc_notify_action.commit_postfix_txdelta: _("Changed"),
+        pysvn.wc_notify_action.annotate_revision: _("Annotated"),
+        pysvn.wc_notify_action.locked: _("Locked"),
+        pysvn.wc_notify_action.unlocked: _("Unlocked"),
+        pysvn.wc_notify_action.failed_lock: _("Failed Lock"),
+        pysvn.wc_notify_action.failed_unlock: _("Failed Unlock"),
     }
 
     NOTIFY_ACTIONS_COMPLETE = [
         pysvn.wc_notify_action.status_completed,
         pysvn.wc_notify_action.update_completed,
-        commit_completed
+        commit_completed,
     ]
 
     NOTIFY_STATES = {
-        pysvn.wc_notify_state.inapplicable:             _("Inapplicable"),
-        pysvn.wc_notify_state.unknown:                  _("Unknown"),
-        pysvn.wc_notify_state.unchanged:                _("Unchanged"),
-        pysvn.wc_notify_state.missing:                  _("Missing"),
-        pysvn.wc_notify_state.obstructed:               _("Obstructed"),
-        pysvn.wc_notify_state.changed:                  _("Changed"),
-        pysvn.wc_notify_state.merged:                   _("Merged"),
-        pysvn.wc_notify_state.conflicted:               _("Conflicted")
+        pysvn.wc_notify_state.inapplicable: _("Inapplicable"),
+        pysvn.wc_notify_state.unknown: _("Unknown"),
+        pysvn.wc_notify_state.unchanged: _("Unchanged"),
+        pysvn.wc_notify_state.missing: _("Missing"),
+        pysvn.wc_notify_state.obstructed: _("Obstructed"),
+        pysvn.wc_notify_state.changed: _("Changed"),
+        pysvn.wc_notify_state.merged: _("Merged"),
+        pysvn.wc_notify_state.conflicted: _("Conflicted"),
     }
 
     NODE_KINDS_REVERSE = {
         pysvn.node_kind.none: "none",
         pysvn.node_kind.file: "file",
-        pysvn.node_kind.dir:  "dir",
-        pysvn.node_kind.unknown: "unknown"
+        pysvn.node_kind.dir: "dir",
+        pysvn.node_kind.unknown: "unknown",
     }
 
     def __init__(self):
@@ -280,9 +287,9 @@ class SVN(object):
             return [on_error]
 
         try:
-            pysvn_statuses = self.client_status(path,
-                                                depth=pysvn.depth.infinity,
-                                                update=update)
+            pysvn_statuses = self.client_status(
+                path, depth=pysvn.depth.infinity, update=update
+            )
             if not len(pysvn_statuses):
                 # This is NOT in the PySVN documentation, but sometimes it
                 # returns an empty list if the file goes missing...
@@ -304,7 +311,7 @@ class SVN(object):
                 return statuslist
         except pysvn.ClientError as ex:
             # TODO: uncommenting these might not be a good idea
-            #~ traceback.print_exc()
+            # ~ traceback.print_exc()
             log.debug("Exception occurred in SVN.status() for %s" % path)
             log.exception(ex)
             return [on_error]
@@ -364,14 +371,16 @@ class SVN(object):
             # And it's associated with the status "obstructed". The only
             # way to make sure that we're dealing with a working copy
             # is by verifying the SVN administration area exists.
-            if (isdir(path) and
-                    self.client_info(path) and
-                    isdir(os.path.join(path, ".svn"))):
+            if (
+                isdir(path)
+                and self.client_info(path)
+                and isdir(os.path.join(path, ".svn"))
+            ):
                 return True
             return False
         except Exception as e:
             # FIXME: ClientError client in use on another thread
-            #~ log.debug("EXCEPTION in is_working_copy(): %s" % str(e))
+            # ~ log.debug("EXCEPTION in is_working_copy(): %s" % str(e))
             return False
 
     def is_in_a_or_a_working_copy(self, path):
@@ -387,8 +396,7 @@ class SVN(object):
         else:
             try:
                 # info will return nothing for an unversioned file inside a working copy
-                if (self.is_in_a_or_a_working_copy(path) and
-                        self.client_info(path)):
+                if self.is_in_a_or_a_working_copy(path) and self.client_info(path):
                     return True
             except Exception as e:
                 log.exception("is_versioned exception for %s" % path)
@@ -405,12 +413,15 @@ class SVN(object):
         # If looking for "NORMAL", then both statuses must be normal (or propstatus=none)
         # Otherwise, it is an either or situation
         if status_kind == pysvn.wc_status_kind.normal:
-            return (status.data["text_status"] == status_kind
-                and (status.data["prop_status"] == status_kind
-                    or status.data["prop_status"] == pysvn.wc_status_kind.none))
+            return status.data["text_status"] == status_kind and (
+                status.data["prop_status"] == status_kind
+                or status.data["prop_status"] == pysvn.wc_status_kind.none
+            )
         else:
-            return (status.data["text_status"] == status_kind
-                or status.data["prop_status"] == status_kind)
+            return (
+                status.data["text_status"] == status_kind
+                or status.data["prop_status"] == status_kind
+            )
 
         return False
 
@@ -421,7 +432,7 @@ class SVN(object):
             is_locked = self.client.info2(path, recurse=False)[0][1].lock is not None
         except pysvn.ClientError as e:
             return False
-            #log.exception("is_locked exception for %s" % path)
+            # log.exception("is_locked exception for %s" % path)
 
         return is_locked
 
@@ -446,7 +457,9 @@ class SVN(object):
 
             sts = self.statuses(path, invalidate=True)
             for st in sts:
-                if (not statuses) or (st.content in statuses or st.metadata in statuses):
+                if (not statuses) or (
+                    st.content in statuses or st.metadata in statuses
+                ):
                     items.append(st)
 
         return items
@@ -558,7 +571,9 @@ class SVN(object):
         except KeyError as e:
             log.exception("KeyError exception in svn.py get_revision() for %s" % path)
         except AttributeError as e:
-            log.exception("AttributeError exception in svn.py get_revision() for %s" % path)
+            log.exception(
+                "AttributeError exception in svn.py get_revision() for %s" % path
+            )
 
         return returner
 
@@ -601,33 +616,34 @@ class SVN(object):
         """
 
         from_url_root = self.get_repo_root_url(from_url)
-        from_branch = from_url.replace(from_url_root, '')
-        from_branch = from_branch.rstrip('/')
+        from_branch = from_url.replace(from_url_root, "")
+        from_branch = from_branch.rstrip("/")
 
         merge_info = self.propget(to_path, "svn:mergeinfo")
 
         merged_revisions = []
-        for branch in merge_info.split('\n'):
-            if not branch.startswith(from_branch + ':'):
+        for branch in merge_info.split("\n"):
+            if not branch.startswith(from_branch + ":"):
                 continue
-            revisions = branch.split(':')[1]  # branch:rev,rev-rev,...
-            for rev in revisions.split(','):
-                if rev.find('-') != -1:
-                    (rev_s, rev_e) = rev.split('-')
+            revisions = branch.split(":")[1]  # branch:rev,rev-rev,...
+            for rev in revisions.split(","):
+                if rev.find("-") != -1:
+                    (rev_s, rev_e) = rev.split("-")
                     merged_revisions += list(range(int(rev_s), int(rev_e) + 1))
                 else:
                     merged_revisions.append(int(rev))
 
         from_log = self.log(from_url, strict_node_history=False)
-        from_revisions = [ int(l.revision.short()) for l in from_log ]
+        from_revisions = [int(l.revision.short()) for l in from_log]
 
         to_log = self.log(to_path, strict_node_history=False)
-        to_revisions = [ int(l.revision.short()) for l in to_log ]
+        to_revisions = [int(l.revision.short()) for l in to_log]
 
-        candidate_revisions = list(set(from_revisions) - set(to_revisions) - set(merged_revisions))
+        candidate_revisions = list(
+            set(from_revisions) - set(to_revisions) - set(merged_revisions)
+        )
 
         return candidate_revisions
-
 
     #
     # properties
@@ -689,13 +705,18 @@ class SVN(object):
                 pure_unicode(prop_name),
                 pure_unicode(props),
                 pure_unicode(path),
-                recurse=recurse
+                recurse=recurse,
             )
             return True
         except pysvn.ClientError as e:
-            log.exception("pysvn.ClientError exception in svn.py propset() for %s" % S(path).display())
+            log.exception(
+                "pysvn.ClientError exception in svn.py propset() for %s"
+                % S(path).display()
+            )
         except TypeError as e:
-            log.exception("TypeError exception in svn.py propset() %s" % S(path).display())
+            log.exception(
+                "TypeError exception in svn.py propset() %s" % S(path).display()
+            )
 
         return False
 
@@ -744,19 +765,14 @@ class SVN(object):
         try:
             if rev:
                 returner = self.client.propget(
-                    prop_name,
-                    path,
-                    recurse=True,
-                    revision=rev
+                    prop_name, path, recurse=True, revision=rev
                 )
             else:
-                returner = self.client.propget(
-                    prop_name,
-                    path,
-                    recurse=True
-                )
+                returner = self.client.propget(prop_name, path, recurse=True)
         except pysvn.ClientError as e:
-            log.exception("pysvn.ClientError exception in svn.py propget() for %s" % path)
+            log.exception(
+                "pysvn.ClientError exception in svn.py propget() for %s" % path
+            )
             return ""
 
         try:
@@ -787,15 +803,18 @@ class SVN(object):
         returner = False
         try:
             self.client.propdel(
-                pure_unicode(prop_name),
-                pure_unicode(path),
-                recurse=recurse
+                pure_unicode(prop_name), pure_unicode(path), recurse=recurse
             )
             returner = True
         except pysvn.ClientError as e:
-            log.exception("pysvn.ClientError exception in svn.py propdel() for %s" % S(path).display())
+            log.exception(
+                "pysvn.ClientError exception in svn.py propdel() for %s"
+                % S(path).display()
+            )
         except TypeError as e:
-            log.exception("TypeError exception in svn.py propdel() %s" % S(path).display())
+            log.exception(
+                "TypeError exception in svn.py propdel() %s" % S(path).display()
+            )
 
         return returner
 
@@ -816,34 +835,41 @@ class SVN(object):
 
         """
         local_props = self.proplist(path)
-        base_props = self.proplist(path,
-                                   rev=Revision("base").primitive())
+        base_props = self.proplist(path, rev=Revision("base").primitive())
 
         prop_details = {}
 
         local_propnames = set(local_props.keys())
         base_propnames = set(base_props.keys())
 
-        for propname in (local_propnames | base_propnames):
+        for propname in local_propnames | base_propnames:
 
             if propname in (local_propnames & base_propnames):
                 # These are the property names that are common to the WC and
                 # base. If their values have changed, list them as changed
                 if local_props[propname] == base_props[propname]:
-                    prop_details[propname] = {"status": rabbitvcs.vcs.status.status_normal,
-                                              "value": local_props[propname]}
+                    prop_details[propname] = {
+                        "status": rabbitvcs.vcs.status.status_normal,
+                        "value": local_props[propname],
+                    }
 
                 else:
-                    prop_details[propname] = {"status": rabbitvcs.vcs.status.status_modified,
-                                              "value": local_props[propname]}
+                    prop_details[propname] = {
+                        "status": rabbitvcs.vcs.status.status_modified,
+                        "value": local_props[propname],
+                    }
 
             elif propname in local_propnames:
-                prop_details[propname] = {"status": rabbitvcs.vcs.status.status_added,
-                                          "value": local_props[propname]}
+                prop_details[propname] = {
+                    "status": rabbitvcs.vcs.status.status_added,
+                    "value": local_props[propname],
+                }
 
             elif propname in base_propnames:
-                prop_details[propname] = {"status": rabbitvcs.vcs.status.status_deleted,
-                                          "value": base_props[propname]}
+                prop_details[propname] = {
+                    "status": rabbitvcs.vcs.status.status_deleted,
+                    "value": base_props[propname],
+                }
 
         return prop_details
 
@@ -872,10 +898,12 @@ class SVN(object):
         if rev is None:
             rev = self.revision("head")
 
-        self.client.revpropset(pure_unicode(prop_name),
-                               pure_unicode(prop_value),
-                               pure_unicode(url),
-                               revision=rev.primitive())
+        self.client.revpropset(
+            pure_unicode(prop_name),
+            pure_unicode(prop_value),
+            pure_unicode(url),
+            revision=rev.primitive(),
+        )
 
     def revproplist(self, url, rev=None):
         """
@@ -919,9 +947,7 @@ class SVN(object):
             rev = self.revision("head")
 
         return self.client.revpropget(
-            pure_unicode(prop_name),
-            pure_unicode(url),
-            revision=rev.primitive()
+            pure_unicode(prop_name), pure_unicode(url), revision=rev.primitive()
         )
 
     def revpropdel(self, url, prop_name, rev=None, force=False):
@@ -949,7 +975,7 @@ class SVN(object):
             pure_unicode(prop_name),
             pure_unicode(url),
             revision=rev.primitive(),
-            force=force
+            force=force,
         )
 
     #
@@ -1041,7 +1067,7 @@ class SVN(object):
         @param path: the path to add to version control
         @type path: string
         """
-        head, tail = pure_unicode(path),""
+        head, tail = pure_unicode(path), ""
         tails = list()
 
         # We need to add backwards-recursively, since patch could create
@@ -1077,8 +1103,14 @@ class SVN(object):
         dest = helper.urlize(pure_unicode(dest))
         return self.client.copy(src, dest, revision.primitive())
 
-    def copy_all(self, sources, dest_url_or_path, copy_as_child=False,
-            make_parents=False, ignore_externals=False):
+    def copy_all(
+        self,
+        sources,
+        dest_url_or_path,
+        copy_as_child=False,
+        make_parents=False,
+        ignore_externals=False,
+    ):
         """
         Copy sources to the dest_url_or_path.
 
@@ -1100,12 +1132,18 @@ class SVN(object):
 
         """
 
-        return self.client.copy2(pure_unicode(sources),
-            pure_unicode(dest_url_or_path), copy_as_child,
-            make_parents, None, ignore_externals)
+        return self.client.copy2(
+            pure_unicode(sources),
+            pure_unicode(dest_url_or_path),
+            copy_as_child,
+            make_parents,
+            None,
+            ignore_externals,
+        )
 
-    def checkout(self, url, path, recurse=True, revision=Revision("head"),
-            ignore_externals=False):
+    def checkout(
+        self, url, path, recurse=True, revision=Revision("head"), ignore_externals=False
+    ):
 
         """
         Checkout a working copy from a vcs repository
@@ -1129,9 +1167,13 @@ class SVN(object):
 
         url = helper.urlize(pure_unicode(url))
 
-        return self.client.checkout(url, pure_unicode(path),
-            recurse=recurse, revision=revision.primitive(),
-            ignore_externals=ignore_externals)
+        return self.client.checkout(
+            url,
+            pure_unicode(path),
+            recurse=recurse,
+            revision=revision.primitive(),
+            ignore_externals=ignore_externals,
+        )
 
     def cleanup(self, path):
         """
@@ -1179,23 +1221,30 @@ class SVN(object):
             # committed.  The pysvn.depth kwarg must be set to empty.
             # Unfortunately, older pysvn/svn installations do not have the depth
             # enum so for those, recurse must be used.
-            kwargs["depth"] = (recurse and pysvn.depth.infinity or pysvn.depth.empty)
+            kwargs["depth"] = recurse and pysvn.depth.infinity or pysvn.depth.empty
         except AttributeError:
             kwargs["recurse"] = recurse
 
-        retval = self.client.checkin(pure_unicode(paths),
-                                     pure_unicode(log_message), **kwargs)
+        retval = self.client.checkin(
+            pure_unicode(paths), pure_unicode(log_message), **kwargs
+        )
         dummy_commit_dict = {
             "revision": retval,
-            "action": rabbitvcs.vcs.svn.commit_completed
-            }
+            "action": rabbitvcs.vcs.svn.commit_completed,
+        }
         self.client.callback_notify(dummy_commit_dict)
 
         return retval
 
-    def log(self, url_or_path, revision_start=Revision("head"),
-            revision_end=Revision("number", 0), limit=0,
-            discover_changed_paths=True, strict_node_history=False):
+    def log(
+        self,
+        url_or_path,
+        revision_start=Revision("head"),
+        revision_end=Revision("number", 0),
+        limit=0,
+        discover_changed_paths=True,
+        strict_node_history=False,
+    ):
         """
         Retrieve log items for a given path in the repository
 
@@ -1213,14 +1262,23 @@ class SVN(object):
 
         """
 
-        log = self.client.log(pure_unicode(url_or_path),
-            revision_start.primitive(), revision_end.primitive(),
-            discover_changed_paths, strict_node_history, limit)
+        log = self.client.log(
+            pure_unicode(url_or_path),
+            revision_start.primitive(),
+            revision_end.primitive(),
+            discover_changed_paths,
+            strict_node_history,
+            limit,
+        )
 
         returner = []
         for item in log:
             revision = Revision(pysvn.opt_revision_kind.number, item.revision.number)
-            date = datetime.fromtimestamp(item.date) if hasattr(item, "date") else datetime(1900, 1, 1)
+            date = (
+                datetime.fromtimestamp(item.date)
+                if hasattr(item, "date")
+                else datetime(1900, 1, 1)
+            )
 
             author = _("(no author)")
             if hasattr(item, "author"):
@@ -1234,32 +1292,41 @@ class SVN(object):
             for changed_path in item.changed_paths:
                 copy_from_rev = ""
                 if hasattr(changed_path.copyfrom_revision, "number"):
-                    copy_from_rev = self.revision("number", changed_path.copyfrom_revision.number)
+                    copy_from_rev = self.revision(
+                        "number", changed_path.copyfrom_revision.number
+                    )
 
                 copy_from_path = ""
                 if hasattr(changed_path, "copy_from_path"):
                     copy_from_path = changed_path.copy_from_path
 
-                changed_paths.append(rabbitvcs.vcs.log.LogChangedPath(
-                    changed_path.path,
-                    changed_path.action,
-                    copy_from_path,
-                    copy_from_rev
-                ))
+                changed_paths.append(
+                    rabbitvcs.vcs.log.LogChangedPath(
+                        changed_path.path,
+                        changed_path.action,
+                        copy_from_path,
+                        copy_from_rev,
+                    )
+                )
 
-            returner.append(rabbitvcs.vcs.log.Log(
-                date,
-                revision,
-                author,
-                message,
-                changed_paths,
-                None
-            ))
+            returner.append(
+                rabbitvcs.vcs.log.Log(
+                    date, revision, author, message, changed_paths, None
+                )
+            )
 
         return returner
 
-    def export(self, src_url_or_path, dest_path, revision=Revision("head"),
-            recurse=True, ignore_externals=False, force=False, native_eol=None):
+    def export(
+        self,
+        src_url_or_path,
+        dest_path,
+        revision=Revision("head"),
+        recurse=True,
+        ignore_externals=False,
+        force=False,
+        native_eol=None,
+    ):
 
         """
         Export files from either a working copy or repository into a local
@@ -1282,9 +1349,15 @@ class SVN(object):
 
         """
 
-        self.client.export(pure_unicode(src_url_or_path),
-            pure_unicode(dest_path), force,
-            revision.primitive(), native_eol, ignore_externals, recurse)
+        self.client.export(
+            pure_unicode(src_url_or_path),
+            pure_unicode(dest_path),
+            force,
+            revision.primitive(),
+            native_eol,
+            ignore_externals,
+            recurse,
+        )
 
     def import_(self, path, url, log_message, ignore=False):
 
@@ -1306,9 +1379,9 @@ class SVN(object):
         """
 
         url = helper.urlize(url)
-        return self.client.import_(pure_unicode(path),
-                                   pure_unicode(url),
-                                   pure_unicode(log_message), ignore)
+        return self.client.import_(
+            pure_unicode(path), pure_unicode(url), pure_unicode(log_message), ignore
+        )
 
     def lock(self, url_or_path, lock_comment, force=False):
 
@@ -1326,8 +1399,9 @@ class SVN(object):
 
         """
 
-        return self.client.lock(pure_unicode(url_or_path),
-                                pure_unicode(lock_comment), force)
+        return self.client.lock(
+            pure_unicode(url_or_path), pure_unicode(lock_comment), force
+        )
 
     def relocate(self, from_url, to_url, path, recurse=True):
 
@@ -1367,11 +1441,11 @@ class SVN(object):
         if hasattr(self.client, "move2"):
             return self.client.move2([src_url_or_path], dest_url_or_path)
         else:
-            return self.client.move(src_url_or_path, dest_url_or_path,
-                force=True)
+            return self.client.move(src_url_or_path, dest_url_or_path, force=True)
 
-    def move_all(self, sources, dest_url_or_path, move_as_child=False,
-            make_parents=False):
+    def move_all(
+        self, sources, dest_url_or_path, move_as_child=False, make_parents=False
+    ):
         """
         Move sources to the dest_url_or_path.
 
@@ -1390,9 +1464,12 @@ class SVN(object):
 
         """
 
-        return self.client.move2(pure_unicode(sources),
+        return self.client.move2(
+            pure_unicode(sources),
             pure_unicode(dest_url_or_path),
-            move_as_child=move_as_child, make_parents=make_parents)
+            move_as_child=move_as_child,
+            make_parents=make_parents,
+        )
 
     def remove(self, url_or_path, force=False, keep_local=False):
 
@@ -1410,8 +1487,7 @@ class SVN(object):
 
         """
 
-        return self.client.remove(pure_unicode(url_or_path),
-                                  force, keep_local)
+        return self.client.remove(pure_unicode(url_or_path), force, keep_local)
 
     def revert(self, paths, recurse=False):
         """
@@ -1473,8 +1549,9 @@ class SVN(object):
 
         return self.client.unlock(pure_unicode(path), force)
 
-    def update(self, path, recurse=True, revision=Revision("head"),
-            ignore_externals=False):
+    def update(
+        self, path, recurse=True, revision=Revision("head"), ignore_externals=False
+    ):
         """
         Update a working copy.
 
@@ -1492,12 +1569,16 @@ class SVN(object):
 
         """
 
-        return self.client.update(pure_unicode(path),
-                                  recurse, revision.primitive(),
-                                  ignore_externals)
+        return self.client.update(
+            pure_unicode(path), recurse, revision.primitive(), ignore_externals
+        )
 
-    def annotate(self, url_or_path, from_revision=Revision("number", 1),
-            to_revision=Revision("head")):
+    def annotate(
+        self,
+        url_or_path,
+        from_revision=Revision("number", 1),
+        to_revision=Revision("head"),
+    ):
         """
         Get the annotate results for the given file and revision range.
 
@@ -1512,13 +1593,23 @@ class SVN(object):
 
         """
 
-        return self.client.annotate(pure_unicode(url_or_path),
-                                    from_revision.primitive(),
-                                    to_revision.primitive())
+        return self.client.annotate(
+            pure_unicode(url_or_path),
+            from_revision.primitive(),
+            to_revision.primitive(),
+        )
 
-    def merge_ranges(self, source, ranges_to_merge, peg_revision,
-            target_wcpath, notice_ancestry=False, force=False, dry_run=False,
-            record_only=False):
+    def merge_ranges(
+        self,
+        source,
+        ranges_to_merge,
+        peg_revision,
+        target_wcpath,
+        notice_ancestry=False,
+        force=False,
+        dry_run=False,
+        record_only=False,
+    ):
         """
         Merge a range of revisions.
 
@@ -1549,14 +1640,16 @@ class SVN(object):
         TODO: Will firm up the parameter documentation later
 
         """
-        return self.client.merge_peg2(pure_unicode(source),
-                                      ranges_to_merge,
-                                      peg_revision.primitive(),
-                                      pure_unicode(target_wcpath),
-                                      notice_ancestry=notice_ancestry,
-                                      force=force,
-                                      dry_run=dry_run,
-                                      record_only=record_only)
+        return self.client.merge_peg2(
+            pure_unicode(source),
+            ranges_to_merge,
+            peg_revision.primitive(),
+            pure_unicode(target_wcpath),
+            notice_ancestry=notice_ancestry,
+            force=force,
+            dry_run=dry_run,
+            record_only=record_only,
+        )
 
     def has_merge2(self):
         """
@@ -1565,8 +1658,18 @@ class SVN(object):
         """
         return hasattr(self.client, "merge_peg2")
 
-    def merge_trees(self, url_or_path1, revision1, url_or_path2, revision2,
-            local_path, force=False, recurse=True, dry_run=False, record_only=False):
+    def merge_trees(
+        self,
+        url_or_path1,
+        revision1,
+        url_or_path2,
+        revision2,
+        local_path,
+        force=False,
+        recurse=True,
+        dry_run=False,
+        record_only=False,
+    ):
         """
         Merge two trees into one.
 
@@ -1603,15 +1706,17 @@ class SVN(object):
 
         url_or_path1 = helper.urlize(pure_unicode(url_or_path1))
         url_or_path2 = helper.urlize(pure_unicode(url_or_path2))
-        return self.client.merge(url_or_path1,
-                                 revision1.primitive(),
-                                 url_or_path2,
-                                 revision2.primitive(),
-                                 pure_unicode(local_path),
-                                 force = force,
-                                 recurse = recurse,
-                                 dry_run = dry_run,
-                                 record_only = record_only)
+        return self.client.merge(
+            url_or_path1,
+            revision1.primitive(),
+            url_or_path2,
+            revision2.primitive(),
+            pure_unicode(local_path),
+            force=force,
+            recurse=recurse,
+            dry_run=dry_run,
+            record_only=record_only,
+        )
 
     def has_merge_reintegrate(self):
         """
@@ -1638,15 +1743,25 @@ class SVN(object):
 
         """
 
-        return self.client.merge_reintegrate(pure_unicode(url_or_path),
-                                             revision.primitive(),
-                                             pure_unicode(local_path),
-                                             dry_run = dry_run)
+        return self.client.merge_reintegrate(
+            pure_unicode(url_or_path),
+            revision.primitive(),
+            pure_unicode(local_path),
+            dry_run=dry_run,
+        )
 
-
-    def diff(self, tmp_path, url_or_path, revision1, url_or_path2, revision2,
-            recurse=True, ignore_ancestry=False, diff_deleted=True,
-            ignore_content_type=False):
+    def diff(
+        self,
+        tmp_path,
+        url_or_path,
+        revision1,
+        url_or_path2,
+        revision2,
+        recurse=True,
+        ignore_ancestry=False,
+        diff_deleted=True,
+        ignore_content_type=False,
+    ):
         """
         Returns the diff text between the base code and the working copy.
 
@@ -1679,15 +1794,27 @@ class SVN(object):
 
         """
 
-        return self.client.diff(pure_unicode(tmp_path),
-                                pure_unicode(url_or_path),
-                                revision1.primitive(),
-                                pure_unicode(url_or_path2),
-                                revision2.primitive(), recurse, ignore_ancestry,
-                                diff_deleted, ignore_content_type)
+        return self.client.diff(
+            pure_unicode(tmp_path),
+            pure_unicode(url_or_path),
+            revision1.primitive(),
+            pure_unicode(url_or_path2),
+            revision2.primitive(),
+            recurse,
+            ignore_ancestry,
+            diff_deleted,
+            ignore_content_type,
+        )
 
-    def diff_summarize(self, url_or_path1, revision1, url_or_path2, revision2,
-            recurse=True, ignore_ancestry=False):
+    def diff_summarize(
+        self,
+        url_or_path1,
+        revision1,
+        url_or_path2,
+        revision2,
+        recurse=True,
+        ignore_ancestry=False,
+    ):
         """
         Returns a summary of changed items between two paths/revisions
 
@@ -1714,16 +1841,20 @@ class SVN(object):
 
         """
 
-        return self.client.diff_summarize(pure_unicode(url_or_path1),
-                                          revision1.primitive(),
-                                          pure_unicode(url_or_path2),
-                                          revision2.primitive(),
-                                          recurse, ignore_ancestry)
+        return self.client.diff_summarize(
+            pure_unicode(url_or_path1),
+            revision1.primitive(),
+            pure_unicode(url_or_path2),
+            revision2.primitive(),
+            recurse,
+            ignore_ancestry,
+        )
 
     def list(self, url_or_path, revision=Revision("HEAD"), recurse=True):
         url_or_path = helper.urlize(url_or_path)
-        return self.client.list(pure_unicode(url_or_path),
-                                revision=revision.primitive(), recurse=recurse)
+        return self.client.list(
+            pure_unicode(url_or_path), revision=revision.primitive(), recurse=recurse
+        )
 
     def mkdir(self, url_or_path, log_message):
         """
@@ -1737,8 +1868,7 @@ class SVN(object):
 
         """
 
-        return self.client.mkdir(pure_unicode(url_or_path),
-                                 pure_unicode(log_message))
+        return self.client.mkdir(pure_unicode(url_or_path), pure_unicode(log_message))
 
     def apply_patch(self, patch_file, base_dir):
         """
@@ -1761,31 +1891,29 @@ class SVN(object):
             event_dict = dict()
 
             event_dict["path"] = file
-            event_dict["mime_type"] = "" # meh
+            event_dict["mime_type"] = ""  # meh
 
             if success:
-                event_dict["action"] = _("Patched") # not in pysvn, but
-                                                    # we have a fallback
+                event_dict["action"] = _("Patched")  # not in pysvn, but
+                # we have a fallback
             else:
                 any_failures = True
-                event_dict["action"] = _("Patch Failed") # better wording needed?
+                event_dict["action"] = _("Patch Failed")  # better wording needed?
 
             # Creates its own notifications.
             self.add_backwards(fullpath)
 
             if rej_file:
                 rej_info = {
-                    "path" : rej_file,
-                    "action" : _("Rejected Patch"),
-                    "mime_type" : None
+                    "path": rej_file,
+                    "action": _("Rejected Patch"),
+                    "mime_type": None,
                 }
 
             if self.client.callback_notify:
                 self.client.callback_notify(event_dict)
                 if rej_file:
                     self.client.callback_notify(rej_info)
-
-
 
     def is_version_less_than(self, version):
         """
@@ -1796,19 +1924,22 @@ class SVN(object):
         if version[0] > pysvn.version[0]:
             return True
 
-        if ((version[0] == pysvn.version[0])
-                and (version[1] > pysvn.version[1])):
+        if (version[0] == pysvn.version[0]) and (version[1] > pysvn.version[1]):
             return True
 
-        if ((version[0] == pysvn.version[0])
-                and (version[1] == pysvn.version[1])
-                and (version[2] > pysvn.version[2])):
+        if (
+            (version[0] == pysvn.version[0])
+            and (version[1] == pysvn.version[1])
+            and (version[2] > pysvn.version[2])
+        ):
             return True
 
-        if ((version[0] == pysvn.version[0])
-                and (version[1] == pysvn.version[1])
-                and (version[2] == pysvn.version[2])
-                and (version[3] > pysvn.version[3])):
+        if (
+            (version[0] == pysvn.version[0])
+            and (version[1] == pysvn.version[1])
+            and (version[2] == pysvn.version[2])
+            and (version[3] > pysvn.version[3])
+        ):
             return True
 
         return False

--- a/setup.py
+++ b/setup.py
@@ -44,32 +44,33 @@ for c in sys.argv:
     elif c == '--user':
         PREFIX = os.path.expanduser("~/.local")
 
-#==============================================================================
+# ==============================================================================
 # Variables
-#==============================================================================
+# ==============================================================================
 
 # Some descriptive variables
 # This will eventually be passed to the setup function, but we already need them
 # for doing some other stuff so we have to declare them here.
-name                = "rabbitvcs"
-version             = "0.18"
-description         = "Easy version control"
-long_description    = """RabbitVCS is a set of graphical tools written to provide simple and straightforward access to the version control systems you use."""
-author              = "Adam Plumb"
-author_email        = "adamplumb@gmail.com"
-url                 = "http://www.rabbitvcs.org"
-license             = "GNU General Public License version 2 or later"
+name = "rabbitvcs"
+version = "0.18"
+description = "Easy version control"
+long_description = """RabbitVCS is a set of graphical tools written to provide simple and straightforward access to the version control systems you use."""
+author = "Adam Plumb"
+author_email = "adamplumb@gmail.com"
+url = "http://www.rabbitvcs.org"
+license = "GNU General Public License version 2 or later"
 
-#==============================================================================
+# ==============================================================================
 # Paths
-#==============================================================================
+# ==============================================================================
 
 icon_theme_directory = "share/icons/hicolor"
 locale_directory = "share/locale"
 
-#==============================================================================
+# ==============================================================================
 # Helper functions
-#==============================================================================
+# ==============================================================================
+
 
 def include_by_pattern(directory, directory_to_install, pattern):
     files_to_include = []
@@ -82,9 +83,10 @@ def include_by_pattern(directory, directory_to_install, pattern):
                 ))
     return files_to_include
 
-#==============================================================================
+# ==============================================================================
 # Gather all the files that need to be included
-#==============================================================================
+# ==============================================================================
+
 
 # Packages
 packages = []
@@ -120,9 +122,9 @@ fh = open(path, "w")
 fh.write(buildinfo)
 fh.close()
 
-#==============================================================================
+# ==============================================================================
 # Ready to install
-#==============================================================================
+# ==============================================================================
 
 # Calling the setup function will actually install RabbitVCS and also creates
 # an .egg-info file in /usr/lib/python<version>/site-packages/ or
@@ -167,6 +169,7 @@ if sys.argv[1] == "install":
         print("Running gtk-update-icon-cache")
 
         subprocess.Popen(
-            ["gtk-update-icon-cache", os.path.join(PREFIX, icon_theme_directory)],
+            ["gtk-update-icon-cache",
+                os.path.join(PREFIX, icon_theme_directory)],
             stdout=subprocess.PIPE
         ).communicate()[0]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 #!/usr/bin/env python
 
 # If you didn't know already, this is a Python distutils setup script. It borrows
@@ -41,7 +42,7 @@ PREFIX = sys.prefix
 for c in sys.argv:
     if c.startswith("--prefix="):
         PREFIX = c.split("=", 1)[1].strip()
-    elif c == '--user':
+    elif c == "--user":
         PREFIX = os.path.expanduser("~/.local")
 
 # ==============================================================================
@@ -77,11 +78,14 @@ def include_by_pattern(directory, directory_to_install, pattern):
     for root, dirs, files in os.walk(directory):
         for file in files:
             if file.endswith(pattern):
-                files_to_include.append((
-                    root.replace(directory, directory_to_install),
-                    [os.path.join(root, file)]
-                ))
+                files_to_include.append(
+                    (
+                        root.replace(directory, directory_to_install),
+                        [os.path.join(root, file)],
+                    )
+                )
     return files_to_include
+
 
 # ==============================================================================
 # Gather all the files that need to be included
@@ -102,22 +106,20 @@ icons = include_by_pattern("data/icons/hicolor", icon_theme_directory, ".svg")
 icons += include_by_pattern("data/icons/hicolor", icon_theme_directory, ".png")
 
 # Config parsing specification
-config_spec = [(
-    "share/rabbitvcs",
-    ["rabbitvcs/util/configspec/configspec.ini"]
-)]
+config_spec = [("share/rabbitvcs", ["rabbitvcs/util/configspec/configspec.ini"])]
 
 # Documentation
-documentation = [("share/doc/rabbitvcs", [
-    "AUTHORS",
-    "MAINTAINERS"
-])]
+documentation = [("share/doc/rabbitvcs", ["AUTHORS", "MAINTAINERS"])]
 
 # Save build information so we can access the prefix later
 path = "rabbitvcs/buildinfo.py"
-buildinfo = '''rabbitvcs_prefix = "%s"
+buildinfo = """rabbitvcs_prefix = "%s"
 icon_path = "%s/%s"
-''' % (PREFIX, PREFIX, icon_theme_directory)
+""" % (
+    PREFIX,
+    PREFIX,
+    icon_theme_directory,
+)
 fh = open(path, "w")
 fh.write(buildinfo)
 fh.close()
@@ -141,7 +143,6 @@ dist = setup(
     author_email=author_email,
     url=url,
     license=license,
-
     # There are actually several arguments that are used to install files:
     # - py_modules: installs specific modules to site-packages
     # - packages: install complete packages (directories with an __init__.py
@@ -152,10 +153,10 @@ dist = setup(
         "rabbitvcs": [
             # Include our GtkBuilder UI files right into the package
             "ui/xml/*.xml",
-            "ui/xml/dialogs/*.xml"
+            "ui/xml/dialogs/*.xml",
         ]
     },
-    data_files=translations + icons + documentation + config_spec
+    data_files=translations + icons + documentation + config_spec,
 )
 
 #
@@ -165,11 +166,10 @@ dist = setup(
 # Make sure the icon cache is deleted and recreated
 if sys.argv[1] == "install":
 
-    if os.uname()[0] != 'Darwin':
+    if os.uname()[0] != "Darwin":
         print("Running gtk-update-icon-cache")
 
         subprocess.Popen(
-            ["gtk-update-icon-cache",
-                os.path.join(PREFIX, icon_theme_directory)],
-            stdout=subprocess.PIPE
+            ["gtk-update-icon-cache", os.path.join(PREFIX, icon_theme_directory)],
+            stdout=subprocess.PIPE,
         ).communicate()[0]


### PR DESCRIPTION
clients/thunar/RabbitVCS.py:32:0: W0611: Unused import datetime (unused-import)
clients/thunar/RabbitVCS.py:33:0: W0611: Unused import time (unused-import)
clients/thunar/RabbitVCS.py:46:0: W0611: Unused import os (unused-import)
clients/thunar/RabbitVCS.py:31:0: W0611: Unused isdir imported from os.path (unused-import)
clients/thunar/RabbitVCS.py:31:0: W0611: Unused isfile imported from os.path (unused-import)
clients/thunar/RabbitVCS.py:31:0: W0611: Unused basename imported from os.path (unused-import)
clients/thunar/RabbitVCS.py:55:0: W0611: Unused SEPARATOR imported from rabbitvcs.util.contextmenu (unused-import)
clients/thunar/RabbitVCS.py:54:0: W0611: Unused disable imported from rabbitvcs.util.decorators (unused-import)
clients/thunar/RabbitVCS.py:41:0: W0611: Unused Gtk imported from gi.repository (unused-import)