### PR TITLE
Add missing cursor-changed callback for git revisions_table

### DIFF
--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -703,7 +703,10 @@ class GitLog(Log):
                     "user_data": {"column": 1},
                 }
             ],
-            callbacks={"mouse-event": self.on_revisions_table_mouse_event},
+            callbacks={
+                "mouse-event": self.on_revisions_table_mouse_event,
+                "cursor-changed": self.on_revisions_table_cursor_changed,
+            },
         )
 
         self.paths_table = rabbitvcs.ui.widget.Table(


### PR DESCRIPTION
The cursor-changed callback was missing for the git revisions_table, so the paths_table ("Affected files") was never updated.