### PR TITLE
fix git soft and hard reset

### DIFF
--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -2173,7 +2173,7 @@ class GittyupClient(object):
             cmd.append("--%s" % type)
 
         cmd.append(revision)
-        if relative_path:
+        if relative_path and not "soft" == type and not "hard" == type:
             cmd.append(relative_path)
 
         try:


### PR DESCRIPTION
https://github.com/rabbitvcs/rabbitvcs/issues/319

soft or hard reset in git results in following error message: `fatal: Cannot do hard reset with paths`

deleting the path from reset window instead gives an error `fatal: ../..: '../..' is outside repository`

this change always omits paths for hard and soft resets which is what is supposed to happen