### PR TITLE
fix git file deletion

### DIFF
--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -989,6 +989,8 @@ class GittyupClient(object):
 
         """
 
+        to_stage = []
+
         if isinstance(paths, (str, six.text_type)):
             paths = [paths]
 
@@ -996,11 +998,17 @@ class GittyupClient(object):
 
         for path in paths:
             relative_path = self.get_relative_path(path)
-            if relative_path in index:
-                del index[relative_path]
-                os.remove(path)
+            absolute_path = self.get_absolute_path(path)
 
-        index.write()
+            self.notify({
+                "action": "Deleted",
+                "path": absolute_path,
+                "mime_type": guess_type(absolute_path)[0]
+            })
+            os.remove(absolute_path)
+            to_stage.append(S(relative_path))
+
+        self.repo.stage(to_stage)
 
     def move(self, source, dest):
         """


### PR DESCRIPTION
Deletion command removed file indices causing files to marked as missing - not existing but not staged either, as if erroneously removed by shell `rm FILENAME` command

This was changed to deleting the file from filesystem and then staging that non-existing file - which causes git to properly mark the file for deletion from the repository branch upon commit - as if shell command `git rm FILENAME` was executed