### PR TITLE
SVN: Use annotate2 API

### DIFF
--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -1593,7 +1593,7 @@ class SVN(object):
 
         """
 
-        return self.client.annotate(
+        return self.client.annotate2(
             pure_unicode(url_or_path),
             from_revision.primitive(),
             to_revision.primitive(),


### PR DESCRIPTION
Use annotate2 API from pysvn (available since SVN 1.7 from 2011): https://pysvn.sourceforge.io/Docs/pysvn_prog_ref.html#pysvn_client_annotate2

No need to parse date string twice anymore, as log is retrieved and parsed anyway.