### PR TITLE
Add Support for KDE 6

### DIFF
--- a/clients/dolphin/README
+++ b/clients/dolphin/README
@@ -1,7 +1,7 @@
-RabbitVCS Dolphin/KDE[45] Extension (EXPERIMENTAL!)
+RabbitVCS Dolphin/KDE[456] Extension (EXPERIMENTAL!)
 
 This extension is meant to be used with the Dolphin File Manager which comes
-with KDE 4.x and 5.x
+with KDE 4.x, 5.x and 6.x
 
 Please note this extension only consists in menu entries and is not a Dolphin
 plugin. As a consequence, RabbitVCS functions are available through Dolphin
@@ -32,6 +32,15 @@ To install with KDE 5:
 
     Alternatively you can copy the files for a private user installation to:
         /home/your-username/.local/share/kservices5/
+
+To install with KDE 6:
+    Copy all supplied .desktop files to:
+        /usr/share/kio/servicemenus
+
+    Install the RabbitCVS CLI client into some PATH directory (i.e.: /usr/bin).
+
+    Alternatively you can copy the files for a private user installation to:
+        /home/your-username/.local/share/kio/servicemenus
 
 Troubleshooting:
 

--- a/clients/dolphin/rabbitvcs_git_submenu_directory.desktop
+++ b/clients/dolphin/rabbitvcs_git_submenu_directory.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Service
 ServiceTypes=KonqPopupMenu/Plugin,inode/directory
+MimeType=inode/directory
 Actions=Update;Commit;Push;_SEPARATOR_;Changes;Log;_SEPARATOR_;Delete;Revert;Clean;Reset;Checkout;_SEPARATOR_;Branches;Tags;Remotes;_SEPARATOR_;Export;Merge;_SEPARATOR_;CreatePatch;ApplyPatch;_SEPARATOR_;CreateRepo;Clone;_SEPARATOR_;Settings;About;
 Icon=/usr/share/icons/hicolor/scalable/actions/rabbitvcs.svg
 

--- a/clients/dolphin/rabbitvcs_git_submenu_file.desktop
+++ b/clients/dolphin/rabbitvcs_git_submenu_file.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Service
 ServiceTypes=KonqPopupMenu/Plugin,application/octet-stream
+MimeType=application/octet-stream
 Actions=Checkout;Commit;_SEPARATOR_;Changes;Log;_SEPARATOR_;EditConflicts;Rename;Delete;Revert;Clean;Reset;_SEPARATOR_;Branches;Tags;Remotes;_SEPARATOR_;Export;Merge;_SEPARATOR_;Annotate;_SEPARATOR_;ApplyPatch;_SEPARATOR_;CreatePatch;Stage;Ignore;_SEPARATOR_;Settings;About;
 Icon=/usr/share/icons/hicolor/scalable/actions/rabbitvcs.svg
 

--- a/clients/dolphin/rabbitvcs_svn_submenu_directory.desktop
+++ b/clients/dolphin/rabbitvcs_svn_submenu_directory.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Service
 ServiceTypes=KonqPopupMenu/Plugin,inode/directory
+MimeType=inode/directory
 Actions=Update;Commit;Checkout;_SEPARATOR_;Log;Browser;CheckMods;_SEPARATOR_;Resolve;UpdateToRev;Rename;Delete;Revert;CleanUp;GetLock;ReleaseLock;_SEPARATOR_;BranchTag;Switch;Merge;Export;Relocate;_SEPARATOR_;CreatePatch;ApplyPatch;Properties;_SEPARATOR_;CreateRepo;Add;Import;Ignore;_SEPARATOR_;Settings;About;
 Icon=/usr/share/icons/hicolor/scalable/actions/rabbitvcs.svg
 

--- a/clients/dolphin/rabbitvcs_svn_submenu_file.desktop
+++ b/clients/dolphin/rabbitvcs_svn_submenu_file.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Service
 ServiceTypes=KonqPopupMenu/Plugin,application/octet-stream
+MimeType=application/octet-stream
 Actions=Update;Commit;_SEPARATOR_;Changes;Log;Browser;CheckMods;_SEPARATOR_;EditConflicts;Resolve;UpdateToRev;Rename;Delete;Revert;GetLock;ReleaseLock;_SEPARATOR_;BranchTag;Switch;Merge;_SEPARATOR_;Annotate;_SEPARATOR_;CreatePatch;Properties;_SEPARATOR_;Add;Ignore;_SEPARATOR_;Settings;About;
 Icon=/usr/share/icons/hicolor/scalable/actions/rabbitvcs.svg
 


### PR DESCRIPTION
In KDE6 the directories for the Dolphin Actions changed and one setting more is necessary. I adjusted the `.desktop` files and the README based on the [KDE documentation](https://develop.kde.org/docs/apps/dolphin/service-menus/#where-the-servicemenus-are-located). 

I tested it with KDE6 on Manjaro Linux using the path to install it for all users.