### PR TITLE
Fix incorrect file being compared in the "changes" window

### DIFF
--- a/rabbitvcs/ui/changes.py
+++ b/rabbitvcs/ui/changes.py
@@ -123,15 +123,9 @@ class Changes(InterfaceView):
             self.on_changes_table_event(treeview, event, *args)
 
     def on_changes_table_event(self, treeview, event, *args):
-        selection = treeview.get_selection()
-        (liststore, indexes) = selection.get_selected_rows()
-
-        self.selected_rows = []
-        for tup in indexes:
-            self.selected_rows.append(tup[0])
-
         if not event is None:
             if event.button == 3 and event.type == Gdk.EventType.BUTTON_RELEASE:
+                self.selected_rows = self.changes_table.get_selected_rows()
                 self.show_changes_table_popup_menu(treeview, event)
 
     def on_more_actions_changed(self, widget, data=None):
@@ -145,12 +139,7 @@ class Changes(InterfaceView):
             callback()
 
     def on_changes_table_row_doubleclicked(self, treeview, data=None, col=None):
-        selection = treeview.get_selection()
-        (liststore, indexes) = selection.get_selected_rows()
-
-        self.selected_rows = []
-        for tup in indexes:
-            self.selected_rows.append(tup[0])
+        self.selected_rows = self.changes_table.get_selected_rows()
 
         self.view_selected_diff(sidebyside=True)
 


### PR DESCRIPTION
This fixes a bug in the "changes" window.

**Steps to reproduce bug:**
1. Open the the "changes" window and compare two revisions with multiple changes
2. Double click any of the items

**Expected result:**
A diff for that file should open

**Actual result:**
A diff of a different file opens (it might depend on which row is clicked)

The problem happens because the index of the selected row was obtained directly from `treeview`, which contains the items in a different order than the underlying data. When triggering a diff, that index is being used on the underlying data, not on the treview data.
Solution: the index of the selection of `self.changes_table` should be used instead of the one from `treeview`. This is a quick fix, I don't know if it's the right way