### PR TITLE
Batch Nautilus Git status refreshes and reuse repository context

### DIFF
--- a/rabbitvcs/vcs/__init__.py
+++ b/rabbitvcs/vcs/__init__.py
@@ -199,7 +199,7 @@ class VCS(object):
 
         guess = self.guess(path)
         if guess["vcs"] == VCS_GIT:
-            return self.git(guess["repo_path"], is_repo_path=False)
+            return self.git(guess["repo_path"], is_repo_path=True)
         elif guess["vcs"] == VCS_SVN:
             return self.svn()
         elif guess["vcs"] == VCS_MERCURIAL:

--- a/rabbitvcs/vcs/git/__init__.py
+++ b/rabbitvcs/vcs/git/__init__.py
@@ -134,7 +134,21 @@ class Git(object):
         self.cache = rabbitvcs.vcs.status.StatusCache()
 
     def set_repository(self, path):
-        self.client.set_repository(path)
+        try:
+            current_path = self.client.get_repository()
+        except (AttributeError, TypeError):
+            current_path = None
+
+        if current_path is not None:
+            current_path = os.path.normcase(
+                os.path.realpath(os.fsdecode(current_path))
+            )
+        new_path = os.path.normcase(os.path.realpath(os.fsdecode(path)))
+
+        if current_path != new_path:
+            self.client.set_repository(path)
+            self.cache = rabbitvcs.vcs.status.StatusCache()
+
         self.config = self.client.config
 
     def config_get(self, key1, key2):

--- a/rabbitvcs/vcs/git/__init__.py
+++ b/rabbitvcs/vcs/git/__init__.py
@@ -26,6 +26,7 @@ Concrete VCS implementation for Git functionality.
 from __future__ import absolute_import
 
 import os.path
+import time
 from datetime import datetime
 
 from .gittyup.client import GittyupClient
@@ -132,6 +133,10 @@ class Git(object):
             self.client = GittyupClient()
 
         self.cache = rabbitvcs.vcs.status.StatusCache()
+        # Nautilus sends many invalidating requests during one refresh. Treat
+        # requests for the same displayed directory as one short burst.
+        self._status_refresh_last_request = {}
+        self._status_refresh_gap = 0.5
 
     def set_repository(self, path):
         try:
@@ -148,6 +153,7 @@ class Git(object):
         if current_path != new_path:
             self.client.set_repository(path)
             self.cache = rabbitvcs.vcs.status.StatusCache()
+            self._status_refresh_last_request = {}
 
         self.config = self.client.config
 
@@ -159,6 +165,56 @@ class Git(object):
 
     def find_repository_path(self, path):
         return self.client.find_repository_path(path)
+
+    def _status_refresh_directory(self, path):
+        path_text = os.fsdecode(path)
+        repository = os.path.normcase(
+            os.path.realpath(os.fsdecode(self.client.get_repository()))
+        )
+        normalized_path = os.path.normcase(os.path.realpath(path_text))
+
+        if normalized_path == repository:
+            return path_text
+
+        stripped_path = path_text.rstrip(os.sep)
+        if not stripped_path:
+            return os.sep
+        return os.path.dirname(stripped_path)
+
+    def _status_from_refresh_batch(self, path, summarize):
+        directory = self._status_refresh_directory(path)
+        directory_key = os.path.normcase(os.path.realpath(directory))
+        now = time.monotonic()
+        previous_request = self._status_refresh_last_request.get(directory_key)
+
+        # Nautilus requests status once per visible item, often with duplicate
+        # and out-of-order paths. Treat closely grouped requests for the same
+        # displayed directory as one refresh snapshot.
+        if (
+            previous_request is None
+            or now - previous_request > self._status_refresh_gap
+        ):
+            self.statuses(directory, recurse=False, invalidate=True)
+            now = time.monotonic()
+
+            cutoff = now - 60.0
+            for old_directory, timestamp in list(
+                self._status_refresh_last_request.items()
+            ):
+                if timestamp < cutoff:
+                    del self._status_refresh_last_request[old_directory]
+
+        self._status_refresh_last_request[directory_key] = now
+
+        if path in self.cache:
+            status = self.cache[path]
+            if summarize:
+                status.summary = status.single
+            return status
+
+        # Preserve the original exact-path handling for deleted paths,
+        # unusual symlinks and nested repositories absent from the snapshot.
+        return self.status(path, summarize=summarize, invalidate=False)
 
     #
     # Status Methods
@@ -205,14 +261,14 @@ class Git(object):
             return statuses
 
     def status(self, path, summarize=True, invalidate=False):
+        if invalidate:
+            return self._status_from_refresh_batch(path, summarize)
+
         if path in self.cache:
-            if invalidate:
-                del self.cache[path]
-            else:
-                st = self.cache[path]
-                if summarize:
-                    st.summary = st.single
-                return st
+            st = self.cache[path]
+            if summarize:
+                st.summary = st.single
+            return st
 
         all_statuses = self.statuses(path, invalidate=invalidate)
 


### PR DESCRIPTION
## Summary

Nautilus can issue hundreds of per-file status requests during one folder refresh. RabbitVCS previously allowed each invalidating request to trigger another complete Git status calculation and repeatedly rediscovered or reopened the same repository.

This pull request:

* reuses the current Git repository while its normalized path is unchanged;
* passes the repository root already found by `VCS.guess()` as a repository root;
* groups closely spaced invalidating requests for the same displayed directory into one status snapshot;
* serves duplicate and out-of-order requests from the existing dictionary-backed status cache.

## Reproduction

Test system:

* Ubuntu 24.04
* RabbitVCS 0.19-2
* Nautilus
* Git repository directory with 280 visible entries

One Nautilus refresh generated 694 status requests.

The underlying `GittyupClient.status(directory)` call took only 0.067 seconds, but running it repeatedly caused the live Nautilus refresh to take approximately 15 seconds.

Repeated refreshes could also create a backlog that made cursor movement in the Nautilus directory view noticeably stall.

## Results

With this change, an integration test against the real repository directory reports:

```text
Direct directory entries:       280
First burst requests:           694
First burst backend scans:      1
Second burst backend scans:     1
Underlying repository opens:    1
First burst elapsed:            0.159 s
Second burst elapsed:           0.117 s
```

In normal Nautilus use, the refreshed directory now appears immediately with the correct emblems.

Parent-directory emblems also update more consistently.

## Implementation notes

The first commit is intentionally independent and low risk:

1. `VCS.guess()` has already found the repository root, so it is passed to the Git client with `is_repo_path=True`.
2. `Git.set_repository()` retains the existing repository and status cache while the normalized repository path is unchanged.

The second commit batches status invalidations:

1. The first request after an idle interval creates one non-recursive snapshot for the displayed directory.
2. Subsequent duplicate or out-of-order requests are direct cache lookups.
3. A new snapshot is generated after an idle gap of 0.5 seconds.
4. Exact-path fallback behavior is retained for deleted paths, unusual symlinks and nested repositories that are not part of the directory snapshot.

The 0.5-second idle threshold is a tested compatibility solution. An explicit refresh generation or checker-side in-flight snapshot may be preferable as a longer-term API design, and I am open to adjusting the implementation accordingly.

## Testing

The integration test:

* uses a real Git repository directory;
* sends normal, duplicate and reverse-order requests;
* verifies that every returned status matches its requested path;
* counts backend status scans;
* counts underlying repository openings;
* performs two distinct refresh bursts.

Manual testing also covered:

* clean and modified files;
* reverting files back to clean;
* untracked files;
* repeated F5 refreshes;
* parent-directory emblems;
* path-scoped “Show Log”.

A previously observed issue where “Show Log” for one directory included history from sibling directories was no longer reproducible after this change. This is reported as an observation rather than a claimed direct fix because it does not yet have a focused regression test.

One non-reproducible Nautilus cursor slowdown occurred after extensive interaction and disappeared after closing and reopening the window.
