### PR TITLE
Use unique IDs for Nautilus menu instances

### DIFF
--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -631,8 +631,19 @@ class NautilusContextMenu(MenuBuilder):
 
     signal = "activate"
 
+    # Nautilus menu item names outlive one menu construction. MenuBuilder's
+    # local item index starts at zero for every menu, so include a monotonically
+    # increasing menu generation to avoid reusing an older callback.
+    _menu_generation = 0
+
+    def __init__(self, structure, conditions, callbacks):
+        type(self)._menu_generation += 1
+        self._menu_generation_id = type(self)._menu_generation
+        MenuBuilder.__init__(self, structure, conditions, callbacks)
+
     def make_menu_item(self, item, id_magic):
-        return item.make_nautilus_menu_item(id_magic)
+        unique_id_magic = "%s-%s" % (self._menu_generation_id, id_magic)
+        return item.make_nautilus_menu_item(unique_id_magic)
 
     def attach_submenu(self, menu_node, submenu_list):
         submenu = Nautilus.Menu()


### PR DESCRIPTION
# Title

Use unique IDs for Nautilus menu instances

# Body

## Summary

Nautilus menu item names were unique only within one menu construction.
`MenuBuilder` starts its local item index at zero for every new menu, so a file
context menu and a previously generated directory-background menu could reuse
the same action names.

In practice Nautilus could then activate the older callback. Actions selected
from a file context menu received the parent directory instead of the selected
file.

This change adds a monotonically increasing menu-generation component to the
existing per-item identifier.

## Reproduction

Right-click:

```text
/home/build/src/xxxx.c
```

Before this change, choosing **RabbitVCS Git → Show Log** launched:

```text
.../rabbitvcs/ui/log.py --name RabbitVCS /home/build/src
```

Choosing **Commit** similarly launched:

```text
.../rabbitvcs/ui/commit.py --name RabbitVCS /home/build/src
```

The dialogs consequently showed history or modified files for the whole
directory.

Directly launching either dialog with `xxxx.c`, and a direct backend
status test, both handled exactly that one file. This isolated the problem to
the Nautilus menu callback association.

## Implementation

Identifiers now include both the menu generation and the existing local item
index, for example:

```text
RabbitVCS::Show_Log-17-24
RabbitVCS::Show_Log-18-24
```

Different menu instances can no longer reuse the same Nautilus action name.

## Results

After this change the same file actions launch:

```text
.../rabbitvcs/ui/log.py --name RabbitVCS /home/build/src/xxxx.c
.../rabbitvcs/ui/commit.py --name RabbitVCS /home/build/src/xxxx.c
```

Manual checks confirm:

- Show Log is restricted to the selected file.
- Commit lists only the selected file.
- RabbitVCS entries still appear on the first right-click.
- The directory-background menu still operates on the directory.

## Scope

Only `clients/nautilus/RabbitVCS.py` is changed.