### PR TITLE
Batch initial Nautilus Git status loads

### DIFF
--- a/rabbitvcs/vcs/git/__init__.py
+++ b/rabbitvcs/vcs/git/__init__.py
@@ -214,7 +214,7 @@ class Git(object):
 
         # Preserve the original exact-path handling for deleted paths,
         # unusual symlinks and nested repositories absent from the snapshot.
-        return self.status(path, summarize=summarize, invalidate=False)
+        return self._status_exact(path, summarize)
 
     #
     # Status Methods
@@ -260,33 +260,32 @@ class Git(object):
 
             return statuses
 
+    def _status_exact(self, path, summarize):
+        """Return one exact-path status without starting another batch."""
+        if path in self.cache:
+            status = self.cache[path]
+            if summarize:
+                status.summary = status.single
+            return status
+
+        all_statuses = self.statuses(path, invalidate=False)
+        if not summarize:
+            return all_statuses[0]
+
+        for status in all_statuses:
+            if status.path == path:
+                status.summary = status.single
+                return status
+
+        return rabbitvcs.vcs.status.Status.status_unknown(path)
+
     def status(self, path, summarize=True, invalidate=False):
-        if invalidate:
+        # Initial Nautilus population uses invalidate=False. A cache miss is
+        # therefore also the beginning of a per-directory request burst.
+        if invalidate or path not in self.cache:
             return self._status_from_refresh_batch(path, summarize)
 
-        if path in self.cache:
-            st = self.cache[path]
-            if summarize:
-                st.summary = st.single
-            return st
-
-        all_statuses = self.statuses(path, invalidate=invalidate)
-
-        if summarize:
-            path_status = None
-            for st in all_statuses:
-                if st.path == path:
-                    path_status = st
-                    break
-
-            if path_status:
-                path_status.summary = path_status.single
-            else:
-                path_status = rabbitvcs.vcs.status.Status.status_unknown(path)
-        else:
-            path_status = all_statuses[0]
-
-        return path_status
+        return self._status_exact(path, summarize)
 
     def is_working_copy(self, path):
         if os.path.isdir(path) and os.path.isdir(os.path.join(path, ".git")):


### PR DESCRIPTION
# Title

Batch initial Nautilus Git status loads

# Body

## Summary

This is a follow-up to #424.

The batching added there handles invalidating requests generated by an F5
refresh. A newly opened Nautilus directory uses `invalidate=False`, however.
With an empty status cache, every visible item can therefore still trigger its
own complete Git status calculation.

This change treats an uncached status request as the start of the same
per-directory request burst used for refreshes.

## Reproduction

Test system:

- Ubuntu 24.04
- Nautilus
- Git directory with 280 visible entries

The initial Nautilus population generated per-item status requests with
`invalidate=False`. An isolated integration test sent 694 normal, duplicate and
reverse-order initial requests.

## Implementation

- A cache miss now enters `_status_from_refresh_batch()` even when
  `invalidate=False`.
- The previous exact-path logic is moved to `_status_exact()`.
- The batch fallback calls `_status_exact()` directly, avoiding recursion for
  deleted paths, unusual symlinks and nested repositories that are absent from
  the directory snapshot.

## Results

```text
Direct directory entries:       280
Initial burst requests:         694
Initial-load backend scans:     1
F5 backend scans:               1
Underlying repository opens:    1
Initial burst elapsed:          0.119 s
F5 burst elapsed:               0.113 s
```

This result measures the Git status request path itself. The current Nautilus
client also eagerly queues one `GenerateMenuConditions` request per directory
entry before the emblem requests. That is an independent bottleneck and can
still dominate the visible cold-directory load; this pull request does not
claim to fix that separate menu-preloading behavior. Hope to come up with sth
for this soon, but it needs more effort and is independent from this patch.

## Scope

Only `rabbitvcs/vcs/git/__init__.py` is changed.