### PR TITLE
Perf/nautilus batched menu warmup

### DIFF
--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -413,13 +413,21 @@ class RabbitVCS(
             return ()
 
         # Schedule menu conditions computation for directory contents.
+        # RABBITVCS_BATCHED_MENU_WARMUP_V8
+        uncached_paths = []
         for file in os.listdir(path):
             subpath = os.path.join(path, file)
-            if not subpath in self.items_cache:
+            if subpath not in self.items_cache:
                 self.items_cache[subpath] = "in-progress"
-                self.status_checker.generate_menu_conditions_async(
-                    provider, path, [subpath], self.update_background_items
-                )
+                uncached_paths.append(subpath)
+
+        if uncached_paths:
+            self.status_checker.generate_menu_conditions_batch_async(
+                provider,
+                path,
+                uncached_paths,
+                self.update_background_items_batch,
+            )
 
         conditions_dict = None
         if path in self.items_cache:
@@ -438,6 +446,18 @@ class RabbitVCS(
             self.items_cache[path] = "in-progress"
 
         return ()
+
+    def update_background_items_batch(
+        self, provider, base_dir, paths, path_dicts
+    ):
+        for index, path in enumerate(paths):
+            if index < len(path_dicts):
+                self.items_cache[path] = path_dicts[index]
+            else:
+                self.items_cache[path] = {}
+
+        # One signal replaces one signal for every directory entry.
+        Nautilus.MenuProvider.emit_items_updated_signal(provider)
 
     def update_background_items(self, provider, base_dir, paths, conditions_dict):
         paths_str = "-".join(paths)

--- a/rabbitvcs/services/checkerservice.py
+++ b/rabbitvcs/services/checkerservice.py
@@ -191,6 +191,18 @@ class StatusCheckerService(dbus.service.Object):
 
         path_dict = self.status_checker.generate_menu_conditions(upaths)
         return json.dumps(path_dict)
+    # RABBITVCS_BATCHED_MENU_WARMUP_V8
+    @dbus.service.method(
+        INTERFACE, in_signature="ayaay", out_signature="s"
+    )
+    def GenerateMenuConditionsBatch(self, base_dir, paths):
+        ubase_dir = S(bytearray(base_dir))
+        upaths = [S(bytearray(path)) for path in paths]
+        path_dicts = self.status_checker.generate_menu_conditions_batch(
+            ubase_dir, upaths
+        )
+        return json.dumps(path_dicts)
+
 
     @dbus.service.method(INTERFACE)
     def CheckVersionOrDie(self, version):
@@ -428,6 +440,48 @@ class StatusCheckerStub(object):
             self.generate_menu_conditions, provider, base_dir, paths, callback
         )
         return {}
+    def generate_menu_conditions_batch(
+        self, provider, base_dir, paths, callback
+    ):
+        def real_reply_handler(obj):
+            path_dicts = json.loads(obj)
+            callback(provider, base_dir, paths, path_dicts)
+
+        def reply_handler(*args, **kwargs):
+            GLib.idle_add(real_reply_handler, *args, **kwargs)
+
+        def error_handler(dbus_ex):
+            log.exception(dbus_ex)
+            self._connect_to_checker()
+            callback(provider, base_dir, paths, [{} for path in paths])
+
+        bbase_dir = bytearray(S(base_dir).bytes())
+        bpaths = [bytearray(S(path).bytes()) for path in paths]
+        try:
+            self.status_checker.GenerateMenuConditionsBatch(
+                bbase_dir,
+                bpaths,
+                dbus_interface=INTERFACE,
+                timeout=TIMEOUT,
+                reply_handler=reply_handler,
+                error_handler=error_handler,
+            )
+        except dbus.DBusException as ex:
+            log.exception(ex)
+            callback(provider, base_dir, paths, [{} for path in paths])
+            self._connect_to_checker()
+
+    def generate_menu_conditions_batch_async(
+        self, provider, base_dir, paths, callback
+    ):
+        GLib.idle_add(
+            self.generate_menu_conditions_batch,
+            provider,
+            base_dir,
+            paths,
+            callback,
+        )
+        return []
 
 
 def start():

--- a/rabbitvcs/services/statuschecker.py
+++ b/rabbitvcs/services/statuschecker.py
@@ -20,6 +20,7 @@ Very simple status checking class. Useful when you can't get any of the others
 to work, or you need to prototype things.
 """
 from __future__ import absolute_import
+import os
 from rabbitvcs.util.log import Log
 
 import rabbitvcs.vcs
@@ -54,6 +55,108 @@ class StatusChecker(object):
 
         conditions = MainContextMenuConditions(self.vcs_client, paths)
         return conditions.path_dict
+    # RABBITVCS_BATCHED_MENU_WARMUP_V8
+    def _menu_paths_share_repository(self, base_dir, paths):
+        if not paths:
+            return False
+
+        guesses = [self.vcs_client.guess(path) for path in paths]
+        keys = {
+            (guess.get("vcs"), guess.get("repo_path"))
+            for guess in guesses
+        }
+        if len(keys) != 1:
+            return False
+
+        vcs_type, repo_path = next(iter(keys))
+        if not vcs_type or not repo_path:
+            return False
+
+        try:
+            base_real = os.path.normcase(
+                os.path.realpath(os.fsdecode(base_dir))
+            )
+            repo_real = os.path.normcase(
+                os.path.realpath(os.fsdecode(repo_path))
+            )
+            return os.path.commonpath([base_real, repo_real]) == repo_real
+        except (OSError, TypeError, ValueError):
+            return False
+
+    def _menu_statuses_for_path(self, path, all_statuses):
+        normalized_path = os.path.normcase(
+            os.path.normpath(os.fsdecode(path))
+        )
+        directory_prefix = normalized_path.rstrip(os.sep) + os.sep
+        path_is_directory = os.path.isdir(path)
+
+        statuses = []
+        seen_paths = set()
+
+        for status in all_statuses:
+            status_path = os.path.normcase(
+                os.path.normpath(os.fsdecode(status.path))
+            )
+
+            # Preserve the exact semantics of the old per-path Git
+            # calculation. Gittyup's ignored-file scan is repository-wide,
+            # even when status() was requested for one file or subdirectory.
+            # Consequently every old menu condition set included all ignored
+            # statuses and could report has_ignored=True.
+            include = status.simple_content_status() == "ignored"
+
+            if status_path == normalized_path:
+                include = True
+            elif (
+                path_is_directory
+                and status_path.startswith(directory_prefix)
+            ):
+                # VCS.statuses() defaults to recurse=True, so a directory menu
+                # receives its complete subtree, not only direct children.
+                include = True
+
+            if include and status_path not in seen_paths:
+                statuses.append(status)
+                seen_paths.add(status_path)
+
+        return statuses
+
+    def generate_menu_conditions_batch(self, base_dir, paths):
+        from rabbitvcs.util.contextmenu import MainContextMenuConditions
+
+        if not paths:
+            return []
+
+        # Preserve the old behaviour for mixed directories containing paths
+        # from different repositories or VCS implementations.
+        if not self._menu_paths_share_repository(base_dir, paths):
+            return [
+                self.generate_menu_conditions([path])
+                for path in paths
+            ]
+
+        # One recursive snapshot populates the VCS cache for every visible
+        # child. Each condition dictionary is derived from that snapshot.
+        all_statuses = self.vcs_client.statuses(
+            base_dir, recurse=True, invalidate=True
+        )
+
+        result = []
+        for path in paths:
+            path_statuses = self._menu_statuses_for_path(
+                path, all_statuses
+            )
+            if path_statuses:
+                conditions = MainContextMenuConditions(
+                    self.vcs_client,
+                    [path],
+                    statuses=path_statuses,
+                )
+                result.append(conditions.path_dict)
+            else:
+                result.append(self.generate_menu_conditions([path]))
+
+        return result
 
     def extra_info(self):
         return None

--- a/rabbitvcs/services/statuschecker.py
+++ b/rabbitvcs/services/statuschecker.py
@@ -127,36 +127,121 @@ class StatusChecker(object):
         if not paths:
             return []
 
-        # Preserve the old behaviour for mixed directories containing paths
-        # from different repositories or VCS implementations.
-        if not self._menu_paths_share_repository(base_dir, paths):
-            return [
-                self.generate_menu_conditions([path])
-                for path in paths
-            ]
+        # RABBITVCS_GROUPED_SPARSE_MENU_SNAPSHOT_V8G
+        # One Nautilus/D-Bus batch can contain a nested repository. Group the
+        # paths by their actual VCS and repository instead of falling back to
+        # one old-style calculation per path.
+        groups = {}
+        group_order = []
 
-        # One recursive snapshot populates the VCS cache for every visible
-        # child. Each condition dictionary is derived from that snapshot.
-        all_statuses = self.vcs_client.statuses(
-            base_dir, recurse=True, invalidate=True
-        )
-
-        result = []
         for path in paths:
-            path_statuses = self._menu_statuses_for_path(
-                path, all_statuses
-            )
-            if path_statuses:
-                conditions = MainContextMenuConditions(
-                    self.vcs_client,
-                    [path],
-                    statuses=path_statuses,
-                )
-                result.append(conditions.path_dict)
-            else:
-                result.append(self.generate_menu_conditions([path]))
+            guess = self.vcs_client.guess(path)
+            key = (guess.get("vcs"), guess.get("repo_path"))
+            if key not in groups:
+                groups[key] = []
+                group_order.append(key)
+            groups[key].append(path)
 
-        return result
+        path_dicts = {}
+
+        for key in group_order:
+            vcs_type, repo_path = key
+            group_paths = groups[key]
+
+            if not vcs_type or not repo_path:
+                for path in group_paths:
+                    path_dicts[path] = self.generate_menu_conditions([path])
+                continue
+
+            try:
+                base_real = os.path.normcase(
+                    os.path.realpath(os.fsdecode(base_dir))
+                )
+                repo_real = os.path.normcase(
+                    os.path.realpath(os.fsdecode(repo_path))
+                )
+                if os.path.commonpath([base_real, repo_real]) == repo_real:
+                    group_base = base_dir
+                else:
+                    # A direct child can itself be a nested repository root.
+                    group_base = repo_path
+            except (OSError, TypeError, ValueError):
+                group_base = repo_path
+
+            vcs_backend = self.vcs_client.client(group_base)
+
+            if (
+                vcs_type == "git"
+                and hasattr(vcs_backend, "menu_statuses_batch")
+            ):
+                batches = vcs_backend.menu_statuses_batch(
+                    group_base, group_paths
+                )
+                for path in group_paths:
+                    path_statuses = batches.get(path, [])
+                    if path_statuses:
+                        conditions = MainContextMenuConditions(
+                            self.vcs_client,
+                            [path],
+                            statuses=path_statuses,
+                        )
+
+                        # RABBITVCS_GROUPED_SPARSE_MENU_SNAPSHOT_V8G
+                        # The batch already contains the exact status for this
+                        # path. Derive is_versioned from it instead of asking
+                        # the shared VCS facade again; that extra lookup can
+                        # observe a different repository/cache generation when
+                        # one Nautilus directory contains nested repositories.
+                        normalized_path = os.path.normcase(
+                            os.path.normpath(os.fsdecode(path))
+                        )
+                        exact_status = next(
+                            (
+                                status
+                                for status in path_statuses
+                                if os.path.normcase(
+                                    os.path.normpath(
+                                        os.fsdecode(status.path)
+                                    )
+                                )
+                                == normalized_path
+                            ),
+                            None,
+                        )
+                        if exact_status is not None:
+                            conditions.path_dict["is_versioned"] = (
+                                exact_status.is_versioned()
+                            )
+
+                        path_dicts[path] = conditions.path_dict
+                    else:
+                        path_dicts[path] = (
+                            self.generate_menu_conditions([path])
+                        )
+                continue
+
+            # Preserve V8b's recursive grouped behaviour for other VCS
+            # implementations.
+            all_statuses = self.vcs_client.statuses(
+                group_base, recurse=True, invalidate=True
+            )
+            for path in group_paths:
+                path_statuses = self._menu_statuses_for_path(
+                    path, all_statuses
+                )
+                if path_statuses:
+                    conditions = MainContextMenuConditions(
+                        self.vcs_client,
+                        [path],
+                        statuses=path_statuses,
+                    )
+                    path_dicts[path] = conditions.path_dict
+                else:
+                    path_dicts[path] = (
+                        self.generate_menu_conditions([path])
+                    )
+
+        return [path_dicts[path] for path in paths]
 
     def extra_info(self):
         return None

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -1318,33 +1318,22 @@ class MainContextMenuConditions(ContextMenuConditions):
 
     """
 
-    def __init__(self, vcs_client, paths=[]):
-        """
-        @param  vcs_client: The vcs client to be used
-        @type   vcs_client: rabbitvcs.vcs.create_vcs_instance()
-
-        @param  paths: The selected paths
-        @type   paths: list
-
-        """
-
+    def __init__(self, vcs_client, paths=[], statuses=None):
         self.vcs_client = vcs_client
         self.paths = paths
         self.statuses = {}
 
-        self.generate_statuses(paths)
+        if statuses is None:
+            self.generate_statuses(paths)
+        else:
+            self._set_statuses(statuses)
         self.generate_path_dict(paths)
 
-    # FIXME: major bottleneck
-    def generate_statuses(self, paths):
+    # RABBITVCS_BATCHED_MENU_WARMUP_V8
+    def _set_statuses(self, statuses):
         self.statuses = {}
-        for path in paths:
-            if not path:
-                continue
-
-            statuses_tmp = self.vcs_client.statuses(path)
-            for status in statuses_tmp:
-                self.statuses[status.path] = status
+        for status in statuses:
+            self.statuses[status.path] = status
 
         self.text_statuses = [
             self.statuses[key].simple_content_status()
@@ -1354,6 +1343,15 @@ class MainContextMenuConditions(ContextMenuConditions):
             self.statuses[key].simple_metadata_status()
             for key in list(self.statuses.keys())
         ]
+
+    # FIXME: major bottleneck when called once for every visible path
+    def generate_statuses(self, paths):
+        statuses = []
+        for path in paths:
+            if not path:
+                continue
+            statuses.extend(self.vcs_client.statuses(path))
+        self._set_statuses(statuses)
 
 
 class MainContextMenu(object):

--- a/rabbitvcs/vcs/git/__init__.py
+++ b/rabbitvcs/vcs/git/__init__.py
@@ -220,6 +220,26 @@ class Git(object):
     # Status Methods
     #
 
+    # RABBITVCS_GROUPED_SPARSE_MENU_SNAPSHOT_V8G
+    def menu_statuses_batch(self, base_dir, paths):
+        raw_batches = self.client.menu_statuses_batch(base_dir, paths)
+        result = {}
+
+        for requested_path, raw_statuses in raw_batches.items():
+            converted = []
+            for raw_status in raw_statuses:
+                raw_copy = type(raw_status)(raw_status.path)
+                raw_copy.path = self.client.get_absolute_path(raw_copy.path)
+                status = rabbitvcs.vcs.status.GitStatus(raw_copy)
+                converted.append(status)
+
+                if raw_copy.path == requested_path:
+                    self.cache[requested_path] = status
+
+            result[requested_path] = converted
+
+        return result
+
     def statuses(self, path, recurse=False, invalidate=False):
         """
         Generates a list of GittyupStatus objects for the specified file.

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -1623,6 +1623,199 @@ class GittyupClient(object):
 
         return tags
 
+    # RABBITVCS_GROUPED_SPARSE_MENU_SNAPSHOT_V8G
+    def menu_statuses_batch(self, base_dir, paths):
+        # Return per-path status lists without recursively enumerating every
+        # normal file below base_dir.
+        requested = []
+        for absolute_path in paths:
+            relative_path = S(self.get_relative_path(absolute_path))
+            if relative_path == ".":
+                relative_path = ""
+            requested.append(
+                {
+                    "absolute": absolute_path,
+                    "relative": relative_path,
+                    "is_dir": os.path.isdir(absolute_path),
+                }
+            )
+
+        changed = {}
+        changed_order = []
+
+        cmd = [
+            "git",
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            base_dir,
+        ]
+        try:
+            (_status, stdout, _stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify
+            ).execute()
+        except GittyupCommandError as error:
+            self.callback_notify(error)
+            stdout = []
+
+        for line in stdout:
+            components = RE_STATUS.match(line)
+            if not components:
+                continue
+
+            raw_status = components.group(1)
+            strip_status = raw_status.strip()
+            relative_path = self.string_unescape(components.group(2))
+            if (
+                len(relative_path) >= 2
+                and relative_path[0] == '"'
+                and relative_path[-1] == '"'
+            ):
+                relative_path = relative_path[1:-1]
+
+            if raw_status == " D":
+                status_class = MissingStatus
+            elif any(code in strip_status for code in ["M", "R", "U"]):
+                status_class = ModifiedStatus
+            elif strip_status in ["A", "C"]:
+                status_class = AddedStatus
+            elif strip_status == "D":
+                status_class = RemovedStatus
+            elif strip_status == "??":
+                status_class = UntrackedStatus
+            else:
+                continue
+
+            changed[relative_path] = status_class
+            changed_order.append(relative_path)
+
+        untracked_directories = []
+        cmd = ["git", "clean", "-nd", self.repo.path]
+        try:
+            (_status, stdout, _stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify
+            ).execute()
+        except GittyupCommandError as error:
+            self.callback_notify(error)
+            stdout = []
+
+        for line in stdout:
+            components = re.match("^(Would remove)\\s(.*?)$", line)
+            if components:
+                relative_path = components.group(2)
+                if relative_path.endswith("/"):
+                    untracked_directories.append(relative_path[:-1])
+
+        ignored_files = []
+        ignored_directories = []
+        cmd = ["git", "clean", "-ndX", self.repo.path]
+        try:
+            (_status, stdout, _stderr) = GittyupCommand(
+                cmd, cwd=self.repo.path, notify=self.notify
+            ).execute()
+        except GittyupCommandError as error:
+            self.callback_notify(error)
+            stdout = []
+
+        for line in stdout:
+            components = re.match("^(Would remove)\\s(.*?)$", line)
+            if not components:
+                continue
+            relative_path = components.group(2)
+            if relative_path.endswith("/"):
+                ignored_directories.append(relative_path[:-1])
+            else:
+                ignored_files.append(relative_path)
+
+        def under(path, directory):
+            if directory in ("", "."):
+                return True
+            prefix = directory.rstrip("/") + "/"
+            return path == directory or path.startswith(prefix)
+
+        def ignored_exact(relative_path):
+            if relative_path in ignored_files:
+                return True
+            return any(
+                under(relative_path, ignored_dir)
+                for ignored_dir in ignored_directories
+            )
+
+        result = {}
+
+        for item in requested:
+            relative_path = item["relative"]
+            is_dir = item["is_dir"]
+
+            exact_class = changed.get(relative_path)
+
+            if ignored_exact(relative_path):
+                exact_class = IgnoredStatus
+            elif is_dir:
+                descendants = [
+                    changed_path
+                    for changed_path in changed_order
+                    if under(changed_path, relative_path)
+                ]
+                if descendants:
+                    exact_class = ModifiedStatus
+                elif any(
+                    under(relative_path, untracked_dir)
+                    for untracked_dir in untracked_directories
+                ):
+                    # An untracked child directory does not make its tracked
+                    # parent unversioned. Only the untracked directory itself
+                    # and paths below it receive UntrackedStatus.
+                    exact_class = UntrackedStatus
+
+            if exact_class is None:
+                exact_class = NormalStatus
+
+            statuses = [exact_class(relative_path)]
+            seen = {relative_path}
+
+            if is_dir:
+                for changed_path in changed_order:
+                    if not under(changed_path, relative_path):
+                        continue
+                    if changed_path in seen:
+                        continue
+                    statuses.append(changed[changed_path](changed_path))
+                    seen.add(changed_path)
+
+            # Preserve the existing repository-wide ignored-file semantics.
+            for ignored_path in ignored_files:
+                if ignored_path in seen:
+                    continue
+                statuses.append(IgnoredStatus(ignored_path))
+                seen.add(ignored_path)
+
+            if is_dir:
+                # Preserve has_unversioned for empty/untracked child
+                # directories. They must be child statuses, not the exact
+                # status of a tracked parent directory.
+                for untracked_dir in untracked_directories:
+                    if not under(untracked_dir, relative_path):
+                        continue
+                    if untracked_dir in seen:
+                        continue
+                    statuses.append(UntrackedStatus(untracked_dir))
+                    seen.add(untracked_dir)
+
+                # Ignored directories below a selected directory make
+                # has_ignored true in the old recursive calculation.
+                for ignored_dir in ignored_directories:
+                    if not under(ignored_dir, relative_path):
+                        continue
+                    if ignored_dir in seen:
+                        continue
+                    statuses.append(IgnoredStatus(ignored_dir))
+                    seen.add(ignored_dir)
+
+            result[item["absolute"]] = statuses
+
+        return result
+
     def status_porcelain(self, path):
         if os.path.isdir(path):
             (files, directories) = self._read_directory_tree(path)


### PR DESCRIPTION
# Title

Batch Nautilus menu warm-up with grouped Git snapshots

# Body

## Summary

When Nautilus opens a directory, RabbitVCS currently schedules one
`GenerateMenuConditions` D-Bus request for every direct child. Each request
constructs `MainContextMenuConditions` and performs another VCS status
calculation before the later `CheckStatus` requests can add emblems.

This pull request keeps the useful menu warm-up—the RabbitVCS menu is still
available on the first right-click—but performs it as one batch:

- one D-Bus request per displayed directory;
- one callback and one Nautilus items-updated signal;
- one condition dictionary per direct child;
- Git paths grouped by their actual repository, including nested repositories;
- one sparse Git snapshot per repository group, without recursively enumerating
  every unchanged file.

The pull request is split into two commits so the D-Bus batching and the
Git-specific sparse optimization can be reviewed independently.

## Commit 1: batch menu-condition warm-up

The first commit:

- lets `MainContextMenuConditions` consume precomputed status objects;
- adds `GenerateMenuConditionsBatch` to the checker service and client stub;
- replaces the per-child Nautilus requests with one batch request;
- fills `items_cache` in one callback and emits one update signal;
- uses one recursive status snapshot when all paths share a repository;
- preserves the old per-path fallback for mixed repositories and unusual paths.

## Commit 2: grouped sparse Git snapshots

The second commit removes the remaining expensive recursive Git walk:

- direct children are grouped by `(VCS type, repository root)`;
- nested Git repositories are handled as separate groups rather than forcing a
  global per-path fallback;
- each Git group runs one `git status --porcelain --untracked-files=all`, one
  `git clean -nd`, and one `git clean -ndX`;
- changed descendants are used to derive directory menu conditions without
  creating status objects for every unchanged file;
- repository-wide ignored-status behavior is intentionally preserved;
- untracked child directories remain child statuses and do not make a tracked
  parent directory unversioned;
- `is_versioned` is derived from the already computed exact status, avoiding a
  second lookup through a shared repository/cache context;
- non-Git backends retain the recursive grouped implementation from commit 1.

## Reproduction

On Ubuntu 24.04 with Nautilus, opening a source directory with 280 direct
entries generated 280 menu-condition requests before the emblem requests.
The initial menu warm-up took about 15 seconds.

A repository root with 63 direct entries also contained a nested Git
repository. The all-or-nothing fallback took about 4 seconds.

## Semantic comparison

The tests calculate every menu-condition dictionary using the old per-path
implementation, then compare it field by field with the batched result.

### 63 direct entries, two Git repositories

```text
Direct directory entries:       63
Repository/VCS groups:          2
Sparse Git groups:              2
Condition mismatches:           0
JSON payload size:              33131 bytes
Baseline elapsed:               3.920 s
Grouped sparse elapsed:         0.138 s
```

### 280 direct entries, one Git repository

```text
Direct directory entries:       280
Repository/VCS groups:          1
Sparse Git groups:              1
Condition mismatches:           0
JSON payload size:              147265 bytes
Baseline elapsed:               15.246 s
Grouped sparse elapsed:         0.233 s
```

## Manual testing

Manual testing covered:

- cold first display of both directories;
- correct emblems on initial display and after F5;
- immediate navigation from the repository root into the large source
  directory without waiting for the previous directory's warm-up;
- RabbitVCS menu present on the first right-click;
- file and directory context menus;
- nested Git repository roots;
- tracked directories containing untracked child directories;
- ignored files and ignored directories;
- parent-directory emblem propagation;
- file-scoped Show Log and Commit behavior when the unique-menu-ID fix is also
  installed.

## Relationship to other pull requests

This branch is based on `master` after #424.

It does not include or require #425 or #426. Those changes were installed
during part of the live testing, but this pull request has separate source
changes and its semantic tests run directly against the current branch.

## Scope

Six files are changed:

```text
clients/nautilus/RabbitVCS.py
rabbitvcs/services/checkerservice.py
rabbitvcs/services/statuschecker.py
rabbitvcs/util/contextmenu.py
rabbitvcs/vcs/git/__init__.py
rabbitvcs/vcs/git/gittyup/client.py
```
