### PR TITLE
fix: Replace deprecated getName and other threading methods

### DIFF
--- a/clients/thunar/RabbitVCS.py
+++ b/clients/thunar/RabbitVCS.py
@@ -144,7 +144,7 @@ class RabbitVCS(GObject.GObject, Thunarx.MenuProvider, Thunarx.PropertyPageProvi
     )
 
     def __init__(self):
-        threading.currentThread().setName("RabbitVCS extension thread")
+        threading.current_thread().name = "RabbitVCS extension thread"
 
         self.status_checker = StatusChecker()
 

--- a/rabbitvcs/util/decorators.py
+++ b/rabbitvcs/util/decorators.py
@@ -156,13 +156,13 @@ def debug_calls(caller_log, show_caller=False):
         def newfunc(*args, **kwargs):
             caller_log.debug(
                 "Calling: %s (%s)"
-                % (func.__name__, threading.currentThread().getName())
+                % (func.__name__, threading.current_thread().name)
             )
 
             result = func(*args, **kwargs)
             caller_log.debug(
                 "Returned: %s (%s)"
-                % (func.__name__, threading.currentThread().getName())
+                % (func.__name__, threading.current_thread().name)
             )
             return result
 


### PR DESCRIPTION
This change addresses the deprecation warning W4902 about `getName()` in `rabbitvcs/util/decorators.py` and other deprecated threading methods (`currentThread` and `setName`) in both `rabbitvcs/util/decorators.py` and `clients/thunar/RabbitVCS.py`. It modernizes them using `threading.current_thread().name`.

---
*PR created automatically by Jules for task [14243582705007718489](https://jules.google.com/task/14243582705007718489) started by @CloCkWeRX*