### PR TITLE
fix: Fix pylint E0102 function and class redefinition warnings

### DIFF
--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -27,7 +27,19 @@ import rabbitvcs.vcs
 import rabbitvcs.util.settings
 from rabbitvcs.util.strings import S
 from rabbitvcs.util.decorators import gtk_unsafe
-from rabbitvcs.util.contextmenuitems import *
+from rabbitvcs.util.contextmenuitems import (
+    MenuItem,
+    MenuSeparator,
+    MenuCheckout,
+    MenuBranches,
+    MenuTags,
+    MenuBranchTag,
+    MenuExport,
+    MenuMerge,
+    MenuReset,
+    MenuOpen,
+    MenuAnnotate,
+)
 from rabbitvcs.util.contextmenu import GtkContextMenu
 import rabbitvcs.ui.widget
 from rabbitvcs.ui.action import SVNAction, GitAction

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -700,13 +700,6 @@ class ContextMenuConditions(object):
 
         return False
 
-    def update(self, data=None):
-        return (
-            self.path_dict["is_in_a_or_a_working_copy"]
-            and self.path_dict["is_versioned"]
-            and not self.path_dict["is_added"]
-        )
-
     def commit(self, data=None):
         if (
             self.path_dict["is_svn"]

--- a/rabbitvcs/util/contextmenu4.py
+++ b/rabbitvcs/util/contextmenu4.py
@@ -606,13 +606,6 @@ class ContextMenuConditions(object):
 
         return False
 
-    def update(self, data=None):
-        return (
-            self.path_dict["is_in_a_or_a_working_copy"]
-            and self.path_dict["is_versioned"]
-            and not self.path_dict["is_added"]
-        )
-
     def commit(self, data=None):
         if (
             self.path_dict["is_svn"]

--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -1186,17 +1186,6 @@ class SVN(object):
 
         return self.client.cleanup(pure_unicode(path))
 
-    def revert(self, paths):
-        """
-        Revert files or directories so they are unversioned
-
-        @type   paths: list
-        @param  paths: A list of files/directories.
-
-        """
-
-        return self.client.revert(pure_unicode(paths))
-
     def commit(self, paths, log_message="", recurse=False, keep_locks=False):
         """
         Commit a list of files to the repository.


### PR DESCRIPTION
This PR addresses and fixes four duplicate definition (E0102) pylint warnings across the rabbitvcs codebase:

1. rabbitvcs/util/contextmenu4.py:
   Removed first duplicate definition of `update()`, preserving the second.
2. rabbitvcs/util/contextmenu.py:
   Removed first duplicate definition of `update()`, preserving the second.
3. rabbitvcs/vcs/svn/__init__.py:
   Removed first duplicate definition of `revert()`, preserving the second which supports the `recurse` keyword argument.
4. rabbitvcs/ui/log.py:
   Replaced wildcard import with an explicit import of menu classes to resolve class redefinition warning of `Log`.

All pylint E0102 errors in these files have been successfully resolved, resulting in a perfect 10.00/10 score.

---
*PR created automatically by Jules for task [17031356046469555610](https://jules.google.com/task/17031356046469555610) started by @CloCkWeRX*