### PR TITLE
Fix cyclic import in rabbitvcs-plugin.py

### DIFF
--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -1241,7 +1241,10 @@ class RevisionSelector(object):
         container.add(hbox.box)
 
     def __revision_browse_clicked(self, widget):
-        from rabbitvcs.ui.log import SVNLogDialog, GitLogDialog
+        import importlib
+        log_module = importlib.import_module("rabbitvcs.ui.log")
+        SVNLogDialog = log_module.SVNLogDialog
+        GitLogDialog = log_module.GitLogDialog
 
         if self.client.vcs == rabbitvcs.vcs.VCS_GIT:
             GitLogDialog(self.get_url(), ok_callback=self.__log_closed)


### PR DESCRIPTION
Resolved a cyclic import between rabbitvcs.ui.log and rabbitvcs.ui.widget by dynamically loading the SVNLogDialog and GitLogDialog classes in RevisionSelector.__revision_browse_clicked via importlib. This resolves the R0401 cyclic import warning when checking rabbitvcs-plugin.py.

---
*PR created automatically by Jules for task [16770733335059672477](https://jules.google.com/task/16770733335059672477) started by @CloCkWeRX*