### PR TITLE
Fix remaining cyclic imports in utility, VCS, and UI modules

### DIFF
--- a/rabbitvcs/ui/action.py
+++ b/rabbitvcs/ui/action.py
@@ -24,13 +24,10 @@ from __future__ import division, absolute_import
 from rabbitvcs.util.log import Log
 from rabbitvcs import gettext
 from rabbitvcs.util.decorators import gtk_unsafe
-from rabbitvcs.ui.dialog import MessageBox
 from rabbitvcs.util.strings import S
 from rabbitvcs.util import helper
 import rabbitvcs.vcs
 import rabbitvcs.util
-import rabbitvcs.ui.dialog
-import rabbitvcs.ui.widget
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject
 import threading
@@ -88,6 +85,7 @@ class DummyNotifier(object):
 
     @gtk_unsafe
     def exception_callback(self, e):
+        from rabbitvcs.ui.dialog import MessageBox
         log.exception(e)
         MessageBox(str(e))
 
@@ -110,6 +108,7 @@ class MessageCallbackNotifier(VCSNotifier):
         @param  visible: Show the notification window.  Defaults to True.
 
         """
+        import rabbitvcs.ui.widget
 
         VCSNotifier.__init__(self, callback_cancel, visible)
 
@@ -208,6 +207,7 @@ class LoadingNotifier(VCSNotifier):
     gtkbuilder_id = "Loading"
 
     def __init__(self, callback_cancel=None, visible=True):
+        import rabbitvcs.ui.widget
 
         VCSNotifier.__init__(self, callback_cancel, visible)
 
@@ -237,6 +237,7 @@ class LoadingNotifier(VCSNotifier):
     @gtk_unsafe
     def exception_callback(self, e):
         if not self.was_canceled_by_user:
+            from rabbitvcs.ui.dialog import MessageBox
             log.exception(e)
             MessageBox(str(e))
 
@@ -384,10 +385,11 @@ class VCSAction(threading.Thread):
         should_continue = True
         message = self.message
         if message is None:
+            from rabbitvcs.ui import dialog
             settings = rabbitvcs.util.settings.SettingsManager()
             message = settings.get_multiline("general", "default_commit_message")
             result = helper.run_in_main_thread(
-                lambda: rabbitvcs.ui.dialog.TextChange(_("Log Message"), message).run()
+                lambda: dialog.TextChange(_("Log Message"), message).run()
             )
             should_continue = result[0] == Gtk.ResponseType.OK
             message = result[1]
@@ -425,8 +427,9 @@ class VCSAction(threading.Thread):
         if self.login_tries >= 3:
             return (False, "", "", False)
 
+        from rabbitvcs.ui import dialog
         result = helper.run_in_main_thread(
-            lambda: rabbitvcs.ui.dialog.Authentication(realm, may_save).run()
+            lambda: dialog.Authentication(realm, may_save).run()
         )
 
         if result is not None:
@@ -453,8 +456,9 @@ class VCSAction(threading.Thread):
 
         result = 0
         if data:
+            from rabbitvcs.ui import dialog
             result = helper.run_in_main_thread(
-                lambda: rabbitvcs.ui.dialog.Certificate(
+                lambda: dialog.Certificate(
                     data["realm"],
                     data["hostname"],
                     data["issuer_dname"],
@@ -490,9 +494,10 @@ class VCSAction(threading.Thread):
         @rtype:             (boolean, string, boolean)
         @return:            (True=continue/False=cancel, password, may save)
         """
+        from rabbitvcs.ui import dialog
 
         return helper.run_in_main_thread(
-            lambda: rabbitvcs.ui.dialog.CertAuthentication(realm, may_save).run()
+            lambda: dialog.CertAuthentication(realm, may_save).run()
         )
 
     def get_client_cert(self, realm, may_save):
@@ -511,9 +516,10 @@ class VCSAction(threading.Thread):
         @rtype:             (boolean, string, boolean)
         @return:            (True=continue/False=cancel, password, may save)
         """
+        from rabbitvcs.ui import dialog
 
         return helper.run_in_main_thread(
-            lambda: rabbitvcs.ui.dialog.SSLClientCertPrompt(realm, may_save).run()
+            lambda: dialog.SSLClientCertPrompt(realm, may_save).run()
         )
 
     def set_log_message(self, message):
@@ -715,8 +721,9 @@ class GitAction(VCSAction):
                     self.notification.append(["", data, ""])
 
     def get_user(self):
+        from rabbitvcs.ui import dialog
         return helper.run_in_main_thread(
-            lambda: rabbitvcs.ui.dialog.NameEmailPrompt().run()
+            lambda: dialog.NameEmailPrompt().run()
         )
 
     def conflict_filter(self, data):
@@ -751,8 +758,9 @@ class MercurialAction(VCSAction):
                     self.notification.append(["", data, ""])
 
     def get_user(self):
+        from rabbitvcs.ui import dialog
         return helper.run_in_main_thread(
-            lambda: rabbitvcs.ui.dialog.NameEmailPrompt().run()
+            lambda: dialog.NameEmailPrompt().run()
         )
 
     def conflict_filter(self, data):

--- a/rabbitvcs/ui/dialog.py
+++ b/rabbitvcs/ui/dialog.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from rabbitvcs.util.strings import S
 import rabbitvcs.util.helper
 import rabbitvcs.ui.wraplabel
-import rabbitvcs.ui.widget
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk, Pango
 
@@ -45,17 +44,18 @@ An error has occurred in the RabbitVCS Nautilus extension. Please contact the \
 
 class PreviousMessages(InterfaceView):
     def __init__(self):
+        from rabbitvcs.ui import widget
         InterfaceView.__init__(self, "dialogs/previous_messages", "PreviousMessages")
 
-        self.message = rabbitvcs.ui.widget.TextView(self.get_widget("prevmes_message"))
+        self.message = widget.TextView(self.get_widget("prevmes_message"))
 
-        self.message_table = rabbitvcs.ui.widget.Table(
+        self.message_table = widget.Table(
             self.get_widget("prevmes_table"),
             [GObject.TYPE_STRING, GObject.TYPE_STRING],
             [_("Date"), _("Message")],
             filters=[
                 {
-                    "callback": rabbitvcs.ui.widget.long_text_filter,
+                    "callback": widget.long_text_filter,
                     "user_data": {"column": 1, "cols": 80},
                 }
             ],
@@ -245,12 +245,13 @@ class SSLClientCertPrompt(InterfaceView):
 
 class Property(InterfaceView):
     def __init__(self, name="", value="", recurse=True):
+        from rabbitvcs.ui import widget
         InterfaceView.__init__(self, "dialogs/property", "Property")
 
         self.save_name = name
         self.save_value = value
 
-        self.name = rabbitvcs.ui.widget.ComboBox(
+        self.name = widget.ComboBox(
             self.get_widget("property_name"),
             [  # default svn properties
                 "svn:author",
@@ -270,7 +271,7 @@ class Property(InterfaceView):
         )
         self.name.set_child_text(name)
 
-        self.value = rabbitvcs.ui.widget.TextView(
+        self.value = widget.TextView(
             self.get_widget("property_value"), value
         )
 
@@ -382,11 +383,12 @@ class DeleteConfirmation(InterfaceView):
 
 class TextChange(InterfaceView):
     def __init__(self, title=None, message=""):
+        from rabbitvcs.ui import widget
         InterfaceView.__init__(self, "dialogs/text_change", "TextChange")
         if title:
             self.get_widget("TextChange").set_title(title)
 
-        self.textview = rabbitvcs.ui.widget.TextView(
+        self.textview = widget.TextView(
             self.get_widget("textchange_message"), message
         )
 
@@ -436,10 +438,11 @@ class OneLineTextChange(InterfaceView):
 
 class NewFolder(InterfaceView):
     def __init__(self):
+        from rabbitvcs.ui import widget
         InterfaceView.__init__(self, "dialogs/create_folder", "CreateFolder")
 
         self.folder_name = self.get_widget("folder_name")
-        self.textview = rabbitvcs.ui.widget.TextView(
+        self.textview = widget.TextView(
             self.get_widget("log_message"), _("Added a folder to the repository")
         )
         self.on_folder_name_changed(self.folder_name)
@@ -465,16 +468,17 @@ class NewFolder(InterfaceView):
 
 class ErrorNotification(InterfaceView):
     def __init__(self, text):
+        from rabbitvcs.ui import widget
         InterfaceView.__init__(self, "dialogs/error_notification", "ErrorNotification")
 
         notice = rabbitvcs.ui.wraplabel.WrapLabel(ERROR_NOTICE)
         notice.set_use_markup(True)
 
-        notice_box = rabbitvcs.ui.widget.Box(self.get_widget("notice_box"))
+        notice_box = widget.Box(self.get_widget("notice_box"))
         notice_box.pack_start(notice, True, True, 0)
         notice_box.show_all()
 
-        self.textview = rabbitvcs.ui.widget.TextView(
+        self.textview = widget.TextView(
             self.get_widget("error_text"), text, spellcheck=False
         )
 
@@ -556,11 +560,12 @@ class ConflictDecision(InterfaceView):
 
 class Loading(InterfaceView):
     def __init__(self):
+        from rabbitvcs.ui import widget
         InterfaceView.__init__(self, "dialogs/loading", "Loading")
 
         self.get_widget("loading_cancel").set_sensitive(False)
 
-        self.pbar = rabbitvcs.ui.widget.ProgressBar(self.get_widget("pbar"))
+        self.pbar = widget.ProgressBar(self.get_widget("pbar"))
         self.pbar.start_pulsate()
 
     def on_destroy(self, widget):

--- a/rabbitvcs/util/decorators.py
+++ b/rabbitvcs/util/decorators.py
@@ -167,24 +167,3 @@ def debug_calls(caller_log, show_caller=False):
     return real_debug
 
 
-def structure_map(func):
-    """
-    Descend recursively into object if it is a list, a tuple, a set or a dict
-    and build the equivalent structure with func results.
-    Do not apply function to None.
-    """
-
-    def newfunc(obj, *args, **kwargs):
-        if obj is None:
-            return obj
-        if isinstance(obj, list):
-            return [newfunc(item, *args, **kwargs) for item in obj]
-        if isinstance(obj, tuple):
-            return tuple(newfunc(item, *args, **kwargs) for item in obj)
-        if isinstance(obj, set):
-            return {newfunc(item, *args, **kwargs) for item in obj}
-        if isinstance(obj, dict):
-            return {key: newfunc(obj[key], *args, **kwargs) for key in obj}
-        return func(obj, *args, **kwargs)
-
-    return update_func_meta(newfunc, func)

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -47,7 +47,6 @@ from six.moves import range
 import six.moves.urllib.parse
 
 from rabbitvcs.util.settings import *
-from rabbitvcs.util.decorators import structure_map
 from rabbitvcs.util.strings import *
 
 from rabbitvcs.util.log import Log
@@ -93,6 +92,46 @@ def gobject_threads_init():
 
     if compare_version(GObject.pygobject_version, [3, 10, 2]) < 0:
         GObject.threads_init()
+
+
+def update_func_meta(fake_func, real_func):
+    """
+    Set meta information (eg. __doc__) of fake function to that of the real
+    function.
+
+    @rtype: function
+    @return Fake function with metadata of the real function.
+    """
+
+    fake_func.__module__ = real_func.__module__
+    fake_func.__name__ = real_func.__name__
+    fake_func.__doc__ = real_func.__doc__
+    fake_func.__dict__.update(real_func.__dict__)
+
+    return fake_func
+
+
+def structure_map(func):
+    """
+    Descend recursively into object if it is a list, a tuple, a set or a dict
+    and build the equivalent structure with func results.
+    Do not apply function to None.
+    """
+
+    def newfunc(obj, *args, **kwargs):
+        if obj is None:
+            return obj
+        if isinstance(obj, list):
+            return [newfunc(item, *args, **kwargs) for item in obj]
+        if isinstance(obj, tuple):
+            return tuple(newfunc(item, *args, **kwargs) for item in obj)
+        if isinstance(obj, set):
+            return {newfunc(item, *args, **kwargs) for item in obj}
+        if isinstance(obj, dict):
+            return {key: newfunc(obj[key], *args, **kwargs) for key in obj}
+        return func(obj, *args, **kwargs)
+
+    return update_func_meta(newfunc, func)
 
 
 @structure_map

--- a/rabbitvcs/vcs/dummy/__init__.py
+++ b/rabbitvcs/vcs/dummy/__init__.py
@@ -25,7 +25,6 @@ Concrete VCS dummy implementation.
 """
 from __future__ import absolute_import
 
-import rabbitvcs.vcs
 import rabbitvcs.vcs.status
 
 

--- a/rabbitvcs/vcs/git/__init__.py
+++ b/rabbitvcs/vcs/git/__init__.py
@@ -35,7 +35,6 @@ from .gittyup import objects
 from rabbitvcs.util import helper
 from rabbitvcs.util.strings import S
 
-import rabbitvcs.vcs
 import rabbitvcs.vcs.status
 import rabbitvcs.vcs.log
 from rabbitvcs.vcs.branch import BranchEntry, LocalBranchEntry
@@ -125,7 +124,7 @@ class Git(object):
     STATUSES_FOR_UNSTAGE = ["added"]
 
     def __init__(self, repo=None):
-        self.vcs = rabbitvcs.vcs.VCS_GIT
+        self.vcs = "git"
         self.interface = "gittyup"
         if repo:
             self.client = GittyupClient(repo)

--- a/rabbitvcs/vcs/mercurial/__init__.py
+++ b/rabbitvcs/vcs/mercurial/__init__.py
@@ -32,7 +32,6 @@ from mercurial import commands, ui, hg
 
 from rabbitvcs.util.strings import S
 
-import rabbitvcs.vcs
 import rabbitvcs.vcs.status
 import rabbitvcs.vcs.log
 import rabbitvcs.vcs.mercurial.util
@@ -110,7 +109,7 @@ class Mercurial(object):
     STATUSES_FOR_UNSTAGE = ["added"]
 
     def __init__(self, repo=None):
-        self.vcs = rabbitvcs.vcs.VCS_MERCURIAL
+        self.vcs = "mercurial"
         self.interface = "mercurial"
 
         self.ui = ui.ui()

--- a/rabbitvcs/vcs/status.py
+++ b/rabbitvcs/vcs/status.py
@@ -26,7 +26,6 @@ import os.path
 import unittest
 import six
 
-import rabbitvcs.vcs
 from rabbitvcs.util.strings import S
 
 from rabbitvcs.util.log import Log
@@ -176,7 +175,7 @@ class Status(object):
     def status_calc(path):
         return Status(path, status_calculating, summary=status_calculating)
 
-    vcs_type = rabbitvcs.vcs.VCS_DUMMY
+    vcs_type = "unknown"
 
     clean_statuses = ["unchanged"]
 
@@ -320,7 +319,7 @@ class Status(object):
 
 class SVNStatus(Status):
 
-    vcs_type = rabbitvcs.vcs.VCS_SVN
+    vcs_type = "svn"
 
     content_status_map = {
         "normal": status_normal,

--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -33,12 +33,11 @@ from datetime import datetime
 
 import pysvn
 
-import rabbitvcs.vcs
 import rabbitvcs.vcs.status
 import rabbitvcs.vcs.log
 from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
-from rabbitvcs.util.decorators import structure_map
+from rabbitvcs.util.helper import structure_map
 from rabbitvcs.util.strings import *
 import six
 from six.moves import map
@@ -264,7 +263,7 @@ class SVN(object):
     def __init__(self):
         self.client = pysvn.Client()
         self.interface = "pysvn"
-        self.vcs = rabbitvcs.vcs.VCS_SVN
+        self.vcs = "svn"
         self.cache = rabbitvcs.vcs.status.StatusCache()
 
     def statuses(self, path, recurse=True, update=False, invalidate=False):


### PR DESCRIPTION
Fixes cyclic imports reported by Pylint: breaks util.decorators -> util.helper by relocating structure_map to helper.py, resolves vcs -> submodules -> status cycles by utilizing literals instead of importing rabbitvcs.vcs, and breaks ui.action -> ui.dialog -> ui.widget -> ui.log cyclic chains by refactoring module-level imports to dynamic local imports.

---
*PR created automatically by Jules for task [17455642335762136623](https://jules.google.com/task/17455642335762136623) started by @CloCkWeRX*