### PR TITLE
fix: Remove absolute_import statements

### DIFF
--- a/clients/caja/RabbitVCS.py
+++ b/clients/caja/RabbitVCS.py
@@ -28,7 +28,6 @@ Our module for everything related to the Caja extension.
 
 """
 from __future__ import with_statement
-from __future__ import absolute_import
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 import rabbitvcs.services.service

--- a/clients/gedit/rabbitvcs-plugin.py
+++ b/clients/gedit/rabbitvcs-plugin.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is a Gedit plugin to allow for RabbitVCS integration in the Gedit

--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -26,7 +26,6 @@ Our module for everything related to the Nautilus extension.
 
 """
 from __future__ import with_statement
-from __future__ import absolute_import
 from rabbitvcs.util.contextmenu4 import (
     MenuBuilder,
     MainContextMenu,

--- a/clients/nautilus/RabbitVCS3.py
+++ b/clients/nautilus/RabbitVCS3.py
@@ -26,7 +26,6 @@ Our module for everything related to the Nautilus extension.
 
 """
 from __future__ import with_statement
-from __future__ import absolute_import
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 import rabbitvcs.services.service

--- a/clients/nemo/RabbitVCS.py
+++ b/clients/nemo/RabbitVCS.py
@@ -28,7 +28,6 @@ Our module for everything related to the Nemo extension.
 
 
 from __future__ import with_statement
-from __future__ import absolute_import
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 import rabbitvcs.services.service

--- a/clients/pluma/rabbitvcs-plugin.py
+++ b/clients/pluma/rabbitvcs-plugin.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.util.contextmenu import (
     GtkFilesContextMenuConditions,

--- a/clients/thunar/RabbitVCS.py
+++ b/clients/thunar/RabbitVCS.py
@@ -25,7 +25,6 @@ Our module for everything related to the Thunar extension.
 """
 
 from __future__ import with_statement
-from __future__ import absolute_import
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 import rabbitvcs.services.service

--- a/rabbitvcs/__init__.py
+++ b/rabbitvcs/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/services/checkerservice.py
+++ b/rabbitvcs/services/checkerservice.py
@@ -42,7 +42,6 @@ should be kept to a minimum. Use convenience methods to condense and summarise
 data wherever possible (this is the case in the actual status cache and checker
 code).
 """
-from __future__ import absolute_import
 from rabbitvcs import version as SERVICE_VERSION
 
 import os

--- a/rabbitvcs/services/service.py
+++ b/rabbitvcs/services/service.py
@@ -22,7 +22,6 @@
 This module contains helper functions for starting DBUS services. Usually they
 would be used from within a constructor.
 """
-from __future__ import absolute_import
 
 import sys
 import subprocess

--- a/rabbitvcs/services/statuschecker.py
+++ b/rabbitvcs/services/statuschecker.py
@@ -19,7 +19,6 @@
 Very simple status checking class. Useful when you can't get any of the others
 to work, or you need to prototype things.
 """
-from __future__ import absolute_import
 import os
 from rabbitvcs.util.log import Log
 

--- a/rabbitvcs/test.py
+++ b/rabbitvcs/test.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/tests/test_rabbitvcs.py
+++ b/rabbitvcs/tests/test_rabbitvcs.py
@@ -24,7 +24,6 @@
 Unit tests for the top-level rabbitvcs package.
 
 """
-from __future__ import absolute_import
 from os.path import normpath, join, dirname, abspath
 import sys
 

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -25,7 +25,6 @@
 UI layer.
 
 """
-from __future__ import absolute_import
 import rabbitvcs.vcs.status
 from rabbitvcs import APP_NAME, LOCALE_DIR, gettext
 

--- a/rabbitvcs/ui/about.py
+++ b/rabbitvcs/ui/about.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from six.moves import map
 from rabbitvcs import gettext
 import configobj

--- a/rabbitvcs/ui/action.py
+++ b/rabbitvcs/ui/action.py
@@ -20,7 +20,7 @@
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import division, absolute_import
+from __future__ import division
 from rabbitvcs.util.log import Log
 from rabbitvcs import gettext
 from rabbitvcs.util.decorators import gtk_unsafe

--- a/rabbitvcs/ui/add.py
+++ b/rabbitvcs/ui/add.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.vcs.status import Status
 from rabbitvcs.util.log import Log

--- a/rabbitvcs/ui/annotate.py
+++ b/rabbitvcs/ui/annotate.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs.util.log import Log
 from rabbitvcs import gettext
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/applypatch.py
+++ b/rabbitvcs/ui/applypatch.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/branch.py
+++ b/rabbitvcs/ui/branch.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs.status
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/branches.py
+++ b/rabbitvcs/ui/branches.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from xml.sax import saxutils
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/browser.py
+++ b/rabbitvcs/ui/browser.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.decorators import gtk_unsafe
 from rabbitvcs.util.log import Log

--- a/rabbitvcs/ui/changes.py
+++ b/rabbitvcs/ui/changes.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.ui.action
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/checkmods.py
+++ b/rabbitvcs/ui/checkmods.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.decorators import gtk_unsafe
 from rabbitvcs.util.log import Log

--- a/rabbitvcs/ui/checkout.py
+++ b/rabbitvcs/ui/checkout.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.ui.updateto import GitUpdateToRevision
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/clean.py
+++ b/rabbitvcs/ui/clean.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 import rabbitvcs.ui.widget

--- a/rabbitvcs/ui/cleanup.py
+++ b/rabbitvcs/ui/cleanup.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 from rabbitvcs.ui.action import SVNAction

--- a/rabbitvcs/ui/clone.py
+++ b/rabbitvcs/ui/clone.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/commit.py
+++ b/rabbitvcs/ui/commit.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs.status
 from rabbitvcs.util.log import Log

--- a/rabbitvcs/ui/create.py
+++ b/rabbitvcs/ui/create.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.ui.action import GitAction
 import rabbitvcs.ui.dialog

--- a/rabbitvcs/ui/createpatch.py
+++ b/rabbitvcs/ui/createpatch.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.ui.commit import SVNCommit, GitCommit
 from rabbitvcs.util.log import Log

--- a/rabbitvcs/ui/delete.py
+++ b/rabbitvcs/ui/delete.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/dialog.py
+++ b/rabbitvcs/ui/dialog.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs.util.strings import S
 import rabbitvcs.util.helper
 import rabbitvcs.ui.wraplabel

--- a/rabbitvcs/ui/diff.py
+++ b/rabbitvcs/ui/diff.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/editconflicts.py
+++ b/rabbitvcs/ui/editconflicts.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 import rabbitvcs.ui.action

--- a/rabbitvcs/ui/export.py
+++ b/rabbitvcs/ui/export.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/ignore.py
+++ b/rabbitvcs/ui/ignore.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 from rabbitvcs.ui import InterfaceNonView, InterfaceView

--- a/rabbitvcs/ui/import.py
+++ b/rabbitvcs/ui/import.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.strings import S
 import rabbitvcs.ui.dialog

--- a/rabbitvcs/ui/lock.py
+++ b/rabbitvcs/ui/lock.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -20,7 +20,7 @@
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import division, absolute_import
+from __future__ import division
 from six.moves import range
 from rabbitvcs import gettext
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/markresolved.py
+++ b/rabbitvcs/ui/markresolved.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/merge.py
+++ b/rabbitvcs/ui/merge.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.strings import S
 import rabbitvcs.util.settings

--- a/rabbitvcs/ui/open.py
+++ b/rabbitvcs/ui/open.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import six
 from rabbitvcs import gettext
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/properties.py
+++ b/rabbitvcs/ui/properties.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/property_editor.py
+++ b/rabbitvcs/ui/property_editor.py
@@ -28,7 +28,7 @@ To this effect, changes are applied immediately... no saving lists of changes to
 apply later, no trying to keep track of what was done recursively and what
 wasn't; just do the work and make sure the UI is sensible.
 """
-from __future__ import absolute_import, print_function
+from __future__ import print_function
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/property_page.py
+++ b/rabbitvcs/ui/property_page.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/push.py
+++ b/rabbitvcs/ui/push.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import six
 from rabbitvcs import gettext
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/relocate.py
+++ b/rabbitvcs/ui/relocate.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.strings import S
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/remotes.py
+++ b/rabbitvcs/ui/remotes.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import print_function
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 import rabbitvcs.ui.widget

--- a/rabbitvcs/ui/rename.py
+++ b/rabbitvcs/ui/rename.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 from rabbitvcs.ui.dialog import MessageBox, OneLineTextChange

--- a/rabbitvcs/ui/renderers/graphcell.py
+++ b/rabbitvcs/ui/renderers/graphcell.py
@@ -8,7 +8,6 @@ Because we're shiny, we use Cairo to do this, and because we're naughty
 we cheat and draw over the bits of the TreeViewColumn that are supposed to
 just be for the background.
 """
-from __future__ import absolute_import
 
 __copyright__ = "Copyright 2005 Canonical Ltd."
 __author__ = "Scott James Remnant <scott@ubuntu.com>"

--- a/rabbitvcs/ui/reset.py
+++ b/rabbitvcs/ui/reset.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/revert.py
+++ b/rabbitvcs/ui/revert.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/revprops.py
+++ b/rabbitvcs/ui/revprops.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.ui.action import SVNAction
 from rabbitvcs.util.log import Log

--- a/rabbitvcs/ui/settings.py
+++ b/rabbitvcs/ui/settings.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.services.checkerservice
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/stage.py
+++ b/rabbitvcs/ui/stage.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 from rabbitvcs.util.log import Log

--- a/rabbitvcs/ui/switch.py
+++ b/rabbitvcs/ui/switch.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.strings import *
 import rabbitvcs.ui.dialog

--- a/rabbitvcs/ui/tags.py
+++ b/rabbitvcs/ui/tags.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 import rabbitvcs.util.settings

--- a/rabbitvcs/ui/unlock.py
+++ b/rabbitvcs/ui/unlock.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/unstage.py
+++ b/rabbitvcs/ui/unstage.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 from rabbitvcs.util.log import Log

--- a/rabbitvcs/ui/update.py
+++ b/rabbitvcs/ui/update.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget

--- a/rabbitvcs/ui/updateto.py
+++ b/rabbitvcs/ui/updateto.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs import gettext
 import rabbitvcs.ui.dialog
 import rabbitvcs.ui.widget

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs.ui import STATUS_EMBLEMS
 from rabbitvcs.util.log import Log
 from rabbitvcs import gettext

--- a/rabbitvcs/ui/wraplabel.py
+++ b/rabbitvcs/ui/wraplabel.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from rabbitvcs.util.strings import S
 from gi.repository import Gtk, Pango
 

--- a/rabbitvcs/util/__init__.py
+++ b/rabbitvcs/util/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/util/_locale.py
+++ b/rabbitvcs/util/_locale.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import locale
 
 from rabbitvcs.util.log import Log

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/util/contextmenu4.py
+++ b/rabbitvcs/util/contextmenu4.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/util/contextmenuitems.py
+++ b/rabbitvcs/util/contextmenuitems.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/util/contextmenuitems4.py
+++ b/rabbitvcs/util/contextmenuitems4.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/util/decorators.py
+++ b/rabbitvcs/util/decorators.py
@@ -32,7 +32,6 @@ See:
   - http://wiki.python.org/moin/PythonDecoratorLibrary
 
 """
-from __future__ import absolute_import
 
 import time
 import warnings

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -25,7 +25,6 @@
 All sorts of helper functions.
 
 """
-from __future__ import absolute_import
 
 from collections import deque
 import os

--- a/rabbitvcs/util/log.py
+++ b/rabbitvcs/util/log.py
@@ -39,7 +39,6 @@ Usage:
     log.debug("a debug message")
 
 """
-from __future__ import absolute_import
 
 import os
 import logging

--- a/rabbitvcs/util/settings.py
+++ b/rabbitvcs/util/settings.py
@@ -25,7 +25,6 @@
 Everything related retrieving and storing configuration keys.
 
 """
-from __future__ import absolute_import
 from __future__ import print_function
 
 __all__ = ['get_home_folder', 'SettingsManager']

--- a/rabbitvcs/vcs/__init__.py
+++ b/rabbitvcs/vcs/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/vcs/branch.py
+++ b/rabbitvcs/vcs/branch.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/vcs/dummy/__init__.py
+++ b/rabbitvcs/vcs/dummy/__init__.py
@@ -23,7 +23,6 @@
 """
 Concrete VCS dummy implementation.
 """
-from __future__ import absolute_import
 
 import rabbitvcs.vcs
 import rabbitvcs.vcs.status

--- a/rabbitvcs/vcs/git/__init__.py
+++ b/rabbitvcs/vcs/git/__init__.py
@@ -23,7 +23,6 @@
 """
 Concrete VCS implementation for Git functionality.
 """
-from __future__ import absolute_import
 
 import os.path
 import time

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/command.py
+++ b/rabbitvcs/vcs/git/gittyup/command.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # command.py

--- a/rabbitvcs/vcs/git/gittyup/tests/branch.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/branch.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/clone.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/clone.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/commit.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/commit.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/move.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/move.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/pull.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/pull.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/remote.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/remote.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/remove.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/remove.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/run_all.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/run_all.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #!/usr/bin/python
 

--- a/rabbitvcs/vcs/git/gittyup/tests/stage.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/stage.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/tag.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/tag.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import print_function
 
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/util.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/util.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # util.py

--- a/rabbitvcs/vcs/git/gittyup/util.py
+++ b/rabbitvcs/vcs/git/gittyup/util.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # util.py

--- a/rabbitvcs/vcs/log.py
+++ b/rabbitvcs/vcs/log.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/vcs/mercurial/__init__.py
+++ b/rabbitvcs/vcs/mercurial/__init__.py
@@ -23,7 +23,6 @@
 """
 Concrete VCS implementation for Mercurial functionality.
 """
-from __future__ import absolute_import
 
 import os.path
 from datetime import datetime

--- a/rabbitvcs/vcs/mercurial/util.py
+++ b/rabbitvcs/vcs/mercurial/util.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/vcs/status.py
+++ b/rabbitvcs/vcs/status.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -23,7 +23,6 @@
 """
 Concrete VCS implementation for Subversion functionality.
 """
-from __future__ import absolute_import
 import subprocess
 import os
 import shutil

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
 from __future__ import print_function
 
 # If you didn't know already, this is a Python setuptools script. It borrows


### PR DESCRIPTION
Reviewed the entire codebase and recursively removed the obsolete 'from __future__ import absolute_import' statements as we are targeting Python 3 exclusively.

---
*PR created automatically by Jules for task [17018994506963701542](https://jules.google.com/task/17018994506963701542) started by @CloCkWeRX*