### PR TITLE
fix: Remove Obsolete __future__ Imports

### DIFF
--- a/clients/caja/RabbitVCS.py
+++ b/clients/caja/RabbitVCS.py
@@ -27,7 +27,6 @@
 Our module for everything related to the Caja extension.
 
 """
-from __future__ import with_statement
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 import rabbitvcs.services.service

--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -25,7 +25,6 @@
 Our module for everything related to the Nautilus extension.
 
 """
-from __future__ import with_statement
 from rabbitvcs.util.contextmenu4 import (
     MenuBuilder,
     MainContextMenu,

--- a/clients/nautilus/RabbitVCS3.py
+++ b/clients/nautilus/RabbitVCS3.py
@@ -25,7 +25,6 @@
 Our module for everything related to the Nautilus extension.
 
 """
-from __future__ import with_statement
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 import rabbitvcs.services.service

--- a/clients/nemo/RabbitVCS.py
+++ b/clients/nemo/RabbitVCS.py
@@ -27,7 +27,6 @@ Our module for everything related to the Nemo extension.
 """
 
 
-from __future__ import with_statement
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 import rabbitvcs.services.service

--- a/clients/thunar/RabbitVCS.py
+++ b/clients/thunar/RabbitVCS.py
@@ -24,7 +24,6 @@ Our module for everything related to the Thunar extension.
 
 """
 
-from __future__ import with_statement
 from rabbitvcs.util.contextmenuitems import *
 from rabbitvcs.services.checkerservice import StatusCheckerStub as StatusChecker
 import rabbitvcs.services.service

--- a/rabbitvcs/ui/action.py
+++ b/rabbitvcs/ui/action.py
@@ -20,7 +20,6 @@
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import division
 from rabbitvcs.util.log import Log
 from rabbitvcs import gettext
 from rabbitvcs.util.decorators import gtk_unsafe

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -20,7 +20,6 @@
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import division
 from six.moves import range
 from rabbitvcs import gettext
 import rabbitvcs.vcs

--- a/rabbitvcs/ui/property_editor.py
+++ b/rabbitvcs/ui/property_editor.py
@@ -28,7 +28,6 @@ To this effect, changes are applied immediately... no saving lists of changes to
 apply later, no trying to keep track of what was done recursively and what
 wasn't; just do the work and make sure the UI is sensible.
 """
-from __future__ import print_function
 from rabbitvcs import gettext
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.strings import S

--- a/rabbitvcs/ui/remotes.py
+++ b/rabbitvcs/ui/remotes.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 import rabbitvcs.ui.widget

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.

--- a/rabbitvcs/util/contextmenu4.py
+++ b/rabbitvcs/util/contextmenu4.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # This is an extension to the Nautilus file manager to allow better
 # integration with the Subversion source control system.

--- a/rabbitvcs/util/settings.py
+++ b/rabbitvcs/util/settings.py
@@ -25,7 +25,6 @@
 Everything related retrieving and storing configuration keys.
 
 """
-from __future__ import print_function
 
 __all__ = ['get_home_folder', 'SettingsManager']
 

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # client.py
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/branch.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/branch.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # test/stage.py
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/clone.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/clone.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # test/clone.py
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/commit.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/commit.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # test/stage.py
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/move.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/move.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # test/stage.py
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/pull.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/pull.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # test/pull.py
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/remote.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/remote.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # test/remote.py
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/remove.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/remove.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # test/stage.py
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/stage.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/stage.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # test/stage.py
 #

--- a/rabbitvcs/vcs/git/gittyup/tests/tag.py
+++ b/rabbitvcs/vcs/git/gittyup/tests/tag.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # test/stage.py
 #

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 # If you didn't know already, this is a Python setuptools script. It borrows
 # heavily from Phatch's (see: http://photobatch.stani.be/).
 #


### PR DESCRIPTION
This change removes obsolete __future__ imports that were previously used for Python 2 to 3 compatibility. In Python 3, `with_statement`, `division`, and `print_function` are built-in features, making these imports redundant and safe to remove. Verified using py_compile.

---
*PR created automatically by Jules for task [6694446264470948617](https://jules.google.com/task/6694446264470948617) started by @CloCkWeRX*