### PR TITLE
Simplify S class and remove Python 2 checks from strings.py

### DIFF
--- a/rabbitvcs/util/strings.py
+++ b/rabbitvcs/util/strings.py
@@ -29,20 +29,19 @@ Additional strings support.
 import sys
 import codecs
 import re
-import six
 import locale
 
 __all__ = ["S", "IDENTITY_ENCODING", "UTF8_ENCODING", "SURROGATE_ESCAPE"]
 
-unicode_null_string = six.u("")
+unicode_null_string = ""
 non_alpha_num_re = re.compile("[^A-Za-z0-9]+")
 SURROGATE_BASE = 0xDC00
 RE_SURROGATE = re.compile(
-    six.u("[")
-    + six.unichr(SURROGATE_BASE + 0x80)
-    + six.u("-")
-    + six.unichr(SURROGATE_BASE + 0xFF)
-    + six.u("]")
+    "["
+    + chr(SURROGATE_BASE + 0x80)
+    + "-"
+    + chr(SURROGATE_BASE + 0xFF)
+    + "]"
 )
 RE_UTF8 = re.compile("^[Uu][Tt][Ff][ _-]?8$")
 
@@ -51,7 +50,7 @@ RE_UTF8 = re.compile("^[Uu][Tt][Ff][ _-]?8$")
 IDENTITY_ENCODING = "latin-1"
 
 
-#   An UTF-8 codec that implements surrogates, even in Python 2.
+#   An UTF-8 codec that implements surrogates.
 
 UTF8_ENCODING = "rabbitvcs-utf8"
 
@@ -136,7 +135,7 @@ def rabbitvcs_surrogate_escape(e):
     input = e.object[e.start : e.end]
     if isinstance(e, UnicodeDecodeError):
         output = [
-            six.unichr(b) if b < 0x80 else six.unichr(SURROGATE_BASE + b)
+            chr(b) if b < 0x80 else chr(SURROGATE_BASE + b)
             for b in bytearray(input)
         ]
         return (unicode_null_string.join(output), e.end)
@@ -146,7 +145,7 @@ def rabbitvcs_surrogate_escape(e):
             b = ord(c) - SURROGATE_BASE
             if not 0x80 <= b <= 0xFF:
                 raise e
-            output += six.int2byte(b)
+            output += bytes([b])
         return (output, e.end)
     raise e
 
@@ -156,8 +155,7 @@ codecs.register_error(SURROGATE_ESCAPE, rabbitvcs_surrogate_escape)
 
 class S(str):
     """
-    Stores a string in native form: unicode with surrogates in Python 3 and
-        utf-8 in Python 2.
+    Stores a string in native form: unicode with surrogates in Python 3.
     Provides the following methods:
     encode: overloaded to use UTF8_ENCODING and SURROGATE_ESCAPE error handler.
     decode: overloaded to use UTF8_ENCODING and SURROGATE_ESCAPE error handler.
@@ -166,58 +164,25 @@ class S(str):
     display: get the string in native form, without surrogates.
     """
 
-    if str == bytes:
-        # Python 2.
-        def __new__(cls, value, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
-            if isinstance(value, bytearray):
-                value = bytes(value)
-            if isinstance(value, str):
-                encoding, errors = S._codeargs(encoding, errors)
-                if encoding.lower() != UTF8_ENCODING:
-                    value = value.decode(encoding, errors)
-            if isinstance(value, six.text_type):
-                value = value.encode(UTF8_ENCODING, SURROGATE_ESCAPE)
-            elif not isinstance(value, str):
-                value = str(value)
-            return str.__new__(cls, value)
+    def __new__(cls, value, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
+        if isinstance(value, bytearray):
+            value = bytes(value)
+        if isinstance(value, bytes):
+            encoding, errors = S._codeargs(encoding, errors)
+            value = value.decode(encoding, errors)
+        elif not isinstance(value, str):
+            value = str(value)
+        return str.__new__(cls, value)
 
-        def encode(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
-            encoding, errors = self._codeargs(encoding, errors)
-            if encoding.lower() == UTF8_ENCODING:
-                return str(self)
-            value = str.decode(self, UTF8_ENCODING, SURROGATE_ESCAPE)
-            return value.encode(encoding, errors)
+    def encode(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
+        encoding, errors = self._codeargs(encoding, errors)
+        return str.encode(self, encoding, errors)
 
-        def decode(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
-            encoding, errors = self._codeargs(encoding, errors)
-            return str.decode(self, encoding, errors)
+    def decode(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
+        return str(self)
 
-        def display(self, encoding=None, errors="replace"):
-            encoding, errors = self._codeargs(encoding, errors)
-            value = str.decode(self, UTF8_ENCODING, errors)
-            return value.encode(encoding, errors)
-
-    else:
-        # Python 3.
-        def __new__(cls, value, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
-            if isinstance(value, bytearray):
-                value = bytes(value)
-            if isinstance(value, bytes):
-                encoding, errors = S._codeargs(encoding, errors)
-                value = value.decode(encoding, errors)
-            elif not isinstance(value, str):
-                value = str(value)
-            return str.__new__(cls, value)
-
-        def encode(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
-            encoding, errors = self._codeargs(encoding, errors)
-            return str.encode(self, encoding, errors)
-
-        def decode(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
-            return str(self)
-
-        def display(self, encoding=None, errors="replace"):
-            return RE_SURROGATE.sub(six.unichr(0xFFFD), self)
+    def display(self, encoding=None, errors="replace"):
+        return RE_SURROGATE.sub(chr(0xFFFD), self)
 
     def bytes(self, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE):
         return self.encode(encoding, errors)


### PR DESCRIPTION
Overhauled `rabbitvcs/util/strings.py` to remove Python 2 compatibility checks and simplified the `S` class as a native `str` subclass in Python 3.

---
*PR created automatically by Jules for task [17702799316346407266](https://jules.google.com/task/17702799316346407266) started by @CloCkWeRX*