### PR TITLE
refactor: Remove six.moves.range in favor of native range

### DIFF
--- a/clients/caja/RabbitVCS.py
+++ b/clients/caja/RabbitVCS.py
@@ -52,7 +52,6 @@ import datetime
 from os.path import dirname
 import os.path
 import os
-from six.moves import range
 
 
 def log_all_exceptions(type, value, tb):

--- a/clients/nautilus/RabbitVCS.py
+++ b/clients/nautilus/RabbitVCS.py
@@ -49,7 +49,6 @@ import datetime
 from os.path import dirname
 import os.path
 import os
-from six.moves import range
 from gi.repository import Gio
 
 

--- a/clients/nautilus/RabbitVCS3.py
+++ b/clients/nautilus/RabbitVCS3.py
@@ -50,7 +50,6 @@ import datetime
 from os.path import dirname
 import os.path
 import os
-from six.moves import range
 
 
 def log_all_exceptions(type, value, tb):

--- a/clients/nemo/RabbitVCS.py
+++ b/clients/nemo/RabbitVCS.py
@@ -54,8 +54,6 @@ import datetime
 import os.path
 import os
 
-from six.moves import range
-
 import signal
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -29,7 +29,6 @@ import rabbitvcs.vcs.status
 from rabbitvcs import APP_NAME, LOCALE_DIR, gettext
 
 import os
-from six.moves import range
 
 from rabbitvcs.util import helper
 

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -20,7 +20,6 @@
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from six.moves import range
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 import rabbitvcs.util.settings

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -7,7 +7,6 @@ from rabbitvcs.util._locale import get_locale
 from rabbitvcs.util import helper
 from rabbitvcs.util.decorators import gtk_unsafe
 from gi.repository import Gtk, Gdk, GObject, Pango
-from six.moves import range
 
 #
 # This is an extension to the Nautilus file manager to allow better

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -22,7 +22,6 @@
 
 import os
 import os.path
-from six.moves import range
 
 # Yes, * imports are bad. You write it out then.
 from .contextmenuitems import *

--- a/rabbitvcs/util/contextmenu4.py
+++ b/rabbitvcs/util/contextmenu4.py
@@ -22,7 +22,6 @@
 
 import os
 import os.path
-from six.moves import range
 
 # Yes, * imports are bad. You write it out then.
 from .contextmenuitems4 import *

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -42,7 +42,6 @@ import codecs
 from gi.repository import GLib
 
 import six
-from six.moves import range
 import six.moves.urllib.parse
 
 from rabbitvcs.util.settings import *

--- a/rabbitvcs/vcs/status.py
+++ b/rabbitvcs/vcs/status.py
@@ -29,7 +29,6 @@ import rabbitvcs.vcs
 from rabbitvcs.util.strings import S
 
 from rabbitvcs.util.log import Log
-from six.moves import range
 
 log = Log("rabbitvcs.vcs.status")
 

--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -41,7 +41,6 @@ from rabbitvcs.util.decorators import structure_map
 from rabbitvcs.util.strings import *
 import six
 from six.moves import map
-from six.moves import range
 
 log = Log("rabbitvcs.vcs.svn")
 


### PR DESCRIPTION
Removed the 'from six.moves import range' statement across 12 files in the codebase, enabling standard Python 3 native range usage.

---
*PR created automatically by Jules for task [15070230190061773118](https://jules.google.com/task/15070230190061773118) started by @CloCkWeRX*