### PR TITLE
Remove use of six.moves._thread in favor of Python 3 standard code

### DIFF
--- a/rabbitvcs/ui/add.py
+++ b/rabbitvcs/ui/add.py
@@ -33,7 +33,7 @@ from gi.repository import Gtk, GObject, Gdk
 #
 
 import os
-import six.moves._thread
+import threading
 from rabbitvcs.util import helper
 
 import gi
@@ -163,7 +163,7 @@ class Add(InterfaceView, GtkContextMenuCaller):
         """
 
         try:
-            six.moves._thread.start_new_thread(self.load, ())
+            threading.Thread(target=self.load).start()
         except Exception as e:
             log.exception(e)
 

--- a/rabbitvcs/ui/lock.py
+++ b/rabbitvcs/ui/lock.py
@@ -30,7 +30,7 @@ from gi.repository import Gtk, GObject, Gdk
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import six.moves._thread
+import threading
 
 from rabbitvcs.util import helper
 
@@ -106,7 +106,7 @@ class SVNLock(InterfaceView, GtkContextMenuCaller):
         """
 
         try:
-            six.moves._thread.start_new_thread(self.load, ())
+            threading.Thread(target=self.load).start()
         except Exception as e:
             log.exception(e)
 

--- a/rabbitvcs/ui/push.py
+++ b/rabbitvcs/ui/push.py
@@ -1,4 +1,3 @@
-import six
 from rabbitvcs import gettext
 import rabbitvcs.vcs
 import rabbitvcs.util.settings
@@ -30,7 +29,7 @@ from gi.repository import Gtk, GObject
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import six.moves._thread
+import threading
 
 from rabbitvcs.util import helper
 
@@ -111,7 +110,7 @@ class GitPush(Push):
         """
 
         try:
-            six.moves._thread.start_new_thread(self.load_logs, ())
+            threading.Thread(target=self.load_logs).start()
         except Exception as e:
             log.exception(e)
 

--- a/rabbitvcs/ui/revert.py
+++ b/rabbitvcs/ui/revert.py
@@ -31,7 +31,7 @@ from gi.repository import Gtk, GObject, Gdk
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import six.moves._thread
+import threading
 
 from rabbitvcs.util import helper
 
@@ -119,7 +119,7 @@ class Revert(InterfaceView, GtkContextMenuCaller):
         """
 
         try:
-            six.moves._thread.start_new_thread(self.load, ())
+            threading.Thread(target=self.load).start()
         except Exception as e:
             log.exception(e)
 

--- a/rabbitvcs/ui/unlock.py
+++ b/rabbitvcs/ui/unlock.py
@@ -29,7 +29,7 @@ from gi.repository import Gtk
 # along with RabbitVCS;  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import six.moves._thread
+import threading
 
 from rabbitvcs.util import helper
 
@@ -63,7 +63,7 @@ class SVNUnlock(Add):
         """
 
         try:
-            six.moves._thread.start_new_thread(self.load, ())
+            threading.Thread(target=self.load).start()
         except Exception as e:
             log.exception(e)
 


### PR DESCRIPTION
This pull request removes the outdated transitional `six.moves._thread` library import and usage across five RabbitVCS UI components (add, lock, push, revert, unlock), replacing them with Python 3's standard `threading.Thread`. All modified files have been verified via pylint static analysis to have no regressions or syntax issues.

---
*PR created automatically by Jules for task [16252611232917729634](https://jules.google.com/task/16252611232917729634) started by @CloCkWeRX*