### PR TITLE
refactor: Remove legacy 'six' usage and python2 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For Debian-based distros you can run:
 
 For Fedora-based distros you can run:
 ```
-# dnf install python[23]-nautilus python[23]-pysvn python[23]-configobj python[23]-dbus python[23]-dulwich python[23]-tkinter python[23]-gtkspell3 python[23]-pygments subversion git meld
+# dnf install python3-nautilus python3-pysvn python3-configobj python3-dbus python3-dulwich python3-tkinter python3-gtkspell3 python3-pygments subversion git meld
 ```
 
 Manual Installation
@@ -89,8 +89,8 @@ Upgrade
 -------
 To upgrade an existing version manually, copy the contents of the repository
 to the rabbitvcs lib folder. Most likely it is located at
-`/usr/lib/pymodules/python2.7/rabbitvcs`. In case of Debian-based distros this
-is will be `/usr/lib/python2.7/dist-packages/rabbitvcs`.
+`/usr/lib/python3/dist-packages/rabbitvcs` or `/usr/local/lib/python3.*/dist-packages/rabbitvcs`.
+In case of Debian-based distros this will be `/usr/lib/python3/dist-packages/rabbitvcs`.
 For Fedora-based distros on 64-bit make sure to check `/usr/lib64`.
 
 

--- a/rabbitvcs/ui/about.py
+++ b/rabbitvcs/ui/about.py
@@ -1,4 +1,3 @@
-from six.moves import map
 from rabbitvcs import gettext
 import configobj
 import pysvn
@@ -85,8 +84,8 @@ class About(object):
         self.about.set_logo(pixbuf)
 
         versions = []
-        versions.append("Subversion - %s" % ".".join(list(map(str, pysvn.svn_version))))
-        versions.append("Pysvn - %s" % ".".join(list(map(str, pysvn.version))))
+        versions.append("Subversion - %s" % ".".join(map(str, pysvn.svn_version)))
+        versions.append("Pysvn - %s" % ".".join(map(str, pysvn.version)))
         versions.append("ConfigObj - %s" % str(configobj.__version__))
 
         self.about.set_comments("\n".join(versions))

--- a/rabbitvcs/ui/browser.py
+++ b/rabbitvcs/ui/browser.py
@@ -39,7 +39,6 @@ from gi.repository import Gtk, GObject, Gdk
 #
 
 import os.path
-import six
 import locale
 from datetime import datetime
 
@@ -222,7 +221,7 @@ class SVNBrowser(InterfaceView, GtkContextMenuCaller):
         """
 
         filename = S(filename).unicode()
-        if filename == six.u(".."):
+        if filename == "..":
             return "dir"
 
         for item, locked in self.items:

--- a/rabbitvcs/ui/log.py
+++ b/rabbitvcs/ui/log.py
@@ -43,7 +43,6 @@ import rabbitvcs.ui.widget
 from rabbitvcs.ui.action import SVNAction, GitAction
 from rabbitvcs.ui import InterfaceView
 from gi.repository import Gtk, GObject, Gdk
-import six
 from locale import strxfrm
 
 import os
@@ -1672,8 +1671,8 @@ class LogBottomContextMenuCallbacks(object):
         helper.launch_ui_window(
             "changes",
             [
-                six.u("%s@%s") % (url, parent),
-                six.u("%s@%s") % (url, rev_last),
+                "%s@%s" % (url, parent),
+                "%s@%s" % (url, rev_last),
                 "--vcs=%s" % self.caller.get_vcs_name(),
             ],
         )
@@ -1687,8 +1686,8 @@ class LogBottomContextMenuCallbacks(object):
         helper.launch_ui_window(
             "changes",
             [
-                six.u("%s@%s") % (url, rev_first),
-                six.u("%s@%s") % (url, rev_last),
+                "%s@%s" % (url, rev_first),
+                "%s@%s" % (url, rev_last),
                 "--vcs=%s" % self.caller.get_vcs_name(),
             ],
         )

--- a/rabbitvcs/ui/open.py
+++ b/rabbitvcs/ui/open.py
@@ -1,4 +1,3 @@
-import six
 from rabbitvcs import gettext
 from rabbitvcs.util.strings import S
 import rabbitvcs.vcs
@@ -62,7 +61,7 @@ class SVNOpen(InterfaceNonView):
         self.vcs = rabbitvcs.vcs.VCS()
         self.svn = self.vcs.svn()
 
-        if revision and isinstance(revision, (str, six.text_type)):
+        if revision and isinstance(revision, str):
             revision_obj = self.svn.revision("number", number=revision)
         else:
             revision_obj = self.svn.revision("HEAD")

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -41,8 +41,7 @@ import codecs
 
 from gi.repository import GLib
 
-import six
-import six.moves.urllib.parse
+import urllib.parse
 
 from rabbitvcs.util.settings import *
 from rabbitvcs.util.decorators import structure_map
@@ -69,7 +68,7 @@ DT_FORMAT_THISWEEK = _("%a %I:%M%p")
 DT_FORMAT_THISYEAR = _("%b %d")
 DT_FORMAT_ALL = _("%b %d %Y")
 
-LINE_BREAK_CHAR = six.unichr(0x23CE)
+LINE_BREAK_CHAR = chr(0x23CE)
 
 
 def compare_version(version1, version2, length=None):
@@ -98,7 +97,7 @@ def to_bytes(s, encoding=UTF8_ENCODING):
     """
     Convert string (whatever type it is) to bytes in the given encoding.
     """
-    if isinstance(s, six.text_type):
+    if isinstance(s, str):
         return S(s).bytes(encoding)
     if isinstance(s, bytearray):
         if encoding.lower() == UTF8_ENCODING:
@@ -182,13 +181,13 @@ def format_long_text(text, cols=None, line1only=False):
     line. If the param "cols" is given, the text
     beyond cols is replaced by "...".
     """
-    text = S(text.strip()).unicode().replace(six.u("\n"), LINE_BREAK_CHAR)
+    text = S(text.strip()).unicode().replace("\n", LINE_BREAK_CHAR)
     if line1only:
         i = text.find(LINE_BREAK_CHAR)
         if i >= 0:
             text = text[:i]
     if cols and len(text) > cols:
-        text = six.u("%s...") % text[0:cols]
+        text = "%s..." % text[0:cols]
 
     return text
 
@@ -910,25 +909,25 @@ def url_join(path, *args):
 
 
 def _quote(text):
-    return six.moves.urllib.parse.quote(
+    return urllib.parse.quote(
         text, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE
     )
 
 
 def _quote_plus(text):
-    return six.moves.urllib.parse.quote_plus(
+    return urllib.parse.quote_plus(
         text, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE
     )
 
 
 def _unquote(text):
-    return six.moves.urllib.parse.unquote(
+    return urllib.parse.unquote(
         text, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE
     )
 
 
 def _unquote_plus(text):
-    return six.moves.urllib.parse.unquote_plus(
+    return urllib.parse.unquote_plus(
         text, encoding=UTF8_ENCODING, errors=SURROGATE_ESCAPE
     )
 
@@ -941,14 +940,14 @@ unquote_plus = _unquote_plus
 try:
     unquote("")
 except TypeError:
-    quote = six.moves.urllib.parse.quote
-    quote_plus = six.moves.urllib.parse.quote_plus
-    unquote = six.moves.urllib.parse.unquote
-    unquote_plus = six.moves.urllib.parse.unquote_plus
+    quote = urllib.parse.quote
+    quote_plus = urllib.parse.quote_plus
+    unquote = urllib.parse.unquote
+    unquote_plus = urllib.parse.unquote_plus
 
 
 def quote_url(url_text):
-    (scheme, netloc, path, params, query, fragment) = six.moves.urllib.parse.urlparse(
+    (scheme, netloc, path, params, query, fragment) = urllib.parse.urlparse(
         url_text
     )
     # netloc_quoted = quote(netloc)
@@ -957,7 +956,7 @@ def quote_url(url_text):
     query_quoted = quote_plus(query)
     fragment_quoted = quote(fragment)
 
-    url_quoted = six.moves.urllib.parse.urlunparse(
+    url_quoted = urllib.parse.urlunparse(
         (scheme, netloc, path_quoted, params_quoted, query_quoted, fragment_quoted)
     )
 
@@ -965,7 +964,7 @@ def quote_url(url_text):
 
 
 def unquote_url(url_text):
-    (scheme, netloc, path, params, query, fragment) = six.moves.urllib.parse.urlparse(
+    (scheme, netloc, path, params, query, fragment) = urllib.parse.urlparse(
         url_text
     )
     # netloc_unquoted = unquote(netloc)
@@ -974,7 +973,7 @@ def unquote_url(url_text):
     query_unquoted = unquote_plus(query)
     fragment_unquoted = unquote(fragment)
 
-    url_unquoted = six.moves.urllib.parse.urlunparse(
+    url_unquoted = urllib.parse.urlunparse(
         (
             scheme,
             netloc,
@@ -1241,7 +1240,7 @@ indirectly.
 class SanitizeArgv(object):
     def __init__(self):
         self.argmap = None
-        if len(sys.argv) and isinstance(sys.argv[0], six.text_type):
+        if len(sys.argv) and isinstance(sys.argv[0], str):
             argmap = []
             newargv = []
             for arg in sys.argv:

--- a/rabbitvcs/util/highlighter.py
+++ b/rabbitvcs/util/highlighter.py
@@ -24,7 +24,6 @@
 Syntax highlighter based on the pygments module.
 """
 
-import six
 from rabbitvcs.util.strings import S
 from rabbitvcs.util.helper import html_escape
 from rabbitvcs.util.settings import SettingsManager
@@ -131,7 +130,7 @@ else:
                     format_single(self, ttype, lines[0])
                     for line in lines[1:]:
                         flush(self)
-                        outfile.write(six.u("\n"))
+                        outfile.write("\n")
                         format_single(self, ttype, line)
 
             flush(self)

--- a/rabbitvcs/vcs/git/README
+++ b/rabbitvcs/vcs/git/README
@@ -4,4 +4,4 @@ this should supply the basic functionality needed to work with Git.
 Dependencies
 ------------
 * dulwich >= 0.19.0
-* python >= 2.4
+* python >= 3.0

--- a/rabbitvcs/vcs/status.py
+++ b/rabbitvcs/vcs/status.py
@@ -23,7 +23,6 @@
 
 import os.path
 import unittest
-import six
 
 import rabbitvcs.vcs
 from rabbitvcs.util.strings import S
@@ -300,7 +299,7 @@ class Status(object):
         attrs = self.__dict__.copy()
         # Force strings to Unicode to avoid json implicit conversion.
         for key in attrs:
-            if isinstance(attrs[key], (six.string_types, six.text_type)):
+            if isinstance(attrs[key], str):
                 attrs[key] = S(attrs[key]).unicode()
         attrs["__type__"] = type(self).__name__
         attrs["__module__"] = type(self).__module__
@@ -311,7 +310,7 @@ class Status(object):
         del state_dict["__module__"]
         # Store strings in native str type.
         for key in state_dict:
-            if isinstance(state_dict[key], (six.string_types, six.text_type)):
+            if isinstance(state_dict[key], str):
                 state_dict[key] = str(S(state_dict[key]))
         self.__dict__ = state_dict
 

--- a/rabbitvcs/vcs/svn/__init__.py
+++ b/rabbitvcs/vcs/svn/__init__.py
@@ -39,9 +39,6 @@ from rabbitvcs.util import helper
 from rabbitvcs.util.log import Log
 from rabbitvcs.util.decorators import structure_map
 from rabbitvcs.util.strings import *
-import six
-from six.moves import map
-
 log = Log("rabbitvcs.vcs.svn")
 
 from rabbitvcs import gettext
@@ -58,12 +55,11 @@ def pure_unicode(obj):
     Map object string subclass components to real unicode type.
 
     Pysvn (using PyCXX) does not like string subclasses as arguments and
-    requires unsubclassed string/unicode objects. In addition, it fails on
-    Python2 non-ascii byte strings when converting them to utf-8.
-    This function is called each time there is a risk of passing string or
-    unicode objects to the pysvn API.
+    requires unsubclassed string/unicode objects.
+    This function is called each time there is a risk of passing string
+    objects to the pysvn API.
     """
-    if isinstance(obj, (six.string_types, six.text_type)):
+    if isinstance(obj, str):
         obj = S(obj).unicode()
     return obj
 


### PR DESCRIPTION
Removed all remaining references and usages of the compatibility library 'six' in favor of native Python 3 code. Additionally, updated README.md and rabbitvcs/vcs/git/README to remove Python 2 instructions, paths, and package names.

---
*PR created automatically by Jules for task [18162885013109293746](https://jules.google.com/task/18162885013109293746) started by @CloCkWeRX*