### PR TITLE
fix: Fix invalid escape sequence SyntaxWarning in client.py

### DIFF
--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -36,7 +36,7 @@ import tkinter.messagebox
 
 ENCODING = "UTF-8"
 
-RE_STATUS = re.compile("^([\sA-Z\?]+)\s(?:\S+\s->\s)?(.*?)$")
+RE_STATUS = re.compile(r"^([\sA-Z\?]+)\s(?:\S+\s->\s)?(.*?)$")
 
 
 def callback_notify_null(val):
@@ -1696,7 +1696,7 @@ class GittyupClient(object):
             stdout = []
 
         for line in stdout:
-            components = re.match("^(Would remove)\\s(.*?)$", line)
+            components = re.match(r"^(Would remove)\s(.*?)$", line)
             if components:
                 relative_path = components.group(2)
                 if relative_path.endswith("/"):
@@ -1714,7 +1714,7 @@ class GittyupClient(object):
             stdout = []
 
         for line in stdout:
-            components = re.match("^(Would remove)\\s(.*?)$", line)
+            components = re.match(r"^(Would remove)\s(.*?)$", line)
             if not components:
                 continue
             relative_path = components.group(2)
@@ -1870,7 +1870,7 @@ class GittyupClient(object):
 
         untracked_directories = []
         for line in stdout:
-            components = re.match("^(Would remove)\s(.*?)$", line)
+            components = re.match(r"^(Would remove)\s(.*?)$", line)
             if components:
                 untracked_path = components.group(2)
                 if untracked_path[-1] == "/":
@@ -1886,7 +1886,7 @@ class GittyupClient(object):
             self.callback_notify(e)
         ignored_directories = []
         for line in stdout:
-            components = re.match("^(Would remove)\s(.*?)$", line)
+            components = re.match(r"^(Would remove)\s(.*?)$", line)
             if components:
                 ignored_path = components.group(2)
                 if ignored_path[-1] == "/":
@@ -2107,7 +2107,7 @@ class GittyupClient(object):
 
             if line[0:6] == "commit":
                 match = pattern_from.search(line)
-                commit_line = re.sub(" \(from.*\)", "", line).split(" ")
+                commit_line = re.sub(r" \(from.*\)", "", line).split(" ")
                 fromPath = ""
                 if match:
                     fromPath = match.group(1)
@@ -2459,7 +2459,7 @@ class GittyupClient(object):
             # Some messages have a strage tendancy to append a non-printable character,
             # followed by a right square brace and a capitol "K".  This tests for, and
             # strips these superfluous characters.
-            message_components = re.search("^(.+).\[K", message)
+            message_components = re.search(r"^(.+).\[K", message)
             if message_components != None:
                 returnData["path"] = message_components.group(1)
             else:
@@ -2523,7 +2523,7 @@ class GittyupClient(object):
             message_parsed = True
 
         # Look for "Branch" line (e.g. "* branch   master   -> FETCH_HEAD")
-        message_components = re.search("\* branch +([A-z0-9]+) +-> (.+)", data)
+        message_components = re.search(r"\* branch +([A-z0-9]+) +-> (.+)", data)
 
         if message_components != None:
             return_data["action"] = "Branch"
@@ -2533,7 +2533,7 @@ class GittyupClient(object):
             message_parsed = True
 
         # Look for a file line (e.g. "src/somefile.py       | 5 -++++")
-        message_components = re.search(" +(.+) +\| *([0-9]+) ([+-]+)", data)
+        message_components = re.search(r" +(.+) +\| *([0-9]+) ([+-]+)", data)
 
         if message_components != None:
             return_data["action"] = "Modified"
@@ -2579,7 +2579,7 @@ class GittyupClient(object):
 
         # Look for a "binary" line (e.g. "icons/file.png"    | Bin 0 -> 55555 bytes)
         message_components = re.search(
-            "^[ ](.+) +\| Bin ([0-9]+ -> [0-9]+ bytes)", data
+            r"^[ ](.+) +\| Bin ([0-9]+ -> [0-9]+ bytes)", data
         )
 
         if message_components != None:
@@ -2589,7 +2589,7 @@ class GittyupClient(object):
             message_parsed = True
 
         # Look for a "rename" line (e.g. "rename src/{foo.py => bar.py} (50%)")
-        message_components = re.search("rename (.+}) \([0-9]+%\)", data)
+        message_components = re.search(r"rename (.+}) \([0-9]+%\)", data)
 
         if message_components != None:
             return_data["action"] = "Rename"
@@ -2597,7 +2597,7 @@ class GittyupClient(object):
             message_parsed = True
 
         # Look for a "copy" line (e.g. "copy src/{foo.py => bar.py} (50%)")
-        message_components = re.search("copy (.+}) \([0-9]+%\)", data)
+        message_components = re.search(r"copy (.+}) \([0-9]+%\)", data)
 
         if message_components != None:
             return_data["action"] = "Copy"
@@ -2607,7 +2607,7 @@ class GittyupClient(object):
         # Prepend "Error" to conflict lines. e.g. :
         # CONFLICT (content): Merge conflict in file.py.
         # Automatic merge failed; fix conflicts and then commit the result.
-        message_components = re.search("^CONFLICT \(|Automatic merge failed", data)
+        message_components = re.search(r"^CONFLICT \(|Automatic merge failed", data)
 
         if message_components != None:
             return_data["action"] = "Error"
@@ -2634,7 +2634,7 @@ class GittyupClient(object):
             message_parsed = True
 
         # Look for "new branch" line. e.g. " * [new branch]   master -> master"
-        message_components = re.search("^ \* \[new branch\] +(.+) -> (.+)", data)
+        message_components = re.search(r"^ \* \[new branch\] +(.+) -> (.+)", data)
 
         if message_components != None:
             return_data["action"] = "New Branch"
@@ -2644,7 +2644,7 @@ class GittyupClient(object):
             message_parsed = True
 
         # Look for "rejected" line. e.g. " ![rejected]   master -> master (non-fast-forward)".
-        message_components = re.search("!\[rejected\] +(.+)", data)
+        message_components = re.search(r"!\[rejected\] +(.+)", data)
 
         if message_components != None:
             return_data["action"] = "Rejected"


### PR DESCRIPTION
This pull request fixes several SyntaxWarning: invalid escape sequence warnings on Python 3.12+ in rabbitvcs/vcs/git/gittyup/client.py. The regex patterns have been converted to raw string literals by prefixing them with 'r', which is the standard way to define regular expression patterns in Python. All syntax warnings have been successfully resolved, and compilation is clean.

---
*PR created automatically by Jules for task [15851429711699897339](https://jules.google.com/task/15851429711699897339) started by @CloCkWeRX*