### PR TITLE
Fix consider-using-with warnings

### DIFF
--- a/rabbitvcs/services/service.py
+++ b/rabbitvcs/services/service.py
@@ -72,7 +72,7 @@ def start_service(script_file, dbus_service_name, dbus_object_path):
         obj = session_bus.get_object(dbus_service_name, dbus_object_path)
         object_exists = True
     except dbus.DBusException:
-        proc = subprocess.Popen(
+        proc = subprocess.Popen(  # pylint: disable=consider-using-with
             [sys.executable, script_file], stdin=subprocess.PIPE, stdout=subprocess.PIPE
         )
         pid = proc.pid

--- a/rabbitvcs/ui/__init__.py
+++ b/rabbitvcs/ui/__init__.py
@@ -136,7 +136,7 @@ class InterfaceView(GtkBuilderWidgetWrapper):
             try:
                 import subprocess
 
-                subprocess.Popen(
+                subprocess.Popen(  # pylint: disable=consider-using-with
                     'osascript -e "tell application \\"Python\\" to activate"',
                     shell=True,
                 )

--- a/rabbitvcs/ui/about.py
+++ b/rabbitvcs/ui/about.py
@@ -74,7 +74,8 @@ class About:
             doc_path = "/".join(doc_path[:-2])
             authors_path = os.path.join(doc_path, "AUTHORS")
 
-        authors = open(authors_path, "r").read()
+        with open(authors_path, "r") as f:
+            authors = f.read()
 
         self.about.set_authors(authors.split("\n"))
 

--- a/rabbitvcs/ui/action.py
+++ b/rabbitvcs/ui/action.py
@@ -196,9 +196,8 @@ class MessageCallbackNotifier(VCSNotifier):
             path = dialog.run()
 
         if path is not None:
-            fh = open(path, "w")
-            fh.write(self.table.generate_string_from_data())
-            fh.close()
+            with open(path, "w") as fh:
+                fh.write(self.table.generate_string_from_data())
 
 
 class LoadingNotifier(VCSNotifier):

--- a/rabbitvcs/ui/annotate.py
+++ b/rabbitvcs/ui/annotate.py
@@ -309,9 +309,8 @@ class Annotate(InterfaceView):
             path = dialog.run()
 
         if path is not None:
-            fh = open(path, "w")
-            fh.write(self.generate_string_from_result())
-            fh.close()
+            with open(path, "w") as fh:
+                fh.write(self.generate_string_from_result())
 
     def launch_loading(self):
         self.loading_dialog = Loading()

--- a/rabbitvcs/ui/createpatch.py
+++ b/rabbitvcs/ui/createpatch.py
@@ -178,26 +178,23 @@ class SVNCreatePatch(CreatePatch, SVNCommit):
         self.action.append(self.action.set_status, _("Creating Patch File..."))
 
         def create_patch_action(patch_path, patch_items, base_dir):
-            fileObj = open(patch_path, "w")
-
             # PySVN takes a path to create its own temp files...
             temp_dir = tempfile.mkdtemp(prefix=rabbitvcs.TEMP_DIR_PREFIX)
 
             os.chdir(base_dir)
 
-            # Add to the Patch file only the selected items
-            for item in patch_items:
-                rel_path = helper.get_relative_path(base_dir, item)
-                diff_text = self.svn.diff(
-                    temp_dir,
-                    rel_path,
-                    self.svn.revision("base"),
-                    rel_path,
-                    self.svn.revision("working"),
-                )
-                fileObj.write(diff_text)
-
-            fileObj.close()
+            with open(patch_path, "w") as fileObj:
+                # Add to the Patch file only the selected items
+                for item in patch_items:
+                    rel_path = helper.get_relative_path(base_dir, item)
+                    diff_text = self.svn.diff(
+                        temp_dir,
+                        rel_path,
+                        self.svn.revision("base"),
+                        rel_path,
+                        self.svn.revision("working"),
+                    )
+                    fileObj.write(diff_text)
 
             # Note: if we don't want to ignore errors here, we could define a
             # function that logs failures.
@@ -245,25 +242,22 @@ class GitCreatePatch(CreatePatch, GitCommit):
         self.action.append(self.action.set_status, _("Creating Patch File..."))
 
         def create_patch_action(patch_path, patch_items, base_dir):
-            fileObj = open(patch_path, "w")
-
             # PySVN takes a path to create its own temp files...
             temp_dir = tempfile.mkdtemp(prefix=rabbitvcs.TEMP_DIR_PREFIX)
 
             os.chdir(base_dir)
 
-            # Add to the Patch file only the selected items
-            for item in patch_items:
-                rel_path = helper.get_relative_path(base_dir, item)
-                diff_text = self.git.diff(
-                    rel_path,
-                    self.git.revision("HEAD"),
-                    rel_path,
-                    self.git.revision("WORKING"),
-                )
-                fileObj.write(diff_text)
-
-            fileObj.close()
+            with open(patch_path, "w") as fileObj:
+                # Add to the Patch file only the selected items
+                for item in patch_items:
+                    rel_path = helper.get_relative_path(base_dir, item)
+                    diff_text = self.git.diff(
+                        rel_path,
+                        self.git.revision("HEAD"),
+                        rel_path,
+                        self.git.revision("WORKING"),
+                    )
+                    fileObj.write(diff_text)
 
             # Note: if we don't want to ignore errors here, we could define a
             # function that logs failures.

--- a/rabbitvcs/ui/diff.py
+++ b/rabbitvcs/ui/diff.py
@@ -220,14 +220,11 @@ class GitDiff(Diff):
         if not data:
             data = ""
 
-        file = open(path, "wb")
-        try:
+        with open(path, "wb") as file:
             try:
                 file.write(S(data).bytes())
             except Exception as e:
                 log.exception(e)
-        finally:
-            file.close()
 
     def launch_unified_diff(self):
         """

--- a/rabbitvcs/ui/settings.py
+++ b/rabbitvcs/ui/settings.py
@@ -378,9 +378,8 @@ class Settings(InterfaceView):
         )
         if confirmation.run() == Gtk.ResponseType.OK:
             path = helper.get_repository_paths_path()
-            fh = open(path, "w")
-            fh.write("")
-            fh.close()
+            with open(path, "w") as fh:
+                fh.write("")
             rabbitvcs.ui.dialog.MessageBox(_("Repository paths cleared"))
 
     def on_cache_clear_messages_clicked(self, widget):
@@ -389,9 +388,8 @@ class Settings(InterfaceView):
         )
         if confirmation.run() == Gtk.ResponseType.OK:
             path = helper.get_previous_messages_path()
-            fh = open(path, "w")
-            fh.write("")
-            fh.close()
+            with open(path, "w") as fh:
+                fh.write("")
             rabbitvcs.ui.dialog.MessageBox(_("Previous messages cleared"))
 
     def on_cache_clear_authentication_clicked(self, widget):

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -1662,9 +1662,8 @@ class MultiFileTextEditor:
 
     def load_file(self, path):
         if os.path.exists(path):
-            fh = open(path, "r")
-            self.textview.set_text(S(fh.read()).display())
-            fh.close()
+            with open(path, "r") as fh:
+                self.textview.set_text(S(fh.read()).display())
         else:
             self.textview.set_text("")
 
@@ -1683,6 +1682,5 @@ class MultiFileTextEditor:
                 if not os.path.exists(os.path.dirname(tmppath)):
                     os.mkdir(os.path.dirname(tmppath))
 
-                fh = open(tmppath, "w")
-                fh.write(self.cache[tmppath])
-                fh.close()
+                with open(tmppath, "w") as fh:
+                    fh.write(self.cache[tmppath])

--- a/rabbitvcs/util/contextmenu.py
+++ b/rabbitvcs/util/contextmenu.py
@@ -339,7 +339,8 @@ class ContextMenuCallbacks:
                 "--title=RabbitVCS",
                 "--text=Emblem to add:",
             ]
-            emblem = S(Popen(command, stdout=PIPE).communicate()[0]).replace("\n", "")
+            with Popen(command, stdout=PIPE) as proc:
+                emblem = S(proc.communicate()[0]).replace("\n", "")
 
             rabbitvcs_extension = self.caller
             VFSFile_table = rabbitvcs_extension.VFSFile_table

--- a/rabbitvcs/util/contextmenu4.py
+++ b/rabbitvcs/util/contextmenu4.py
@@ -245,7 +245,8 @@ class ContextMenuCallbacks:
                 "--title=RabbitVCS",
                 "--text=Emblem to add:",
             ]
-            emblem = S(Popen(command, stdout=PIPE).communicate()[0]).replace("\n", "")
+            with Popen(command, stdout=PIPE) as proc:
+                emblem = S(proc.communicate()[0]).replace("\n", "")
 
             rabbitvcs_extension = self.caller
             VFSFile_table = rabbitvcs_extension.VFSFile_table

--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -149,7 +149,7 @@ def get_tmp_path(filename):
 
 def process_memory(pid):
     # ps -p 5205 -w -w -o rss --no-headers
-    psproc = subprocess.Popen(
+    with subprocess.Popen(
         [
             "ps",
             "-p",
@@ -162,9 +162,9 @@ def process_memory(pid):
             "--no-headers",
         ],
         stdout=subprocess.PIPE,
-    )
+    ) as psproc:
 
-    (output, stdin) = psproc.communicate()
+        (output, stdin) = psproc.communicate()
 
     mem_in_kb = 0
 
@@ -279,7 +279,8 @@ def get_repository_paths():
     returner = []
     paths_file = get_repository_paths_path()
     if os.path.exists(paths_file):
-        returner = [x.strip() for x in open(paths_file, "r").readlines()]
+        with open(paths_file, "r") as f:
+            returner = [x.strip() for x in f.readlines()]
 
     return returner
 
@@ -309,7 +310,8 @@ def get_previous_messages():
     if not os.path.exists(path):
         return
 
-    lines = open(path, "r").readlines()
+    with open(path, "r") as f:
+        lines = f.readlines()
 
     cur_entry = ""
     returner = []
@@ -344,11 +346,10 @@ def get_exclude_paths():
     if not os.path.exists(path):
         return []
 
-    f = open(path, "r")
     paths = []
-    for l in f:
-        paths.append(l.strip())
-    f.close()
+    with open(path, "r") as f:
+        for l in f:
+            paths.append(l.strip())
 
     return paths
 
@@ -566,7 +567,7 @@ def open_item(path):
 
     if platform.system() == "Darwin":
         openers.append("open")
-        subprocess.Popen(["open", os.path.abspath(path)])
+        subprocess.Popen(["open", os.path.abspath(path)])  # pylint: disable=consider-using-with
     else:
         openers.append("gio")
         openers.append("gvfs-open")
@@ -580,7 +581,7 @@ def open_item(path):
                     command.append("open")
                 command.append(os.path.abspath(path))
 
-                subprocess.Popen(command)
+                subprocess.Popen(command)  # pylint: disable=consider-using-with
                 return
 
 
@@ -596,9 +597,9 @@ def browse_to_item(path):
     import platform
 
     if platform.system() == "Darwin":
-        subprocess.Popen(["open", "--reveal", os.path.dirname(os.path.abspath(path))])
+        subprocess.Popen(["open", "--reveal", os.path.dirname(os.path.abspath(path))])  # pylint: disable=consider-using-with
     else:
-        subprocess.Popen(
+        subprocess.Popen(  # pylint: disable=consider-using-with
             [
                 "nautilus",
                 "--no-desktop",
@@ -673,7 +674,6 @@ def save_log_message(message):
     t = time.strftime(LOG_DATETIME_FORMAT)
     messages.insert(0, (t, message))
 
-    f = open(get_previous_messages_path(), "w")
     s = ""
     for m in messages:
         s = f"""-- {m[0]} --
@@ -681,8 +681,8 @@ def save_log_message(message):
 {s}
 """
 
-    f.write(s)
-    f.close()
+    with open(get_previous_messages_path(), "w") as f:
+        f.write(s)
 
 
 def save_repository_path(path):
@@ -705,9 +705,8 @@ def save_repository_path(path):
     while len(paths) > limit:
         paths.pop()
 
-    f = open(get_repository_paths_path(), "w")
-    f.write(S("\n".join(paths)))
-    f.close()
+    with open(get_repository_paths_path(), "w") as f:
+        f.write(S("\n".join(paths)))
 
 
 def launch_ui_window(filename, args=[], block=False):
@@ -742,7 +741,7 @@ def launch_ui_window(filename, args=[], block=False):
             executable = os.environ["PYTHON"]
         # Give all subprocesses the name 'RabbitVCS' to give Ubuntu desktop files the possibility
         # to group those windows in the launcher on WM_CLASS.
-        proc = subprocess.Popen([executable, path] + ["--name", "RabbitVCS"] + args)
+        proc = subprocess.Popen([executable, path] + ["--name", "RabbitVCS"] + args)  # pylint: disable=consider-using-with
 
         if block:
             proc.wait()
@@ -878,7 +877,7 @@ def launch_repo_browser(uri):
     repo_browser = sm.get("external", "repo_browser")
 
     if repo_browser is not None:
-        subprocess.Popen([repo_browser, uri])
+        subprocess.Popen([repo_browser, uri])  # pylint: disable=consider-using-with
 
 
 def launch_url_in_webbrowser(url):
@@ -1116,70 +1115,70 @@ def parse_patch_output(patch_file, base_dir, strip=0):
     #    reversed if they look like they are.
     env = os.environ.copy().update({"LC_ALL": "C"})
     p = f"-p{strip}"
-    patch_proc = subprocess.Popen(
+    with subprocess.Popen(
         ["patch", "-N", "-t", p, "-i", str(patch_file), "--directory", base_dir],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         env=env,
-    )
+    ) as patch_proc:
 
-    # Intialise things...
-    out = codecs.getreader(UTF8_ENCODING)(patch_proc.stdout, SURROGATE_ESCAPE)
-    line = out.readline()
-    patch_match = PATCHING_RE.match(line)
-
-    current_file = None
-    if patch_match:
-        current_file = patch_match.group(1)
-    elif line:  # and not patch_match
-        # There was output, but unexpected. Almost certainly an error of some
-        # sort.
-        patch_proc.wait()
-        output = line + out.read()
-        raise rabbitvcs.vcs.ExternalUtilError("patch", output)
-        # Note the excluded case: empty line. This falls through, skips the loop
-        # and returns.
-
-    any_errors = False
-    reject_file = None
-
-    while current_file:
-
-        line = out.readline().rstrip(" \t\r\n")
-        while not line and patch_proc.poll() is None:
-            line = out.readline().rstrip(" \t\r\n")
-
-        # Does patch tell us we're starting a new file?
+        # Intialise things...
+        out = codecs.getreader(UTF8_ENCODING)(patch_proc.stdout, SURROGATE_ESCAPE)
+        line = out.readline()
         patch_match = PATCHING_RE.match(line)
 
-        # Starting a new file => that's it for the last one, so return the value
-        # No line => End of patch output => ditto
-        if patch_match or not line:
-
-            yield (current_file, not any_errors, reject_file)
-
-            if not line:
-                # That's it from patch, so end the generator
-                break
-
-            # Starting a new file...
+        current_file = None
+        if patch_match:
             current_file = patch_match.group(1)
-            any_errors = False
-            reject_file = None
+        elif line:  # and not patch_match
+            # There was output, but unexpected. Almost certainly an error of some
+            # sort.
+            patch_proc.wait()
+            output = line + out.read()
+            raise rabbitvcs.vcs.ExternalUtilError("patch", output)
+            # Note the excluded case: empty line. This falls through, skips the loop
+            # and returns.
 
-        else:
-            # Doesn't matter why we're here, anything else means ERROR
+        any_errors = False
+        reject_file = None
 
-            any_errors = True
+        while current_file:
 
-            reject_match = REJECT_RE.match(line)
+            line = out.readline().rstrip(" \t\r\n")
+            while not line and patch_proc.poll() is None:
+                line = out.readline().rstrip(" \t\r\n")
 
-            if reject_match:
-                # Have current file, getting reject file info
-                reject_file = reject_match.group(1)
-            # else: we have an unknown error
+            # Does patch tell us we're starting a new file?
+            patch_match = PATCHING_RE.match(line)
 
-    patch_proc.wait()  # Don't leave process running...
+            # Starting a new file => that's it for the last one, so return the value
+            # No line => End of patch output => ditto
+            if patch_match or not line:
+
+                yield (current_file, not any_errors, reject_file)
+
+                if not line:
+                    # That's it from patch, so end the generator
+                    break
+
+                # Starting a new file...
+                current_file = patch_match.group(1)
+                any_errors = False
+                reject_file = None
+
+            else:
+                # Doesn't matter why we're here, anything else means ERROR
+
+                any_errors = True
+
+                reject_match = REJECT_RE.match(line)
+
+                if reject_match:
+                    # Have current file, getting reject file info
+                    reject_file = reject_match.group(1)
+                # else: we have an unknown error
+
+        patch_proc.wait()  # Don't leave process running...
 
 
 def HSLtoRGB(h, s, l):

--- a/rabbitvcs/util/log.py
+++ b/rabbitvcs/util/log.py
@@ -76,7 +76,8 @@ if changed:
 
 LOG_PATH = os.path.join(get_home_folder(), "RabbitVCS.log")
 if not os.path.exists(LOG_PATH):
-    open(LOG_PATH, "a").close()
+    with open(LOG_PATH, "a"):
+        pass
 DEFAULT_FORMAT = "%(message)s"
 FILE_FORMAT = "%(asctime)s %(levelname)s\t%(name)s\t%(message)s"
 CONSOLE_FORMAT = "%(levelname)s\t%(name)s\t%(message)s"

--- a/rabbitvcs/vcs/git/gittyup/client.py
+++ b/rabbitvcs/vcs/git/gittyup/client.py
@@ -112,14 +112,12 @@ class GittyupClient:
 
     def _initialize_index(self):
         index_path = self.repo.index_path()
-        f = open(index_path, "wb")
-        try:
-            f = SHA1Writer(f)
-            write_index_dict(f, {})
-        except:
-            pass
-
-        f.close()
+        with open(index_path, "wb") as f_raw:
+            try:
+                f = SHA1Writer(f_raw)
+                write_index_dict(f, {})
+            except:
+                pass
 
     def _get_index(self):
         if not self.repo.has_index():
@@ -161,15 +159,15 @@ class GittyupClient:
             return self.git_version
 
         try:
-            proc = subprocess.Popen(
+            with subprocess.Popen(
                 ["git", "--version"],
                 stdout=subprocess.PIPE,
                 universal_newlines=True,
-            )
-            response = proc.communicate()[0].split()
-            version = [int(x) for x in response[2].split(".")]
-            self.git_version = version
-            return self.git_version
+            ) as proc:
+                response = proc.communicate()[0].split()
+                version = [int(x) for x in response[2].split(".")]
+                self.git_version = version
+                return self.git_version
         except Exception as e:
             return None
 
@@ -228,17 +226,15 @@ class GittyupClient:
 
         patterns = []
         if os.path.isfile(path):
-            file = open(path, "r")
-            try:
-                for line in file:
-                    if line == "" or line.startswith("#"):
-                        continue
+            with open(path, "r") as file:
+                try:
+                    for line in file:
+                        if line == "" or line.startswith("#"):
+                            continue
 
-                    patterns.append(line.rstrip("\n"))
-            except:
-                pass
-
-            file.close()
+                        patterns.append(line.rstrip("\n"))
+                except:
+                    pass
 
         return patterns
 
@@ -290,12 +286,8 @@ class GittyupClient:
         return (sorted(files), directories)
 
     def _get_blob_from_file(self, path):
-        file = open(path, "rb")
-        try:
+        with open(path, "rb") as file:
             blob = dulwich.objects.Blob.from_string(file.read())
-        finally:
-            file.close()
-
         return blob
 
     def _write_blob_to_file(self, path, blob):
@@ -303,11 +295,8 @@ class GittyupClient:
         if not os.path.isdir(dirname):
             os.makedirs(dirname)
 
-        file = open(path, "wb")
-        try:
+        with open(path, "wb") as file:
             file.write(blob.data)
-        finally:
-            file.close()
 
     def _load_config(self):
         self.config = self.repo.get_config()

--- a/rabbitvcs/vcs/git/gittyup/command.py
+++ b/rabbitvcs/vcs/git/gittyup/command.py
@@ -48,7 +48,7 @@ class GittyupCommand:
         env["PYTHONIOENCODING"] = "UTF-8"
         env["GIT_TERMINAL_PROMPT"] = "0"
         env["GIT_SSL_CERT_PASSWORD_PROTECTED"] = ""
-        proc = subprocess.Popen(
+        with subprocess.Popen(
             self.command,
             cwd=self.cwd,
             stdin=None,
@@ -57,21 +57,21 @@ class GittyupCommand:
             env=env,
             close_fds=True,
             preexec_fn=os.setsid,
-        )
+        ) as proc:
 
-        out = codecs.getreader(UTF8_ENCODING)(proc.stdout, SURROGATE_ESCAPE)
-        stdout = []
+            out = codecs.getreader(UTF8_ENCODING)(proc.stdout, SURROGATE_ESCAPE)
+            stdout = []
 
-        while True:
-            line = out.readline()
+            while True:
+                line = out.readline()
 
-            if line == "":
-                break
-            line = line.rstrip("\r\n")  # Strip trailing newline.
-            self.notify(line)
-            stdout.append(line)
+                if line == "":
+                    break
+                line = line.rstrip("\r\n")  # Strip trailing newline.
+                self.notify(line)
+                stdout.append(line)
 
-            if self.cancel():
-                proc.kill()
+                if self.cancel():
+                    proc.kill()
 
-        return (0, stdout, None)
+            return (0, stdout, None)

--- a/setup.py
+++ b/setup.py
@@ -123,9 +123,8 @@ icon_path = "%s/%s"
     PREFIX,
     icon_theme_directory,
 )
-fh = open(path, "w")
-fh.write(buildinfo)
-fh.close()
+with open(path, "w") as fh:
+    fh.write(buildinfo)
 
 # ==============================================================================
 # Ready to install
@@ -172,7 +171,8 @@ if installing:
     if os.uname()[0] != "Darwin":
         print("Running gtk-update-icon-cache")
 
-        subprocess.Popen(
+        with subprocess.Popen(
             ["gtk-update-icon-cache", os.path.join(PREFIX, icon_theme_directory)],
             stdout=subprocess.PIPE,
-        ).communicate()[0]
+        ) as proc:
+            proc.communicate()[0]


### PR DESCRIPTION
This pull request resolves all outstanding pylint `consider-using-with` (R1732) warnings in the RabbitVCS codebase. It systematically refactors file opens (`open()`) and synchronous subprocess runs (`subprocess.Popen()`) into proper context-managed `with` blocks. For asynchronous fire-and-forget subprocesses (like launchers, background daemons, or returned process references), the warning is suppressed locally to preserve correct asynchronous process lifetimes. All pylint checks are verified to pass clean (10/10) for this rule.

---
*PR created automatically by Jules for task [13244449783140745187](https://jules.google.com/task/13244449783140745187) started by @CloCkWeRX*