### PR TITLE
Fix super-with-arguments and clean up .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,12 +27,6 @@ clear-cache-post-run=no
 # run arbitrary code.
 extension-pkg-allow-list=
 
-# A comma-separated list of package or module names from where C extensions may
-# be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
-# for backward compatibility.)
-extension-pkg-whitelist=
-
 # Return non-zero exit code if any of these messages/categories are detected,
 # even if score is above --fail-under value. Syntax same as enable. Messages
 # specified are enabled, while categories only check already-enabled messages.
@@ -494,7 +488,6 @@ disable=raw-checker-failed,
         protected-access,
         raise-missing-from,
         super-init-not-called,
-        super-with-arguments,
         superfluous-parens,
         too-few-public-methods,
         too-many-branches,

--- a/rabbitvcs/ui/widget.py
+++ b/rabbitvcs/ui/widget.py
@@ -1395,7 +1395,7 @@ class KeyValueTable(Gtk.Grid):
                       tuple is the key/label, and the second element is the
                       information
         """
-        super(KeyValueTable, self).__init__()
+        super().__init__()
         if stuff and len(stuff):
             row = 0
 

--- a/rabbitvcs/util/contextmenuitems.py
+++ b/rabbitvcs/util/contextmenuitems.py
@@ -287,7 +287,7 @@ class MenuSeparator(MenuItem):
         menuitem.set_property("sensitive", False)
 
     def make_thunar_action(self, id_magic=None):
-        menuitem = super(MenuSeparator, self).make_thunar_action(id_magic)
+        menuitem = super().make_thunar_action(id_magic)
         self.make_insensitive(menuitem)
         return menuitem
         # FIXME: I thought that this would work to create separators,
@@ -316,7 +316,7 @@ class MenuSeparator(MenuItem):
         return menuitem
 
     def make_nautilus_menu_item(self, id_magic=None):
-        menuitem = super(MenuSeparator, self).make_nautilus_menu_item(id_magic)
+        menuitem = super().make_nautilus_menu_item(id_magic)
         self.make_insensitive(menuitem)
         return menuitem
 
@@ -893,7 +893,7 @@ class RabbitVCSAction(Action):
         self.sub_actions = sub_actions
 
     def create_menu_item(self):
-        menu_item = super(RabbitVCSAction, self).create_menu_item()
+        menu_item = super().create_menu_item()
         if self.sub_actions is not None:
             menu = Gtk.Menu()
             menu_item.set_submenu(menu)

--- a/rabbitvcs/util/contextmenuitems4.py
+++ b/rabbitvcs/util/contextmenuitems4.py
@@ -253,7 +253,7 @@ class MenuSeparator(MenuItem):
         menuitem.set_property("sensitive", False)
 
     def make_thunar_action(self, id_magic=None):
-        menuitem = super(MenuSeparator, self).make_thunar_action(id_magic)
+        menuitem = super().make_thunar_action(id_magic)
         self.make_insensitive(menuitem)
         return menuitem
         # FIXME: I thought that this would work to create separators,
@@ -271,7 +271,7 @@ class MenuSeparator(MenuItem):
         # ~ return action
 
     def make_nautilus_menu_item(self, id_magic=None):
-        menuitem = super(MenuSeparator, self).make_nautilus_menu_item(id_magic)
+        menuitem = super().make_nautilus_menu_item(id_magic)
         self.make_insensitive(menuitem)
         return menuitem
 

--- a/rabbitvcs/vcs/status.py
+++ b/rabbitvcs/vcs/status.py
@@ -390,7 +390,7 @@ class GitStatus(Status):
     metadata_status_map = {"normal": status_normal, None: status_normal}
 
     def __init__(self, gittyup_status):
-        super(GitStatus, self).__init__(
+        super().__init__(
             gittyup_status.path, content=str(gittyup_status.identifier), metadata=None
         )
 
@@ -411,7 +411,7 @@ class MercurialStatus(Status):
     metadata_status_map = {"normal": status_normal, None: status_normal}
 
     def __init__(self, mercurial_status):
-        super(MercurialStatus, self).__init__(
+        super().__init__(
             mercurial_status["path"],
             content=str(mercurial_status["content"]),
             metadata=None,

--- a/setup.py
+++ b/setup.py
@@ -116,13 +116,9 @@ documentation = [("share/doc/rabbitvcs", ["AUTHORS", "MAINTAINERS"])]
 
 # Save build information so we can access the prefix later
 path = "rabbitvcs/buildinfo.py"
-buildinfo = """rabbitvcs_prefix = "%s"
-icon_path = "%s/%s"
-""" % (
-    PREFIX,
-    PREFIX,
-    icon_theme_directory,
-)
+buildinfo = f"""rabbitvcs_prefix = "{PREFIX}"
+icon_path = "{PREFIX}/{icon_theme_directory}"
+"""
 fh = open(path, "w")
 fh.write(buildinfo)
 fh.close()


### PR DESCRIPTION
This pull request fixes all occurrences of the 'super-with-arguments' warning in the codebase by converting old Python 2-style super(Class, self) calls to Python 3-style argumentless super() calls. Additionally, it cleans up `.pylintrc` by removing 'super-with-arguments' from the disabled list (thereby enabling the rule) and removing the deprecated 'extension-pkg-whitelist' option.

---
*PR created automatically by Jules for task [9627129852975952552](https://jules.google.com/task/9627129852975952552) started by @CloCkWeRX*